### PR TITLE
Add "sequential-trace" and "subcircuit" autorouter presets

### DIFF
--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -35,6 +35,8 @@ export interface AutorouterConfig {
 
 export type AutorouterProp =
   | AutorouterConfig
+  | "sequential-trace"
+  | "subcircuit"
   | "auto"
   | "auto-local"
   | "auto-cloud"
@@ -47,6 +49,8 @@ export const autorouterConfig = z.object({
 
 export const autorouterProp = z.union([
   autorouterConfig,
+  z.literal("sequential-trace"),
+  z.literal("subcircuit"),
   z.literal("auto"),
   z.literal("auto-local"),
   z.literal("auto-cloud"),


### PR DESCRIPTION
- sequential trace or "trace by trace" means each trace handles it's own autorouting
- subcircuit means each subcircuit handles all it's traces and is allowed to "rip and replace"