### PR TITLE
make pinLabels and schPortArrangement optional

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -163,12 +163,12 @@ export const schematicPortArrangement = z
       rightSide: explicitPinSideDefinition.optional(),
       topSide: explicitPinSideDefinition.optional(),
       bottomSide: explicitPinSideDefinition.optional(),
-    }),
+    })
   )
 
 export const bugProps = commonComponentProps.extend({
-  pinLabels: z.record(z.number(), z.string()),
-  schPortArrangement: schematicPortArrangement,
+  pinLabels: z.record(z.number(), z.string()).optional(),
+  schPortArrangement: schematicPortArrangement.optional(),
   schPinSpacing: distanceOrMultiplier
     .or(z.literal("auto"))
     .optional()
@@ -207,7 +207,7 @@ export const traceProps = z
       thickness: distance.optional(),
       schematicRouteHints: z.array(point).optional(),
       pcbRouteHints: z.array(route_hint_point).optional(),
-    }),
+    })
   )
 export type TraceProps = z.input<typeof traceProps>
 
@@ -227,24 +227,20 @@ export const smtPadProps = z.union([
 export type SmtPadProps = z.input<typeof smtPadProps>
 
 export const platedHoleProps = z.union([
-  pcbLayoutProps
-    .omit({ pcbRotation: true, layer: true })
-    .extend({
-      shape: z.literal("circle"),
-      holeDiameter: distance,
-      outerDiameter: distance,
-      portHints: portHints.optional(),
-    }),
-  pcbLayoutProps
-    .omit({ pcbRotation: true, layer: true })
-    .extend({
-      shape: z.literal("oval"),
-      outerWidth: distance,
-      outerHeight: distance,
-      innerWidth: distance,
-      innerHeight: distance,
-      portHints: portHints.optional(),
-    })
+  pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
+    shape: z.literal("circle"),
+    holeDiameter: distance,
+    outerDiameter: distance,
+    portHints: portHints.optional(),
+  }),
+  pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
+    shape: z.literal("oval"),
+    outerWidth: distance,
+    outerHeight: distance,
+    innerWidth: distance,
+    innerHeight: distance,
+    portHints: portHints.optional(),
+  }),
 ])
 export type PlatedHoleProps = z.input<typeof platedHoleProps>
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -163,7 +163,7 @@ export const schematicPortArrangement = z
       rightSide: explicitPinSideDefinition.optional(),
       topSide: explicitPinSideDefinition.optional(),
       bottomSide: explicitPinSideDefinition.optional(),
-    })
+    }),
   )
 
 export const bugProps = commonComponentProps.extend({
@@ -207,7 +207,7 @@ export const traceProps = z
       thickness: distance.optional(),
       schematicRouteHints: z.array(point).optional(),
       pcbRouteHints: z.array(route_hint_point).optional(),
-    })
+    }),
   )
 export type TraceProps = z.input<typeof traceProps>
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     "format:check": "biome format ."
   },
   "keywords": [],
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "author": "",
   "license": "ISC",
   "devDependencies": {


### PR DESCRIPTION
The builder can handle these optional properties already, it will error if there isn't a footprint (currently)