### PR TITLE
Add width/height to group layoutConfig

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -739,6 +739,9 @@ export const layoutConfig = z.object({
   flexColumn: z.boolean().optional(),
   gap: z.number().or(z.string()).optional(),
 
+  width: length.optional(),
+  height: length.optional(),
+
   matchAdapt: z.boolean().optional(),
 })
 export interface LayoutConfig {
@@ -760,6 +763,9 @@ export interface LayoutConfig {
   flexRow?: boolean
   flexColumn?: boolean
   gap?: number | string
+
+  width?: Distance
+  height?: Distance
 
   matchAdapt?: boolean
 }
@@ -931,7 +937,7 @@ export const jumperProps = commonComponentProps.extend({
 export const ledProps = commonComponentProps.extend({
   color: z.string().optional(),
   wavelength: z.string().optional(),
-  schValLabel: z.string().optional(),
+  schDisplayValue: z.string().optional(),
 })
 ```
 
@@ -1408,6 +1414,12 @@ export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   radius: Distance
   portHints?: PortHints
 }
+export interface PolygonSmtPadProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "polygon"
+  points: Point[]
+  portHints?: PortHints
+}
 export const rectSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
   .extend({
@@ -1439,6 +1451,13 @@ export const pillSmtPadProps = pcbLayoutProps
     width: distance,
     height: distance,
     radius: distance,
+    portHints: portHints.optional(),
+  })
+export const polygonSmtPadProps = pcbLayoutProps
+  .omit({ pcbRotation: true })
+  .extend({
+    shape: z.literal("polygon"),
+    points: z.array(point),
     portHints: portHints.optional(),
   })
 ```

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -35,6 +35,9 @@ export const layoutConfig = z.object({
   flexColumn: z.boolean().optional(),
   gap: z.number().or(z.string()).optional(),
 
+  width: length.optional(),
+  height: length.optional(),
+
   matchAdapt: z.boolean().optional(),
 })
 
@@ -57,6 +60,9 @@ export interface LayoutConfig {
   flexRow?: boolean
   flexColumn?: boolean
   gap?: number | string
+
+  width?: Distance
+  height?: Distance
 
   matchAdapt?: boolean
 }


### PR DESCRIPTION
## Summary
- expose `width` and `height` options in `layoutConfig`
- regenerate component type docs

## Testing
- `bun run generate:component-types`
- `bun run generate:readme-docs`
- `bun test`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_683f4c762d54832e824559af8a58113b