### PR TITLE
Add matchAdaptTemplate to layout config

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -743,6 +743,7 @@ export const layoutConfig = z.object({
   height: length.optional(),
 
   matchAdapt: z.boolean().optional(),
+  matchAdaptTemplate: z.any().optional(),
 })
 export interface LayoutConfig {
   layoutMode?: "grid" | "flex" | "match-adapt" | "none"
@@ -768,6 +769,7 @@ export interface LayoutConfig {
   height?: Distance
 
   matchAdapt?: boolean
+  matchAdaptTemplate?: any
 }
 export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   name?: string

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-06-05T22:17:52.427Z
+> Generated at 2025-06-06T17:08:15.013Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -313,6 +313,7 @@ export interface LayoutConfig {
   height?: Distance
 
   matchAdapt?: boolean
+  matchAdaptTemplate?: any
 }
 
 

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -39,6 +39,7 @@ export const layoutConfig = z.object({
   height: length.optional(),
 
   matchAdapt: z.boolean().optional(),
+  matchAdaptTemplate: z.any().optional(),
 })
 
 export interface LayoutConfig {
@@ -65,6 +66,7 @@ export interface LayoutConfig {
   height?: Distance
 
   matchAdapt?: boolean
+  matchAdaptTemplate?: any
 }
 
 expectTypesMatch<LayoutConfig, z.input<typeof layoutConfig>>(true)


### PR DESCRIPTION
## Summary
- add `matchAdaptTemplate` optional prop on `LayoutConfig`
- regenerate component type docs

## Testing
- `bun test`
- `bun run format:check`

------
https://chatgpt.com/codex/tasks/task_b_68431ffae670832ebdd25b85f237f73b