### PR TITLE
Remove default footprintVariant for testpoint

### DIFF
--- a/docs/manual-edits.generated.md
+++ b/docs/manual-edits.generated.md
@@ -5,7 +5,9 @@
 - [Manual Edit Events](#manual-edit-events)
   - [BaseManualEditEvent](#basemanualeditevent)
   - [EditPcbComponentLocationEvent](#editpcbcomponentlocationevent)
+  - [EditPcbGroupLocationEvent](#editpcbgrouplocationevent)
   - [EditSchematicComponentLocationEvent](#editschematiccomponentlocationevent)
+  - [EditSchematicGroupLocationEvent](#editschematicgrouplocationevent)
   - [EditTraceHintEvent](#edittracehintevent)
 - [Manual Edit Files](#manual-edit-files)
   - [ManualEditsFile](#manualeditsfile)
@@ -42,12 +44,34 @@ interface EditPcbComponentLocationEvent extends BaseManualEditEvent {
 }
 ```
 
+### EditPcbGroupLocationEvent
+
+```typescript
+interface EditPcbGroupLocationEvent extends BaseManualEditEvent {
+  edit_event_type: "edit_pcb_group_location"
+  pcb_group_id: string
+  original_center: { x: number; y: number }
+  new_center: { x: number; y: number }
+}
+```
+
 ### EditSchematicComponentLocationEvent
 
 ```typescript
 interface EditSchematicComponentLocationEvent extends BaseManualEditEvent {
   edit_event_type: "edit_schematic_component_location"
   schematic_component_id: string
+  original_center: { x: number; y: number }
+  new_center: { x: number; y: number }
+}
+```
+
+### EditSchematicGroupLocationEvent
+
+```typescript
+interface EditSchematicGroupLocationEvent extends BaseManualEditEvent {
+  edit_event_type: "edit_schematic_group_location"
+  schematic_group_id: string
   original_center: { x: number; y: number }
   new_center: { x: number; y: number }
 }

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1348,7 +1348,7 @@ export const schematicBoxProps = z
     paddingBottom: distance.optional(),
 
     title: z.string().optional(),
-    titleAlignment: nine_point_anchor.default("center"),
+    titleAlignment: ninePointAnchor.default("center"),
     titleColor: z.string().optional(),
     titleFontSize: distance.optional(),
     titleInside: z.boolean().default(false),
@@ -1386,7 +1386,7 @@ export const schematicTextProps = z.object({
   text: z.string(),
   fontSize: z.number().default(1),
   anchor: z
-    .union([five_point_anchor.describe("legacy"), nine_point_anchor])
+    .union([fivePointAnchor.describe("legacy"), ninePointAnchor])
     .default("center"),
   color: z.string().default("#000000"),
   schRotation: rotation.default(0),
@@ -1450,7 +1450,7 @@ export const silkscreenRectProps = pcbLayoutProps
 ```typescript
 export const silkscreenTextProps = pcbLayoutProps.extend({
   text: z.string(),
-  anchorAlignment: nine_point_anchor.default("center"),
+  anchorAlignment: ninePointAnchor.default("center"),
   font: z.enum(["tscircuit2024"]).optional(),
   fontSize: length.optional(),
 })
@@ -1638,7 +1638,7 @@ export interface TestpointProps extends CommonComponentProps {
   height?: number | string
 }
 .extend({
-    footprintVariant: z.enum(["pad", "through_hole"]).optional().default("pad"),
+    footprintVariant: z.enum(["pad", "through_hole"]).optional(),
     padShape: z.enum(["rect", "circle"]).optional().default("circle"),
     padDiameter: distance.optional(),
     holeDiameter: distance.optional(),

--- a/lib/components/testpoint.ts
+++ b/lib/components/testpoint.ts
@@ -35,7 +35,7 @@ export interface TestpointProps extends CommonComponentProps {
 
 export const testpointProps = commonComponentProps
   .extend({
-    footprintVariant: z.enum(["pad", "through_hole"]).optional().default("pad"),
+    footprintVariant: z.enum(["pad", "through_hole"]).optional(),
     padShape: z.enum(["rect", "circle"]).optional().default("circle"),
     padDiameter: distance.optional(),
     holeDiameter: distance.optional(),
@@ -44,7 +44,8 @@ export const testpointProps = commonComponentProps
   })
   .refine(
     (props) =>
-      props.footprintVariant === "pad" || props.holeDiameter !== undefined,
+      props.footprintVariant !== "through_hole" ||
+      props.holeDiameter !== undefined,
     { message: "holeDiameter is required for through_hole testpoints" },
   )
 

--- a/tests/testpoint.test.ts
+++ b/tests/testpoint.test.ts
@@ -8,6 +8,7 @@ import { z } from "zod"
 test("should parse pad testpoint", () => {
   const rawProps: TestpointProps = {
     name: "tp1",
+    footprintVariant: "pad",
     padDiameter: 1,
   }
   const parsed = testpointProps.parse(rawProps)
@@ -16,12 +17,12 @@ test("should parse pad testpoint", () => {
   expect(parsed.holeDiameter).toBeUndefined()
 })
 
-test("should parse pad testpoint without padDiameter", () => {
+test("should parse testpoint without footprintVariant", () => {
   const rawProps: TestpointProps = {
     name: "tp0",
   }
   const parsed = testpointProps.parse(rawProps)
-  expect(parsed.footprintVariant).toBe("pad")
+  expect(parsed.footprintVariant).toBeUndefined()
   expect(parsed.padDiameter).toBeUndefined()
 })
 


### PR DESCRIPTION
## Summary
- remove the default `footprintVariant` for `testpointProps`
- update validation logic and associated tests
- regenerate documentation

## Testing
- `bun run format`
- `bun run generate:component-types`
- `bun run generate:readme-docs`
- `bun run generate:manual-edits-docs`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_684b358a4638832e85280f9850a9b4a0