### PR TITLE
Add polygon SMT pad support

### DIFF
--- a/lib/components/smtpad.ts
+++ b/lib/components/smtpad.ts
@@ -6,6 +6,7 @@ import {
 import { z } from "zod"
 import { distance, type Distance } from "lib/common/distance"
 import { portHints, type PortHints } from "lib/common/portHints"
+import { point, type Point } from "lib/common/point"
 import { expectTypesMatch } from "lib/typecheck"
 
 export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
@@ -38,11 +39,19 @@ export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   portHints?: PortHints
 }
 
+export interface PolygonSmtPadProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "polygon"
+  points: Point[]
+  portHints?: PortHints
+}
+
 export type SmtPadProps =
   | RectSmtPadProps
   | CircleSmtPadProps
   | RotatedRectSmtPadProps
   | PillSmtPadProps
+  | PolygonSmtPadProps
 
 // ----------------------------------------------------------------------------
 // Zod
@@ -93,11 +102,22 @@ export const pillSmtPadProps = pcbLayoutProps
 type InferredPillSmtPadProps = z.input<typeof pillSmtPadProps>
 expectTypesMatch<InferredPillSmtPadProps, PillSmtPadProps>(true)
 
+export const polygonSmtPadProps = pcbLayoutProps
+  .omit({ pcbRotation: true })
+  .extend({
+    shape: z.literal("polygon"),
+    points: z.array(point),
+    portHints: portHints.optional(),
+  })
+type InferredPolygonSmtPadProps = z.input<typeof polygonSmtPadProps>
+expectTypesMatch<InferredPolygonSmtPadProps, PolygonSmtPadProps>(true)
+
 export const smtPadProps = z.union([
   circleSmtPadProps,
   rectSmtPadProps,
   rotatedRectSmtPadProps,
   pillSmtPadProps,
+  polygonSmtPadProps,
 ])
 
 export type InferredSmtPadProps = z.input<typeof smtPadProps>

--- a/tests/smtpad.test.ts
+++ b/tests/smtpad.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import {
+  smtPadProps,
+  polygonSmtPadProps,
+  type PolygonSmtPadProps,
+  type SmtPadProps,
+} from "lib/components/smtpad"
+import { expectTypeOf } from "expect-type"
+import { z } from "zod"
+
+test("should parse PolygonSmtPadProps", () => {
+  const rawProps: PolygonSmtPadProps = {
+    shape: "polygon",
+    points: [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+    ],
+    pcbX: 0,
+    pcbY: "1mm",
+  }
+
+  expectTypeOf(rawProps).toMatchTypeOf<z.input<typeof polygonSmtPadProps>>()
+
+  const parsed = polygonSmtPadProps.parse(rawProps)
+  expect(parsed.points.length).toBe(3)
+  expect(parsed.pcbY).toBe(1)
+
+  const parsedUnion = smtPadProps.parse(rawProps)
+  if (parsedUnion.shape === "polygon") {
+    expect(parsedUnion.points.length).toBe(3)
+  } else {
+    throw new Error("Expected PolygonSmtPadProps")
+  }
+})
+
+test("type inference for SmtPadProps", () => {
+  const polygon: SmtPadProps = {
+    shape: "polygon",
+    points: [{ x: 0, y: 0 }],
+  }
+  expectTypeOf(polygon).toMatchTypeOf<PolygonSmtPadProps>()
+})


### PR DESCRIPTION
## Summary
- extend SMT pad types with new `polygon` shape
- add parser for polygon pads
- test new polygon SMT pad props

## Testing
- `bun test | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_b_683f2eef8b78832ea5e4cbdee2289af3