### PR TITLE
Refactor platedhole use z.discriminatedUnion for type safety

### DIFF
--- a/lib/components/platedhole.ts
+++ b/lib/components/platedhole.ts
@@ -54,8 +54,8 @@ export interface CircularHoleWithRectPlatedProps
   holeDiameter: number | string
   rectPadWidth: number | string
   rectPadHeight: number | string
-  holeShape: "circle"
-  padShape: "rect"
+  holeShape?: "circle"
+  padShape?: "rect"
   portHints?: PortHints
 }
 
@@ -123,8 +123,8 @@ export const platedHoleProps = z
       holeDiameter: distance,
       rectPadWidth: distance,
       rectPadHeight: distance,
-      holeShape: z.literal("circle"),
-      padShape: z.literal("rect"),
+      holeShape: z.literal("circle").optional(),
+      padShape: z.literal("rect").optional(),
       portHints: portHints.optional(),
     }),
     pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({

--- a/lib/components/platedhole.ts
+++ b/lib/components/platedhole.ts
@@ -50,12 +50,12 @@ export interface PillPlatedHoleProps
 export interface CircularHoleWithRectPlatedProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  shape: "circular_hole_with_rect_pad"
   holeDiameter: number | string
   rectPadWidth: number | string
   rectPadHeight: number | string
-  holeShape?: "circle"
-  padShape?: "rect"
-  shape?: "circular_hole_with_rect_pad"
+  holeShape: "circle"
+  padShape: "rect"
   portHints?: PortHints
 }
 
@@ -87,7 +87,7 @@ const distanceHiddenUndefined = z
   })
 
 export const platedHoleProps = z
-  .union([
+  .discriminatedUnion("shape", [
     pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
       name: z.string().optional(),
       shape: z.literal("circle"),
@@ -117,28 +117,16 @@ export const platedHoleProps = z
       innerHeight: distance.optional().describe("DEPRECATED use holeHeight"),
       portHints: portHints.optional(),
     }),
-    pcbLayoutProps
-      .omit({ pcbRotation: true, layer: true })
-      .extend({
-        name: z.string().optional(),
-        holeDiameter: distance,
-        rectPadWidth: distance,
-        rectPadHeight: distance,
-        holeShape: z.literal("circle").optional(),
-        padShape: z.literal("rect").optional(),
-        shape: z.literal("circular_hole_with_rect_pad").optional(),
-        portHints: portHints.optional(),
-      })
-      .refine(
-        (prop) => {
-          return prop.shape === "circular_hole_with_rect_pad"
-            ? prop.holeDiameter && prop.rectPadWidth && prop.rectPadHeight
-            : true
-        },
-        {
-          message: "Missing required fields for circular_hole_with_rect_pad",
-        },
-      ),
+    pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
+      name: z.string().optional(),
+      shape: z.literal("circular_hole_with_rect_pad"),
+      holeDiameter: distance,
+      rectPadWidth: distance,
+      rectPadHeight: distance,
+      holeShape: z.literal("circle"),
+      padShape: z.literal("rect"),
+      portHints: portHints.optional(),
+    }),
     pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
       name: z.string().optional(),
       shape: z.literal("pill_hole_with_rect_pad"),

--- a/tests/platedhole.test.ts
+++ b/tests/platedhole.test.ts
@@ -12,8 +12,6 @@ test("should parse CircularHoleWithRectPlatedProps with all required fields", ()
     holeDiameter: 5,
     rectPadWidth: 10,
     rectPadHeight: 20,
-    padShape: "rect",
-    holeShape: "circle",
   }
 
   expectTypeOf(rawProps).toMatchTypeOf<z.input<typeof platedHoleProps>>()
@@ -24,8 +22,6 @@ test("should parse CircularHoleWithRectPlatedProps with all required fields", ()
     expect(parsedProps.holeDiameter).toBe(5)
     expect(parsedProps.rectPadWidth).toBe(10)
     expect(parsedProps.rectPadHeight).toBe(20)
-    expect(parsedProps.padShape).toBe("rect")
-    expect(parsedProps.holeShape).toBe("circle")
   } else {
     throw new Error(
       "Expected CircularHoleWithRectPlatedProps, but got a different shape",

--- a/tests/platedhole.test.ts
+++ b/tests/platedhole.test.ts
@@ -12,6 +12,8 @@ test("should parse CircularHoleWithRectPlatedProps with all required fields", ()
     holeDiameter: 5,
     rectPadWidth: 10,
     rectPadHeight: 20,
+    padShape: "rect",
+    holeShape: "circle",
   }
 
   expectTypeOf(rawProps).toMatchTypeOf<z.input<typeof platedHoleProps>>()
@@ -22,6 +24,8 @@ test("should parse CircularHoleWithRectPlatedProps with all required fields", ()
     expect(parsedProps.holeDiameter).toBe(5)
     expect(parsedProps.rectPadWidth).toBe(10)
     expect(parsedProps.rectPadHeight).toBe(20)
+    expect(parsedProps.padShape).toBe("rect")
+    expect(parsedProps.holeShape).toBe("circle")
   } else {
     throw new Error(
       "Expected CircularHoleWithRectPlatedProps, but got a different shape",


### PR DESCRIPTION
fix #204 
- Replaced z.union([...]) with z.discriminatedUnion("shape", [...]).
- Made shape required in all variants, including "circular_hole_with_rect_pad". 
- Ensured compatibility with existing TypeScript types and validation refinements