### PR TITLE
export manual edit events

### DIFF
--- a/lib/manual-edits/index.ts
+++ b/lib/manual-edits/index.ts
@@ -1,4 +1,5 @@
 export * from "./manual-edit-events"
+export * from "./manual_edit_event"
 export * from "./manual_edit_file"
 export * from "./manual_pcb_placement"
 export * from "./manual_schematic_placement"

--- a/lib/manual-edits/manual-edit-events/edit_trace_hint_event.ts
+++ b/lib/manual-edits/manual-edit-events/edit_trace_hint_event.ts
@@ -7,7 +7,8 @@ import { expectTypesMatch } from "lib/typecheck"
 import { route_hint_point } from "circuit-json"
 
 export const edit_trace_hint_event = base_manual_edit_event.extend({
-  pcb_edit_event_type: z.literal("edit_trace_hint"),
+  pcb_edit_event_type: z.literal("edit_trace_hint").describe("deprecated"),
+  edit_event_type: z.literal("edit_pcb_trace_hint").optional(),
   pcb_port_id: z.string(),
   pcb_trace_hint_id: z.string().optional(),
   route: z.array(
@@ -16,7 +17,9 @@ export const edit_trace_hint_event = base_manual_edit_event.extend({
 })
 
 export interface EditTraceHintEvent extends BaseManualEditEvent {
+  /** @deprecated */
   pcb_edit_event_type: "edit_trace_hint"
+  edit_event_type?: "edit_pcb_trace_hint"
   pcb_port_id: string
   pcb_trace_hint_id?: string
   route: Array<{ x: number; y: number; via?: boolean }>

--- a/lib/manual-edits/manual_edit_event.ts
+++ b/lib/manual-edits/manual_edit_event.ts
@@ -1,19 +1,27 @@
 import { z } from "zod"
 import {
-  edit_component_location_event,
+  edit_pcb_component_location_event,
   type EditPcbComponentLocationEvent,
 } from "./manual-edit-events/edit_pcb_component_location_event"
+import {
+  edit_schematic_component_location_event,
+  type EditSchematicComponentLocationEvent,
+} from "./manual-edit-events/edit_schematic_component_location_event"
 import {
   edit_trace_hint_event,
   type EditTraceHintEvent,
 } from "./manual-edit-events/edit_trace_hint_event"
 import { expectTypesMatch } from "lib/typecheck"
 
-export type ManualEditEvent = EditPcbComponentLocationEvent | EditTraceHintEvent
+export type ManualEditEvent =
+  | EditPcbComponentLocationEvent
+  | EditTraceHintEvent
+  | EditSchematicComponentLocationEvent
 
 export const manual_edit_event = z.union([
-  edit_component_location_event,
+  edit_pcb_component_location_event,
   edit_trace_hint_event,
+  edit_schematic_component_location_event,
 ])
 
 export type ManualEditEventInput = z.input<typeof manual_edit_event>


### PR DESCRIPTION
- **fix exports to include manual edit events**
- **more consistent edit event type property edit pcb trace hint**
