### PR TITLE
feat: add potentiometer

### DIFF
--- a/lib/components/potentiometer.ts
+++ b/lib/components/potentiometer.ts
@@ -1,0 +1,22 @@
+import { resistance } from "circuit-json"
+import {
+    type CommonComponentProps,
+    commonComponentProps,
+    lrPins,
+} from "lib/common/layout"
+import { expectTypesMatch } from "lib/typecheck"
+import { z } from "zod"
+
+export interface PotentiometerProps extends CommonComponentProps {
+  resistance: number | string
+  wiper?: number
+}
+
+export const potentiometerProps = commonComponentProps.extend({
+  resistance,
+  wiper: z.number().min(0).max(1).optional().default(0.5),
+})
+export const potentiometerPins = lrPins
+
+type InferredPotentiometerProps = z.input<typeof potentiometerProps>
+expectTypesMatch<PotentiometerProps, InferredPotentiometerProps>(true)

--- a/lib/components/potentiometer.ts
+++ b/lib/components/potentiometer.ts
@@ -1,8 +1,8 @@
 import { resistance } from "circuit-json"
 import {
-    type CommonComponentProps,
-    commonComponentProps,
-    lrPins,
+  type CommonComponentProps,
+  commonComponentProps,
+  lrPins,
 } from "lib/common/layout"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"

--- a/lib/components/potentiometer.ts
+++ b/lib/components/potentiometer.ts
@@ -5,16 +5,14 @@ import {
   lrPins,
 } from "lib/common/layout"
 import { expectTypesMatch } from "lib/typecheck"
-import { z } from "zod"
+import type { z } from "zod"
 
 export interface PotentiometerProps extends CommonComponentProps {
-  resistance: number | string
-  wiper?: number
+  maxResistance: number | string
 }
 
 export const potentiometerProps = commonComponentProps.extend({
-  resistance,
-  wiper: z.number().min(0).max(1).optional().default(0.5),
+  maxResistance: resistance,
 })
 export const potentiometerPins = lrPins
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -52,6 +52,7 @@ export * from "./components/jumper"
 export * from "./components/platedhole"
 
 export * from "./components/resistor"
+export * from "./components/potentiometer"
 export * from "./components/capacitor"
 export * from "./components/group"
 export * from "./components/net"


### PR DESCRIPTION
Do we need these as well in props?

```
pullupFor: z.string().optional(),
pullupTo: z.string().optional(),
pulldownFor: z.string().optional(),
pulldownTo: z.string().optional(),
```