### PR TITLE
Add cellBorder prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
 
   pcbLayout?: LayoutConfig
   schLayout?: LayoutConfig
+  cellBorder?: CellBorder
 }
 ```
 

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -71,6 +71,18 @@ export interface LayoutConfig {
 
 expectTypesMatch<LayoutConfig, z.input<typeof layoutConfig>>(true)
 
+export interface CellBorder {
+  strokeWidth?: Distance
+  dashed?: boolean
+  solid?: boolean
+}
+
+export const cellBorder = z.object({
+  strokeWidth: length.optional(),
+  dashed: z.boolean().optional(),
+  solid: z.boolean().optional(),
+})
+
 export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   name?: string
   key?: any
@@ -83,6 +95,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
 
   pcbLayout?: LayoutConfig
   schLayout?: LayoutConfig
+  cellBorder?: CellBorder
 }
 
 export type PartsEngine = {
@@ -187,6 +200,7 @@ export const baseGroupProps = commonLayoutProps.extend({
   schHeight: length.optional(),
   pcbLayout: layoutConfig.optional(),
   schLayout: layoutConfig.optional(),
+  cellBorder: cellBorder.optional(),
 })
 
 export const partsEngine = z.custom<PartsEngine>((v) => "findPart" in v)

--- a/tests/group.test.ts
+++ b/tests/group.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import { baseGroupProps, type BaseGroupProps } from "../lib/components/group"
+
+test("should parse cellBorder", () => {
+  const raw: BaseGroupProps = {
+    name: "g",
+    cellBorder: {
+      strokeWidth: "2mm",
+      dashed: true,
+    },
+  }
+
+  const parsed = baseGroupProps.parse(raw)
+  expect(parsed.cellBorder?.strokeWidth).toBe(2)
+  expect(parsed.cellBorder?.dashed).toBe(true)
+})


### PR DESCRIPTION
## Summary
- support optional `cellBorder` on groups
- document the new prop in README
- test `cellBorder` parsing

## Testing
- `bun test`
- `bun test tests/group.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_684c840a32e0832eb688c062656a7802