### PR TITLE
Add showPinAliases prop to chips

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ export interface ChipPropsSU<PinLabel extends string = string>
   extends CommonComponentProps {
   manufacturerPartNumber?: string
   pinLabels?: PinLabelsProp<string, PinLabel>
+  /**
+   * Whether to show pin aliases in the schematic
+   */
+  showPinAliases?: boolean
   schPinArrangement?: SchematicPortArrangement
   /** @deprecated Use schPinArrangement instead. */
   schPortArrangement?: SchematicPortArrangement

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -393,6 +393,7 @@ export interface ChipPropsSU<PinLabel extends string = string>
   extends CommonComponentProps {
   manufacturerPartNumber?: string
   pinLabels?: PinLabelsProp<string, PinLabel>
+  showPinAliases?: boolean
   schPinArrangement?: SchematicPortArrangement
   schPortArrangement?: SchematicPortArrangement
   pinCompatibleVariants?: PinCompatibleVariant[]
@@ -429,6 +430,7 @@ export const pinCompatibleVariant = z.object({
 export const chipProps = commonComponentProps.extend({
   manufacturerPartNumber: z.string().optional(),
   pinLabels: pinLabelsProp.optional(),
+  showPinAliases: z.boolean().optional(),
   internallyConnectedPins: z.array(z.array(z.string())).optional(),
   externallyConnectedPins: z.array(z.array(z.string())).optional(),
   schPinArrangement: schematicPinArrangement.optional(),
@@ -1093,7 +1095,10 @@ export const pinHeaderProps = commonComponentProps.extend({
   holeDiameter: distance.optional(),
   platedDiameter: distance.optional(),
   pinLabels: z.array(z.string()).optional(),
-  connections: z.record(z.string(), connectionTarget).optional(),
+  connections: z
+    .custom<Connections>()
+    .pipe(z.record(z.string(), connectionTarget))
+    .optional(),
   facingDirection: z.enum(["left", "right"]).optional(),
   schPinArrangement: schematicPinArrangement.optional(),
 })

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-06-06T17:08:15.013Z
+> Generated at 2025-06-09T20:18:44.102Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -134,6 +134,22 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
 }
 
 
+export interface BreakoutProps
+  extends Omit<SubcircuitGroupProps, "subcircuit"> {
+  padding?: Distance
+  paddingLeft?: Distance
+  paddingRight?: Distance
+  paddingTop?: Distance
+  paddingBottom?: Distance
+}
+
+
+export interface BreakoutPointProps
+  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
+  connection: string
+}
+
+
 export interface CapacitorProps extends CommonComponentProps {
   capacitance: number | string
   maxVoltageRating?: number | string
@@ -158,6 +174,10 @@ export interface ChipPropsSU<PinLabel extends string = string>
   extends CommonComponentProps {
   manufacturerPartNumber?: string
   pinLabels?: PinLabelsProp<string, PinLabel>
+  /**
+   * Whether to show pin aliases in the schematic
+   */
+  showPinAliases?: boolean
   schPinArrangement?: SchematicPortArrangement
   /** @deprecated Use schPinArrangement instead. */
   schPortArrangement?: SchematicPortArrangement
@@ -631,6 +651,14 @@ export interface PolygonSmtPadProps
   shape: "polygon"
   points: Point[]
   portHints?: PortHints
+}
+
+
+export interface SolderJumperProps extends JumperProps {
+  /**
+   * Pins that are bridged with solder by default
+   */
+  bridgedPins?: string[][]
 }
 
 

--- a/lib/components/chip.ts
+++ b/lib/components/chip.ts
@@ -36,6 +36,10 @@ export interface ChipPropsSU<PinLabel extends string = string>
   extends CommonComponentProps {
   manufacturerPartNumber?: string
   pinLabels?: PinLabelsProp<string, PinLabel>
+  /**
+   * Whether to show pin aliases in the schematic
+   */
+  showPinAliases?: boolean
   schPinArrangement?: SchematicPortArrangement
   /** @deprecated Use schPinArrangement instead. */
   schPortArrangement?: SchematicPortArrangement
@@ -121,6 +125,7 @@ export const pinCompatibleVariant = z.object({
 export const chipProps = commonComponentProps.extend({
   manufacturerPartNumber: z.string().optional(),
   pinLabels: pinLabelsProp.optional(),
+  showPinAliases: z.boolean().optional(),
   internallyConnectedPins: z.array(z.array(z.string())).optional(),
   externallyConnectedPins: z.array(z.array(z.string())).optional(),
   schPinArrangement: schematicPinArrangement.optional(),

--- a/tests/chip1-basic.test.ts
+++ b/tests/chip1-basic.test.ts
@@ -21,6 +21,7 @@ test("should parse chip props", () => {
     },
     schPinSpacing: "0.2mm",
     schWidth: 2,
+    showPinAliases: true,
     noSchematicRepresentation: true,
   }
 
@@ -28,6 +29,7 @@ test("should parse chip props", () => {
 
   expect(parsedProps.schPinSpacing).toBe(0.2)
   expect(parsedProps.noSchematicRepresentation).toBe(true)
+  expect(parsedProps.showPinAliases).toBe(true)
 })
 
 // New tests for connections prop


### PR DESCRIPTION
## Summary
- add `showPinAliases` boolean property for chip components
- regenerate docs
- update chip tests

## Testing
- `bun test`
- `bun run generate:component-types`
- `bun run generate:readme-docs`
- `npx tsx scripts/generate-props-overview.ts`


------
https://chatgpt.com/codex/tasks/task_b_684740b31c84832e8ab3b3c8b9fa7ada