### PR TITLE
Rename titleAnchorAlignment

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -854,7 +854,7 @@ export const schematicBoxProps = z
     paddingBottom: distance.optional(),
 
     title: z.string().optional(),
-    titleAnchorAlignment: nine_point_anchor.default("center"),
+    titleAlignment: nine_point_anchor.default("center"),
     titleColor: z.string().optional(),
     titleFontSize: distance.optional(),
     titleInside: z.boolean().default(false),

--- a/lib/components/schematic-box.ts
+++ b/lib/components/schematic-box.ts
@@ -17,7 +17,7 @@ export const schematicBoxProps = z
     paddingBottom: distance.optional(),
 
     title: z.string().optional(),
-    titleAnchorAlignment: nine_point_anchor.default("center"),
+    titleAlignment: nine_point_anchor.default("center"),
     titleColor: z.string().optional(),
     titleFontSize: distance.optional(),
     titleInside: z.boolean().default(false),


### PR DESCRIPTION
## Summary
- rename `titleAnchorAlignment` to `titleAlignment`

## Testing
- `npm run format:check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6845d6867800832e96871a8e852711e8