### PR TITLE
Refactor smtpads use z.discriminatedUnion for type safety

### DIFF
--- a/lib/components/smtpad.ts
+++ b/lib/components/smtpad.ts
@@ -112,7 +112,7 @@ export const polygonSmtPadProps = pcbLayoutProps
 type InferredPolygonSmtPadProps = z.input<typeof polygonSmtPadProps>
 expectTypesMatch<InferredPolygonSmtPadProps, PolygonSmtPadProps>(true)
 
-export const smtPadProps = z.union([
+export const smtPadProps = z.discriminatedUnion("shape", [
   circleSmtPadProps,
   rectSmtPadProps,
   rotatedRectSmtPadProps,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8a6825dd-0918-46e4-a8d1-e93de7918ead)
