### PR TITLE
Add connector component

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ resistorProps.parse({ resistance: "10k" } as ResistorPropsInput)
 | `<group />` | [`BaseGroupProps`](#basegroupprops-group) |
 | `<hole />` | [`HoleProps`](#holeprops-hole) |
 | `<jumper />` | [`JumperProps`](#jumperprops-jumper) |
+| `<connector />` | [`ConnectorProps`](#connectorprops-connector) |
 | `<mosfet />` | [`MosfetProps`](#mosfetprops-mosfet) |
 | `<net />` | [`NetProps`](#netprops-net) |
 | `<netalias />` | [`NetAliasProps`](#netaliasprops-netalias) |
@@ -375,6 +376,33 @@ export interface JumperProps extends CommonComponentProps {
 ```
 
 [Source](https://github.com/tscircuit/props/blob/main/lib/components/jumper.ts)
+
+
+### ConnectorProps `<connector />`
+
+```ts
+export interface ConnectorProps extends CommonComponentProps {
+  manufacturerPartNumber?: string
+  pinLabels?: Record<number | string, string | string[]>
+  schPinStyle?: SchematicPinStyle
+  schPinSpacing?: number | string
+  schWidth?: number | string
+  schHeight?: number | string
+  schDirection?: "left" | "right"
+  schPortArrangement?: SchematicPortArrangement
+  /**
+   * Groups of pins that are internally connected (bridged)
+   * e.g., [["1","2"], ["2","3"]]
+   */
+  internallyConnectedPins?: string[][]
+  /**
+   * Connector standard, e.g. usb_c, m2
+   */
+  standard?: "usb_c" | "m2"
+}
+```
+
+[Source](https://github.com/tscircuit/props/blob/main/lib/components/connector.ts)
 
 
 ### MosfetProps `<mosfet />`

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -709,6 +709,37 @@ export const jumperProps = commonComponentProps.extend({
 })
 ```
 
+### connector
+
+```typescript
+export interface ConnectorProps extends CommonComponentProps {
+  manufacturerPartNumber?: string
+  pinLabels?: Record<number | string, string | string[]>
+  schPinStyle?: SchematicPinStyle
+  schPinSpacing?: number | string
+  schWidth?: number | string
+  schHeight?: number | string
+  schDirection?: "left" | "right"
+  schPortArrangement?: SchematicPortArrangement
+  internallyConnectedPins?: string[][]
+  standard?: "usb_c" | "m2"
+}
+export const connectorProps = commonComponentProps.extend({
+  manufacturerPartNumber: z.string().optional(),
+  pinLabels: z
+    .record(z.number().or(z.string()), z.string().or(z.array(z.string())))
+    .optional(),
+  schPinStyle: schematicPinStyle.optional(),
+  schPinSpacing: distance.optional(),
+  schWidth: distance.optional(),
+  schHeight: distance.optional(),
+  schDirection: z.enum(["left", "right"]).optional(),
+  schPortArrangement: schematicPortArrangement.optional(),
+  internallyConnectedPins: z.array(z.array(z.string())).optional(),
+  standard: z.enum(["usb_c", "m2"]).optional(),
+})
+```
+
 ### led
 
 ```typescript

--- a/lib/components/connector.ts
+++ b/lib/components/connector.ts
@@ -1,0 +1,53 @@
+import { distance } from "circuit-json"
+import {
+  type CommonComponentProps,
+  commonComponentProps,
+} from "lib/common/layout"
+import {
+  type SchematicPortArrangement,
+  schematicPortArrangement,
+} from "lib/common/schematicPinDefinitions"
+import {
+  type SchematicPinStyle,
+  schematicPinStyle,
+} from "lib/common/schematicPinStyle"
+import { expectTypesMatch } from "lib/typecheck"
+import { z } from "zod"
+
+export interface ConnectorProps extends CommonComponentProps {
+  manufacturerPartNumber?: string
+  pinLabels?: Record<number | string, string | string[]>
+  schPinStyle?: SchematicPinStyle
+  schPinSpacing?: number | string
+  schWidth?: number | string
+  schHeight?: number | string
+  schDirection?: "left" | "right"
+  schPortArrangement?: SchematicPortArrangement
+  /**
+   * Groups of pins that are internally connected (bridged)
+   * e.g., [["1","2"], ["2","3"]]
+   */
+  internallyConnectedPins?: string[][]
+  /**
+   * Connector standard, e.g. usb_c, m2
+   */
+  standard?: "usb_c" | "m2"
+}
+
+export const connectorProps = commonComponentProps.extend({
+  manufacturerPartNumber: z.string().optional(),
+  pinLabels: z
+    .record(z.number().or(z.string()), z.string().or(z.array(z.string())))
+    .optional(),
+  schPinStyle: schematicPinStyle.optional(),
+  schPinSpacing: distance.optional(),
+  schWidth: distance.optional(),
+  schHeight: distance.optional(),
+  schDirection: z.enum(["left", "right"]).optional(),
+  schPortArrangement: schematicPortArrangement.optional(),
+  internallyConnectedPins: z.array(z.array(z.string())).optional(),
+  standard: z.enum(["usb_c", "m2"]).optional(),
+})
+
+type InferredConnectorProps = z.input<typeof connectorProps>
+expectTypesMatch<ConnectorProps, InferredConnectorProps>(true)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,6 +11,7 @@ export * from "./common/cadModel"
 export * from "./components/board"
 export * from "./components/chip"
 export * from "./components/jumper"
+export * from "./components/connector"
 export * from "./components/fuse"
 export * from "./components/platedhole"
 

--- a/tests/connector.test.ts
+++ b/tests/connector.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test"
+import { connectorProps, type ConnectorProps } from "lib/components/connector"
+
+test("should parse connector with usb_c standard", () => {
+  const raw: ConnectorProps = { name: "conn", standard: "usb_c" }
+  const parsed = connectorProps.parse(raw)
+  expect(parsed.standard).toBe("usb_c")
+})
+
+test("should parse connector with m2 standard", () => {
+  const raw: ConnectorProps = { name: "conn", standard: "m2" }
+  const parsed = connectorProps.parse(raw)
+  expect(parsed.standard).toBe("m2")
+})
+
+test("should parse connector without standard", () => {
+  const raw: ConnectorProps = { name: "conn" }
+  const parsed = connectorProps.parse(raw)
+  expect(parsed.standard).toBeUndefined()
+})
+
+test("should fail for invalid connector standard", () => {
+  expect(() => connectorProps.parse({ name: "conn", standard: "invalid" } as any)).toThrow()
+})


### PR DESCRIPTION
## Summary
- add new `<connector />` component
- document new component in README and generated docs
- export connector from public index
- add tests for connector props
- rename prop `type` to `standard`
- drop `pinCount` prop from connector

## Testing
- `bun test` *(fails: Cannot find package dependencies)*