### PR TITLE
Add connections to pinheader

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,11 @@ export interface PinHeaderProps extends CommonComponentProps {
   pinLabels?: string[]
 
   /**
+   * Connections to other components
+   */
+  connections?: Connections<string>
+
+  /**
    * Direction the header is facing
    */
   facingDirection?: "left" | "right"

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1155,6 +1155,8 @@ export interface PinHeaderProps extends CommonComponentProps {
 
   pinLabels?: string[]
 
+  connections?: Connections<string>
+
   facingDirection?: "left" | "right"
 
   schPinArrangement?: SchematicPinArrangement
@@ -1172,6 +1174,7 @@ export const pinHeaderProps = commonComponentProps.extend({
   holeDiameter: distance.optional(),
   platedDiameter: distance.optional(),
   pinLabels: z.array(z.string()).optional(),
+  connections: z.record(z.string(), connectionTarget).optional(),
   facingDirection: z.enum(["left", "right"]).optional(),
   schPinArrangement: schematicPinArrangement.optional(),
 })

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -481,6 +481,11 @@ export interface PinHeaderProps extends CommonComponentProps {
   pinLabels?: string[]
 
   /**
+   * Connections to other components
+   */
+  connections?: Connections<string>
+
+  /**
    * Direction the header is facing
    */
   facingDirection?: "left" | "right"

--- a/lib/components/pin-header.ts
+++ b/lib/components/pin-header.ts
@@ -7,6 +7,8 @@ import {
   schematicPinArrangement,
   type SchematicPinArrangement,
 } from "lib/common/schematicPinDefinitions"
+import { connectionTarget } from "lib/common/connectionsProp"
+import type { Connections } from "lib/utility-types/connections-and-selectors"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
@@ -57,6 +59,11 @@ export interface PinHeaderProps extends CommonComponentProps {
   pinLabels?: string[]
 
   /**
+   * Connections to other components
+   */
+  connections?: Connections<string>
+
+  /**
    * Direction the header is facing
    */
   facingDirection?: "left" | "right"
@@ -77,6 +84,10 @@ export const pinHeaderProps = commonComponentProps.extend({
   holeDiameter: distance.optional(),
   platedDiameter: distance.optional(),
   pinLabels: z.array(z.string()).optional(),
+  connections: z
+    .custom<Connections>()
+    .pipe(z.record(z.string(), connectionTarget))
+    .optional(),
   facingDirection: z.enum(["left", "right"]).optional(),
   schPinArrangement: schematicPinArrangement.optional(),
 })

--- a/tests/pin-header.test.ts
+++ b/tests/pin-header.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import { pinHeaderProps, type PinHeaderProps } from "lib/components/pin-header"
+
+// Ensure connections prop parses with simple string targets
+
+test("should parse pin header props with single string connections", () => {
+  const rawProps: PinHeaderProps = {
+    name: "header",
+    pinCount: 2,
+    connections: {
+      1: "net.VCC",
+      2: "net.GND",
+    },
+  }
+  const parsed = pinHeaderProps.parse(rawProps)
+  expect(parsed.connections).toEqual({
+    1: "net.VCC",
+    2: "net.GND",
+  })
+})
+
+// Ensure array connections also parse
+
+test("should parse pin header props with array connections", () => {
+  const rawProps: PinHeaderProps = {
+    name: "header",
+    pinCount: 2,
+    connections: {
+      1: ["net.VCC", "net.POWER"],
+      2: ["net.GND"],
+    },
+  }
+  const parsed = pinHeaderProps.parse(rawProps)
+  expect(parsed.connections).toEqual({
+    1: ["net.VCC", "net.POWER"],
+    2: ["net.GND"],
+  })
+})
+
+// Connections should be optional
+
+test("should allow optional connections", () => {
+  const rawProps: PinHeaderProps = {
+    name: "header",
+    pinCount: 2,
+  }
+  const parsed = pinHeaderProps.parse(rawProps)
+  expect(parsed.connections).toBeUndefined()
+})


### PR DESCRIPTION
## Summary
- add support for connections prop on pin headers
- document the new prop
- generate updated component type docs
- test parsing of connections in pin headers

## Testing
- `bun run format`
- `bun x tsc --noEmit`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68470b2215c8832eb19c2bcb6b6b8cff