### PR TITLE
Add border prop to group

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,8 +388,8 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
 
   pcbLayout?: LayoutConfig
   schLayout?: LayoutConfig
-  cellBorder?: CellBorder
-  border?: CellBorder
+  cellBorder?: Border
+  border?: Border
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbLayout?: LayoutConfig
   schLayout?: LayoutConfig
   cellBorder?: CellBorder
+  border?: CellBorder
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2,6 +2,25 @@
 
 ## Common Types
 
+### connectionsProp
+
+```typescript
+export const createConnectionsProp = <T extends readonly [string, ...string[]]>(
+  labels: T,
+) => {
+  return z.record(z.enum(labels), connectionTarget)
+}
+```
+
+### point
+
+```typescript
+export const point = z.object({
+  x: distance,
+  y: distance,
+})
+```
+
 ### cadModel
 
 ```typescript
@@ -48,14 +67,102 @@ export const cadModelJscad = cadModelBase.extend({
 })
 ```
 
-### connectionsProp
+### schematicPinStyle
 
 ```typescript
-export const createConnectionsProp = <T extends readonly [string, ...string[]]>(
-  labels: T,
-) => {
-  return z.record(z.enum(labels), connectionTarget)
+export type SchematicPinStyle = Record<
+  string,
+  {
+    marginTop?: number | string
+    marginRight?: number | string
+    marginBottom?: number | string
+    marginLeft?: number | string
+
+    leftMargin?: number | string
+    rightMargin?: number | string
+    topMargin?: number | string
+    bottomMargin?: number | string
+  }
+/** @deprecated use marginBottom */
+export const schematicPinStyle = z.record(
+  z.object({
+    marginLeft: distance.optional(),
+    marginRight: distance.optional(),
+    marginTop: distance.optional(),
+    marginBottom: distance.optional(),
+
+    leftMargin: distance.optional(),
+    rightMargin: distance.optional(),
+    topMargin: distance.optional(),
+    bottomMargin: distance.optional(),
+  }),
+```
+
+### schematicPinDefinitions
+
+```typescript
+/**
+ * @deprecated Use SchematicPortArrangementWithPinCounts instead.
+ */
+export interface SchematicPortArrangementWithSizes {
+  leftSize?: number
+  topSize?: number
+  rightSize?: number
+  bottomSize?: number
 }
+/**
+ * Specifies the number of pins on each side of the schematic box component.
+ */
+export interface SchematicPortArrangementWithPinCounts {
+  leftPinCount?: number
+  topPinCount?: number
+  rightPinCount?: number
+  bottomPinCount?: number
+}
+export interface PinSideDefinition {
+  pins: Array<number | string>
+  direction:
+    | "top-to-bottom"
+    | "left-to-right"
+    | "bottom-to-top"
+    | "right-to-left"
+}
+export interface SchematicPortArrangementWithSides {
+  leftSide?: PinSideDefinition
+  topSide?: PinSideDefinition
+  rightSide?: PinSideDefinition
+  bottomSide?: PinSideDefinition
+}
+export interface SchematicPortArrangement
+  extends SchematicPortArrangementWithSizes,
+    SchematicPortArrangementWithSides,
+    SchematicPortArrangementWithPinCounts {}
+export const explicitPinSideDefinition = z.object({
+  pins: z.array(z.union([z.number(), z.string()])),
+  direction: z.union([
+    z.literal("top-to-bottom"),
+    z.literal("left-to-right"),
+    z.literal("bottom-to-top"),
+    z.literal("right-to-left"),
+  ]),
+})
+/**
+ * @deprecated Use schematicPinArrangement instead.
+ */
+export const schematicPortArrangement = z.object({
+  leftSize: z.number().optional().describe("@deprecated, use leftPinCount"),
+  topSize: z.number().optional().describe("@deprecated, use topPinCount"),
+  rightSize: z.number().optional().describe("@deprecated, use rightPinCount"),
+  bottomSize: z.number().optional().describe("@deprecated, use bottomPinCount"),
+  leftPinCount: z.number().optional(),
+  rightPinCount: z.number().optional(),
+  topPinCount: z.number().optional(),
+  bottomPinCount: z.number().optional(),
+  leftSide: explicitPinSideDefinition.optional(),
+  rightSide: explicitPinSideDefinition.optional(),
+  topSide: explicitPinSideDefinition.optional(),
+  bottomSide: explicitPinSideDefinition.optional(),
+})
 ```
 
 ### distance
@@ -66,25 +173,14 @@ export type Distance = number | string
 export { distance, length } from "circuit-json"
 ```
 
-### footprintProp
+### point3
 
 ```typescript
-/**
- * This is an abbreviated definition of the soup elements that you can find here:
- * https://docs.tscircuit.com/api-reference/advanced/soup#pcb-smtpad
- */
-export type FootprintSoupElements = {
-  type: "pcb_smtpad" | "pcb_plated_hole"
-  x: string | number
-  y: string | number
-  layer?: LayerRef
-  holeDiameter?: string | number
-  outerDiameter?: string | number
-  shape?: "circle" | "rect"
-  width?: string | number
-  height?: string | number
-  portHints?: string[]
-}
+export const point3 = z.object({
+  x: distance,
+  y: distance,
+  z: distance,
+})
 ```
 
 ### layout
@@ -159,177 +255,28 @@ export const lrPolarPins = [
 ] as const
 ```
 
-### point
-
-```typescript
-export const point = z.object({
-  x: distance,
-  y: distance,
-})
-```
-
-### point3
-
-```typescript
-export const point3 = z.object({
-  x: distance,
-  y: distance,
-  z: distance,
-})
-```
-
-### schematicPinDefinitions
+### footprintProp
 
 ```typescript
 /**
- * @deprecated Use SchematicPortArrangementWithPinCounts instead.
+ * This is an abbreviated definition of the soup elements that you can find here:
+ * https://docs.tscircuit.com/api-reference/advanced/soup#pcb-smtpad
  */
-export interface SchematicPortArrangementWithSizes {
-  leftSize?: number
-  topSize?: number
-  rightSize?: number
-  bottomSize?: number
+export type FootprintSoupElements = {
+  type: "pcb_smtpad" | "pcb_plated_hole"
+  x: string | number
+  y: string | number
+  layer?: LayerRef
+  holeDiameter?: string | number
+  outerDiameter?: string | number
+  shape?: "circle" | "rect"
+  width?: string | number
+  height?: string | number
+  portHints?: string[]
 }
-/**
- * Specifies the number of pins on each side of the schematic box component.
- */
-export interface SchematicPortArrangementWithPinCounts {
-  leftPinCount?: number
-  topPinCount?: number
-  rightPinCount?: number
-  bottomPinCount?: number
-}
-export interface PinSideDefinition {
-  pins: Array<number | string>
-  direction:
-    | "top-to-bottom"
-    | "left-to-right"
-    | "bottom-to-top"
-    | "right-to-left"
-}
-export interface SchematicPortArrangementWithSides {
-  leftSide?: PinSideDefinition
-  topSide?: PinSideDefinition
-  rightSide?: PinSideDefinition
-  bottomSide?: PinSideDefinition
-}
-export interface SchematicPortArrangement
-  extends SchematicPortArrangementWithSizes,
-    SchematicPortArrangementWithSides,
-    SchematicPortArrangementWithPinCounts {}
-export const explicitPinSideDefinition = z.object({
-  pins: z.array(z.union([z.number(), z.string()])),
-  direction: z.union([
-    z.literal("top-to-bottom"),
-    z.literal("left-to-right"),
-    z.literal("bottom-to-top"),
-    z.literal("right-to-left"),
-  ]),
-})
-/**
- * @deprecated Use schematicPinArrangement instead.
- */
-export const schematicPortArrangement = z.object({
-  leftSize: z.number().optional().describe("@deprecated, use leftPinCount"),
-  topSize: z.number().optional().describe("@deprecated, use topPinCount"),
-  rightSize: z.number().optional().describe("@deprecated, use rightPinCount"),
-  bottomSize: z.number().optional().describe("@deprecated, use bottomPinCount"),
-  leftPinCount: z.number().optional(),
-  rightPinCount: z.number().optional(),
-  topPinCount: z.number().optional(),
-  bottomPinCount: z.number().optional(),
-  leftSide: explicitPinSideDefinition.optional(),
-  rightSide: explicitPinSideDefinition.optional(),
-  topSide: explicitPinSideDefinition.optional(),
-  bottomSide: explicitPinSideDefinition.optional(),
-})
-```
-
-### schematicPinStyle
-
-```typescript
-export type SchematicPinStyle = Record<
-  string,
-  {
-    marginTop?: number | string
-    marginRight?: number | string
-    marginBottom?: number | string
-    marginLeft?: number | string
-
-    leftMargin?: number | string
-    rightMargin?: number | string
-    topMargin?: number | string
-    bottomMargin?: number | string
-  }
-/** @deprecated use marginBottom */
-export const schematicPinStyle = z.record(
-  z.object({
-    marginLeft: distance.optional(),
-    marginRight: distance.optional(),
-    marginTop: distance.optional(),
-    marginBottom: distance.optional(),
-
-    leftMargin: distance.optional(),
-    rightMargin: distance.optional(),
-    topMargin: distance.optional(),
-    bottomMargin: distance.optional(),
-  }),
 ```
 
 ## Available Component Types
-
-### battery
-
-```typescript
-/** @deprecated use battery_capacity from circuit-json when circuit-json is updated */
-export interface BatteryProps extends CommonComponentProps {
-  capacity?: number | string
-}
-export const batteryProps = commonComponentProps.extend({
-  capacity: capacity.optional(),
-})
-```
-
-### board
-
-```typescript
-export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
-  width?: number | string
-  height?: number | string
-  outline?: Point[]
-  outlineOffsetX?: number | string
-  outlineOffsetY?: number | string
-  material?: "fr4" | "fr1"
-}
-export const boardProps = subcircuitGroupProps.extend({
-  width: distance.optional(),
-  height: distance.optional(),
-  outline: z.array(point).optional(),
-  outlineOffsetX: distance.optional(),
-  outlineOffsetY: distance.optional(),
-  material: z.enum(["fr4", "fr1"]).default("fr4"),
-})
-```
-
-### breakout
-
-```typescript
-export interface BreakoutProps
-  extends Omit<SubcircuitGroupProps, "subcircuit"> {
-  padding?: Distance
-  paddingLeft?: Distance
-  paddingRight?: Distance
-  paddingTop?: Distance
-  paddingBottom?: Distance
-}
-export const breakoutProps = subcircuitGroupProps.extend({
-  padding: distance.optional(),
-  paddingLeft: distance.optional(),
-  paddingRight: distance.optional(),
-  paddingTop: distance.optional(),
-  paddingBottom: distance.optional(),
-})
-```
 
 ### breakoutpoint
 
@@ -343,43 +290,6 @@ export const breakoutPointProps = pcbLayoutProps
   .extend({
     connection: z.string(),
   })
-```
-
-### capacitor
-
-```typescript
-export const capacitorPinLabels = [
-  "pin1",
-  "pin2",
-  "pos",
-  "neg",
-  "anode",
-  "cathode",
-] as const
-export interface CapacitorProps extends CommonComponentProps {
-  capacitance: number | string
-  maxVoltageRating?: number | string
-  schShowRatings?: boolean
-  polarized?: boolean
-  decouplingFor?: string
-  decouplingTo?: string
-  bypassFor?: string
-  bypassTo?: string
-  maxDecouplingTraceLength?: number
-  connections?: Connections<CapacitorPinLabels>
-}
-export const capacitorProps = commonComponentProps.extend({
-  capacitance,
-  maxVoltageRating: voltage.optional(),
-  schShowRatings: z.boolean().optional().default(false),
-  polarized: z.boolean().optional().default(false),
-  decouplingFor: z.string().optional(),
-  decouplingTo: z.string().optional(),
-  bypassFor: z.string().optional(),
-  bypassTo: z.string().optional(),
-  maxDecouplingTraceLength: z.number().optional(),
-  connections: createConnectionsProp(capacitorPinLabels).optional(),
-})
 ```
 
 ### chip
@@ -445,506 +355,62 @@ export const chipProps = commonComponentProps.extend({
 })
 ```
 
-### connector
+### resistor
 
 ```typescript
-export interface ConnectorProps extends CommonComponentProps {
-  manufacturerPartNumber?: string
-  pinLabels?: Record<number | string, string | string[]>
-  schPinStyle?: SchematicPinStyle
-  schPinSpacing?: number | string
-  schWidth?: number | string
-  schHeight?: number | string
-  schDirection?: "left" | "right"
-  schPortArrangement?: SchematicPortArrangement
-  internallyConnectedPins?: string[][]
-  standard?: "usb_c" | "m2"
+export interface ResistorProps extends CommonComponentProps {
+  resistance: number | string
+  pullupFor?: string
+  pullupTo?: string
+  pulldownFor?: string
+  pulldownTo?: string
+  connections?: Connections<ResistorPinLabels>
 }
+export const resistorProps = commonComponentProps.extend({
+  resistance,
+
+  pullupFor: z.string().optional(),
+  pullupTo: z.string().optional(),
+
+  pulldownFor: z.string().optional(),
+  pulldownTo: z.string().optional(),
+
+  connections: createConnectionsProp(resistorPinLabels).optional(),
+})
+```
+
+### schematic-path
+
+```typescript
+export const schematicPathProps = z.object({
+  points: z.array(point),
+  isFilled: z.boolean().optional().default(false),
+  fillColor: z.enum(["red", "blue"]).optional(),
+})
+```
+
+### netalias
+
+```typescript
 /**
-   * Connector standard, e.g. usb_c, m2
-   */
-export const connectorProps = commonComponentProps.extend({
-  manufacturerPartNumber: z.string().optional(),
-  pinLabels: z
-    .record(z.number().or(z.string()), z.string().or(z.array(z.string())))
-    .optional(),
-  schPinStyle: schematicPinStyle.optional(),
-  schPinSpacing: distance.optional(),
-  schWidth: distance.optional(),
-  schHeight: distance.optional(),
-  schDirection: z.enum(["left", "right"]).optional(),
-  schPortArrangement: schematicPortArrangement.optional(),
-  internallyConnectedPins: z.array(z.array(z.string())).optional(),
-  standard: z.enum(["usb_c", "m2"]).optional(),
-})
-```
-
-### constrainedlayout
-
-```typescript
-export interface ConstrainedLayoutProps {
-  name?: string
-  pcbOnly?: boolean
-  schOnly?: boolean
-}
-export const constrainedLayoutProps = z.object({
-  name: z.string().optional(),
-  pcbOnly: z.boolean().optional(),
-  schOnly: z.boolean().optional(),
-})
-```
-
-### constraint
-
-```typescript
-export type PcbXDistConstraint = {
-  pcb?: true
-  xDist: Distance
-
-  left: string
-
-  right: string
-
-  edgeToEdge?: true
-
-  centerToCenter?: true
-}
-/**
-   * If true, the provided distance is the distance between the centers of the
-   * left and right components
-   */
-export type PcbYDistConstraint = {
-  pcb?: true
-  yDist: Distance
-
-  top: string
-
-  bottom: string
-
-  edgeToEdge?: true
-  centerToCenter?: true
-}
-/**
-   * Selector for bottom component, e.g. ".U1" or ".R1", you can also specify the
-   * edge or center of the component e.g. ".R1 bottomedge", ".R1 center"
-   */
-export type PcbSameYConstraint = {
-  pcb?: true
-  sameY?: true
-
-  for: string[]
-}
-/**
-   * Selector for components, e.g. [".U1", ".R1"], you can also specify the
-   * edge or center of the component e.g. [".R1 leftedge", ".U1 center"]
-   */
-export type PcbSameXConstraint = {
-  pcb?: true
-  sameX?: true
-  for: string[]
-}
-export const pcbXDistConstraintProps = z.object({
-  pcb: z.literal(true).optional(),
-  xDist: distance,
-  left: z.string(),
-  right: z.string(),
-
-  edgeToEdge: z.literal(true).optional(),
-  centerToCenter: z.literal(true).optional(),
-})
-export const pcbYDistConstraintProps = z.object({
-  pcb: z.literal(true).optional(),
-  yDist: distance,
-  top: z.string(),
-  bottom: z.string(),
-
-  edgeToEdge: z.literal(true).optional(),
-  centerToCenter: z.literal(true).optional(),
-})
-export const pcbSameYConstraintProps = z.object({
-  pcb: z.literal(true).optional(),
-  sameY: z.literal(true).optional(),
-  for: z.array(z.string()),
-})
-export const pcbSameXConstraintProps = z.object({
-  pcb: z.literal(true).optional(),
-  sameX: z.literal(true).optional(),
-  for: z.array(z.string()),
-})
-```
-
-### crystal
-
-```typescript
-export interface CrystalProps extends CommonComponentProps {
-  frequency: number | string
-  loadCapacitance: number | string
-  pinVariant?: PinVariant
-}
-export const crystalProps = commonComponentProps.extend({
-  frequency: frequency,
-  loadCapacitance: capacitance,
-  pinVariant: z.enum(["two_pin", "four_pin"]).optional(),
-})
-```
-
-### cutout
-
-```typescript
-export interface RectCutoutProps
-  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
-  name?: string
-  shape: "rect"
-  width: Distance
-  height: Distance
-}
-export const rectCutoutProps = pcbLayoutProps
-  .omit({
-    layer: true,
-    pcbRotation: true,
-  })
-  .extend({
-    name: z.string().optional(),
-    shape: z.literal("rect"),
-    width: distance,
-    height: distance,
-  })
-export interface CircleCutoutProps
-  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
-  name?: string
-  shape: "circle"
-  radius: Distance
-}
-export const circleCutoutProps = pcbLayoutProps
-  .omit({
-    layer: true,
-    pcbRotation: true,
-  })
-  .extend({
-    name: z.string().optional(),
-    shape: z.literal("circle"),
-    radius: distance,
-  })
-export interface PolygonCutoutProps
-  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
-  name?: string
-  shape: "polygon"
-  points: Point[]
-}
-export const polygonCutoutProps = pcbLayoutProps
-  .omit({
-    layer: true,
-    pcbRotation: true,
-  })
-  .extend({
-    name: z.string().optional(),
-    shape: z.literal("polygon"),
-    points: z.array(point),
-  })
-```
-
-### diode
-
-```typescript
-.extend({
-    connections: connectionsProp.optional(),
-    variant: diodeVariant.optional().default("standard"),
-    standard: z.boolean().optional(),
-    schottky: z.boolean().optional(),
-    zener: z.boolean().optional(),
-    photo: z.boolean().optional(),
-    tvs: z.boolean().optional(),
-  })
-export interface DiodeProps extends CommonComponentProps {
-  connections?: {
-    anode?: string | string[] | readonly string[]
-    cathode?: string | string[] | readonly string[]
-    pin1?: string | string[] | readonly string[]
-    pin2?: string | string[] | readonly string[]
-    pos?: string | string[] | readonly string[]
-    neg?: string | string[] | readonly string[]
-  }
-  variant?: "standard" | "schottky" | "zener" | "photo" | "tvs"
-  standard?: boolean
-  schottky?: boolean
-  zener?: boolean
-  photo?: boolean
-  tvs?: boolean
-}
-```
-
-### fabrication-note-path
-
-```typescript
-export const fabricationNotePathProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
-  .extend({
-    route: z.array(route_hint_point),
-    strokeWidth: length.optional(),
-    color: z.string().optional(),
-  })
-```
-
-### fabrication-note-text
-
-```typescript
-export const fabricationNoteTextProps = pcbLayoutProps.extend({
-  text: z.string(),
-  anchorAlignment: z
-    .enum(["center", "top_left", "top_right", "bottom_left", "bottom_right"])
-    .default("center"),
-  font: z.enum(["tscircuit2024"]).optional(),
-  fontSize: length.optional(),
-  color: z.string().optional(),
-})
-```
-
-### footprint
-
-```typescript
-export interface FootprintProps {
-  originalLayer?: LayerRef
-}
-/**
-   * The layer that the footprint is designed for. If you set this to "top"
-   * then it means the children were intended to represent the top layer. If
-   * the <chip /> with this footprint is moved to the bottom layer, then the
-   * components will be mirrored.
-   *
-   * Generally, you shouldn't set this except where it can help prevent
-   * confusion because you have a complex multi-layer footprint. Default is
-   * "top" and this is most intuitive.
-   */
-export const footprintProps = z.object({
-  originalLayer: layer_ref.default("top").optional(),
-})
-```
-
-### fuse
-
-```typescript
-export interface FuseProps extends CommonComponentProps {
-  currentRating: number | string
-
-  voltageRating?: number | string
-
-  schShowRatings?: boolean
-
-  connections?: Connections<FusePinLabels>
-}
-/**
- * Schema for validating fuse props
+ * @deprecated Use NetLabelProps instead.
  */
-export const fuseProps = commonComponentProps.extend({
-  currentRating: z.union([z.number(), z.string()]),
-  voltageRating: z.union([z.number(), z.string()]).optional(),
-  schShowRatings: z.boolean().optional(),
-  connections: z
-    .record(
-      z.string(),
-      z.union([
-        z.string(),
-        z.array(z.string()).readonly(),
-        z.array(z.string()),
-      ]),
-    )
-    .optional(),
-})
-```
-
-### group
-
-```typescript
-export const layoutConfig = z.object({
-  layoutMode: z.enum(["grid", "flex", "match-adapt", "none"]).optional(),
-  position: z.enum(["absolute", "relative"]).optional(),
-
-  grid: z.boolean().optional(),
-  gridCols: z.number().or(z.string()).optional(),
-  gridRows: z.number().or(z.string()).optional(),
-  gridTemplateRows: z.string().optional(),
-  gridTemplateColumns: z.string().optional(),
-  gridTemplate: z.string().optional(),
-  gridGap: z.number().or(z.string()).optional(),
-
-  flex: z.boolean().or(z.string()).optional(),
-  flexDirection: z.enum(["row", "column"]).optional(),
-  alignItems: z.enum(["start", "center", "end", "stretch"]).optional(),
-  justifyContent: z.enum(["start", "center", "end", "stretch"]).optional(),
-  flexRow: z.boolean().optional(),
-  flexColumn: z.boolean().optional(),
-  gap: z.number().or(z.string()).optional(),
-
-  width: length.optional(),
-  height: length.optional(),
-
-  matchAdapt: z.boolean().optional(),
-  matchAdaptTemplate: z.any().optional(),
-})
-export interface LayoutConfig {
-  layoutMode?: "grid" | "flex" | "match-adapt" | "none"
-  position?: "absolute" | "relative"
-
-  grid?: boolean
-  gridCols?: number | string
-  gridRows?: number | string
-  gridTemplateRows?: string
-  gridTemplateColumns?: string
-  gridTemplate?: string
-  gridGap?: number | string
-
-  flex?: boolean | string
-  flexDirection?: "row" | "column"
-  alignItems?: "start" | "center" | "end" | "stretch"
-  justifyContent?: "start" | "center" | "end" | "stretch"
-  flexRow?: boolean
-  flexColumn?: boolean
-  gap?: number | string
-
-  width?: Distance
-  height?: Distance
-
-  matchAdapt?: boolean
-  matchAdaptTemplate?: any
+export interface NetAliasProps {
+  net?: string
+  connection?: string
+  schX?: number | string
+  schY?: number | string
+  schRotation?: number | string
+  anchorSide?: "left" | "up" | "right" | "down"
 }
-export interface CellBorder {
-  strokeWidth?: Distance
-  dashed?: boolean
-  solid?: boolean
-}
-export const cellBorder = z.object({
-  strokeWidth: length.optional(),
-  dashed: z.boolean().optional(),
-  solid: z.boolean().optional(),
-})
-export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
-  name?: string
-  key?: any
-  children?: any
-
-  pcbWidth?: Distance
-  pcbHeight?: Distance
-  schWidth?: Distance
-  schHeight?: Distance
-
-  pcbLayout?: LayoutConfig
-  schLayout?: LayoutConfig
-  cellBorder?: CellBorder
-  border?: CellBorder
-}
-export type PartsEngine = {
-  findPart: (params: {
-    sourceComponent: AnySourceComponent
-    footprinterString?: string
-  }) => Promise<SupplierPartNumbers> | SupplierPartNumbers
-}
-export interface PcbRouteCache {
-  pcbTraces: PcbTrace[]
-  cacheKey: string
-}
-export interface AutorouterConfig {
-  serverUrl?: string
-  inputFormat?: "simplified" | "circuit-json"
-  serverMode?: "job" | "solve-endpoint"
-  serverCacheEnabled?: boolean
-  cache?: PcbRouteCache
-  groupMode?: "sequential-trace" | "subcircuit"
-  local?: boolean
-  algorithmFn?: (simpleRouteJson: any) => Promise<any>
-}
-export const autorouterConfig = z.object({
-  serverUrl: z.string().optional(),
-  inputFormat: z.enum(["simplified", "circuit-json"]).optional(),
-  serverMode: z.enum(["job", "solve-endpoint"]).optional(),
-  serverCacheEnabled: z.boolean().optional(),
-  cache: z.custom<PcbRouteCache>((v) => true).optional(),
-  groupMode: z.enum(["sequential-trace", "subcircuit"]).optional(),
-  algorithmFn: z
-    .custom<(simpleRouteJson: any) => Promise<any>>(
-      (v) => typeof v === "function" || v === undefined,
-    )
-    .optional(),
-  local: z.boolean().optional(),
-})
-export interface SubcircuitGroupProps extends BaseGroupProps {
-  layout?: LayoutBuilder
-  manualEdits?: ManualEditsFileInput
-  routingDisabled?: boolean
-  defaultTraceWidth?: Distance
-  minTraceWidth?: Distance
-  pcbRouteCache?: PcbRouteCache
-
-  autorouter?: AutorouterProp
-
-  schAutoLayoutEnabled?: boolean
-
-  schTraceAutoLabelEnabled?: boolean
-
-  partsEngine?: PartsEngine
-}
-/**
-   * If true, net labels will automatically be created for complex traces
-   */
-export interface SubcircuitGroupPropsWithBool extends SubcircuitGroupProps {
-  subcircuit: true
-}
-export interface NonSubcircuitGroupProps extends BaseGroupProps {
-  subcircuit?: false | undefined
-}
-export const baseGroupProps = commonLayoutProps.extend({
-  name: z.string().optional(),
-  children: z.any().optional(),
-  key: z.any().optional(),
-
-  ...layoutConfig.shape,
-  pcbWidth: length.optional(),
-  pcbHeight: length.optional(),
-  schWidth: length.optional(),
-  schHeight: length.optional(),
-  pcbLayout: layoutConfig.optional(),
-  schLayout: layoutConfig.optional(),
-  cellBorder: cellBorder.optional(),
-  border: cellBorder.optional(),
-})
-export const subcircuitGroupProps = baseGroupProps.extend({
-  layout: z.custom<LayoutBuilder>((v) => true).optional(),
-  manualEdits: manual_edits_file.optional(),
-  schAutoLayoutEnabled: z.boolean().optional(),
-  schTraceAutoLabelEnabled: z.boolean().optional(),
-  routingDisabled: z.boolean().optional(),
-  defaultTraceWidth: length.optional(),
-  minTraceWidth: length.optional(),
-  partsEngine: partsEngine.optional(),
-  pcbRouteCache: z.custom<PcbRouteCache>((v) => true).optional(),
-  autorouter: autorouterProp.optional(),
-})
-export const subcircuitGroupPropsWithBool = subcircuitGroupProps.extend({
-  subcircuit: z.literal(true),
-})
-```
-
-### hole
-
-```typescript
-export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
-  name?: string
-  diameter?: Distance
-  radius?: Distance
-}
-export const holeProps = pcbLayoutProps
-  .omit({ pcbRotation: true })
-  .extend({
-    name: z.string().optional(),
-    diameter: distance.optional(),
-    radius: distance.optional(),
-  })
-```
-
-### inductor
-
-```typescript
-export const inductorProps = commonComponentProps.extend({
-  inductance,
+/** @deprecated Use netLabelProps instead. */
+export const netAliasProps = z.object({
+  net: z.string().optional(),
+  connection: z.string().optional(),
+  schX: distance.optional(),
+  schY: distance.optional(),
+  schRotation: rotation.optional(),
+  anchorSide: z.enum(["left", "up", "right", "down"]).optional(),
 })
 ```
 
@@ -983,105 +449,18 @@ export const jumperProps = commonComponentProps.extend({
 })
 ```
 
-### led
+### trace
 
 ```typescript
-export const ledProps = commonComponentProps.extend({
-  color: z.string().optional(),
-  wavelength: z.string().optional(),
-  schDisplayValue: z.string().optional(),
-})
-```
-
-### mosfet
-
-```typescript
-export interface MosfetProps extends CommonComponentProps {
-  channelType: "n" | "p"
-  mosfetMode: "enhancement" | "depletion"
-}
-export const mosfetProps = commonComponentProps.extend({
-  channelType: z.enum(["n", "p"]),
-  mosfetMode: z.enum(["enhancement", "depletion"]),
-})
-export const mosfetPins = [
-  "pin1",
-  "drain",
-  "pin2",
-  "source",
-  "pin3",
-  "gate",
-] as const
-```
-
-### net
-
-```typescript
-export interface NetProps {
-  name: string
-}
-export const netProps = z.object({
-  name: z.string(),
-})
-```
-
-### netalias
-
-```typescript
-/**
- * @deprecated Use NetLabelProps instead.
- */
-export interface NetAliasProps {
-  net?: string
-  connection?: string
-  schX?: number | string
-  schY?: number | string
-  schRotation?: number | string
-  anchorSide?: "left" | "up" | "right" | "down"
-}
-/** @deprecated Use netLabelProps instead. */
-export const netAliasProps = z.object({
-  net: z.string().optional(),
-  connection: z.string().optional(),
-  schX: distance.optional(),
-  schY: distance.optional(),
-  schRotation: rotation.optional(),
-  anchorSide: z.enum(["left", "up", "right", "down"]).optional(),
-})
-```
-
-### netlabel
-
-```typescript
-export interface NetLabelProps {
-  net?: string
-  connection?: string
-  schX?: number | string
-  schY?: number | string
-  schRotation?: number | string
-  anchorSide?: "left" | "up" | "right" | "down"
-}
-export const netLabelProps = z.object({
-  net: z.string().optional(),
-  connection: z.string().optional(),
-  schX: distance.optional(),
-  schY: distance.optional(),
-  schRotation: rotation.optional(),
-  anchorSide: z.enum(["left", "up", "right", "down"]).optional(),
-})
-```
-
-### pcb-keepout
-
-```typescript
-pcbLayoutProps.omit({ pcbRotation: true }).extend({
-    shape: z.literal("circle"),
-    radius: distance,
+export const portRef = z.union([
+  z.string(),
+  z.custom<{ getPortSelector: () => string }>((v) =>
+baseTraceProps.extend({
+    path: z.array(portRef),
   }),
-pcbLayoutProps.extend({
-    shape: z.literal("rect"),
-    width: distance,
-    height: distance,
+baseTraceProps.extend({
+    from: portRef,
+    to: portRef,
   }),
 ```
 
@@ -1095,53 +474,75 @@ export const pcbTraceProps = z.object({
 })
 ```
 
-### pin-header
+### battery
 
 ```typescript
-export interface PinHeaderProps extends CommonComponentProps {
-  pinCount: number
-
-  pitch?: number | string
-
-  schFacingDirection?: "up" | "down" | "left" | "right"
-
-  gender?: "male" | "female"
-
-  showSilkscreenPinLabels?: boolean
-
-  doubleRow?: boolean
-
-  holeDiameter?: number | string
-
-  platedDiameter?: number | string
-
-  pinLabels?: string[]
-
-  connections?: Connections<string>
-
-  facingDirection?: "left" | "right"
-
-  schPinArrangement?: SchematicPinArrangement
+/** @deprecated use battery_capacity from circuit-json when circuit-json is updated */
+export interface BatteryProps extends CommonComponentProps {
+  capacity?: number | string
 }
-/**
-   * Pin arrangement in schematic view
-   */
-export const pinHeaderProps = commonComponentProps.extend({
-  pinCount: z.number(),
-  pitch: distance.optional(),
-  schFacingDirection: z.enum(["up", "down", "left", "right"]).optional(),
-  gender: z.enum(["male", "female"]).optional().default("male"),
-  showSilkscreenPinLabels: z.boolean().optional(),
-  doubleRow: z.boolean().optional(),
-  holeDiameter: distance.optional(),
-  platedDiameter: distance.optional(),
-  pinLabels: z.array(z.string()).optional(),
-  connections: z
-    .custom<Connections>()
-    .pipe(z.record(z.string(), connectionTarget))
-    .optional(),
-  facingDirection: z.enum(["left", "right"]).optional(),
-  schPinArrangement: schematicPinArrangement.optional(),
+export const batteryProps = commonComponentProps.extend({
+  capacity: capacity.optional(),
+})
+```
+
+### transistor
+
+```typescript
+export interface TransistorProps extends CommonComponentProps {
+  type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet"
+}
+export const transistorProps = commonComponentProps.extend({
+  type: z.enum(["npn", "pnp", "bjt", "jfet", "mosfet"]),
+})
+export const transistorPins = [
+  "pin1",
+  "emitter",
+  "pin2",
+  "collector",
+  "pin3",
+  "base",
+] as const
+```
+
+### silkscreen-line
+
+```typescript
+export const silkscreenLineProps = pcbLayoutProps
+  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .extend({
+    strokeWidth: distance,
+    x1: distance,
+    y1: distance,
+    x2: distance,
+    y2: distance,
+  })
+```
+
+### silkscreen-circle
+
+```typescript
+export const silkscreenCircleProps = pcbLayoutProps
+  .omit({ pcbRotation: true })
+  .extend({
+    isFilled: z.boolean().optional(),
+    isOutline: z.boolean().optional(),
+    strokeWidth: distance.optional(),
+    radius: distance,
+  })
+```
+
+### fabrication-note-text
+
+```typescript
+export const fabricationNoteTextProps = pcbLayoutProps.extend({
+  text: z.string(),
+  anchorAlignment: z
+    .enum(["center", "top_left", "top_right", "bottom_left", "bottom_right"])
+    .default("center"),
+  font: z.enum(["tscircuit2024"]).optional(),
+  fontSize: length.optional(),
+  color: z.string().optional(),
 })
 ```
 
@@ -1273,189 +674,95 @@ pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
     }),
 ```
 
-### port
+### diode
 
 ```typescript
-export const portProps = commonLayoutProps.extend({
-  name: z.string(),
-  pinNumber: z.number().optional(),
-  aliases: z.array(z.string()).optional(),
-  direction: direction,
-})
-```
-
-### potentiometer
-
-```typescript
-export interface PotentiometerProps extends CommonComponentProps {
-  maxResistance: number | string
-  pinVariant?: PotentiometerPinVariant
-}
-export const potentiometerProps = commonComponentProps.extend({
-  maxResistance: resistance,
-  pinVariant: z.enum(["two_pin", "three_pin"]).optional(),
-})
-```
-
-### power-source
-
-```typescript
-export const powerSourceProps = commonComponentProps.extend({
-  voltage,
-})
-```
-
-### resistor
-
-```typescript
-export interface ResistorProps extends CommonComponentProps {
-  resistance: number | string
-  pullupFor?: string
-  pullupTo?: string
-  pulldownFor?: string
-  pulldownTo?: string
-  connections?: Connections<ResistorPinLabels>
-}
-export const resistorProps = commonComponentProps.extend({
-  resistance,
-
-  pullupFor: z.string().optional(),
-  pullupTo: z.string().optional(),
-
-  pulldownFor: z.string().optional(),
-  pulldownTo: z.string().optional(),
-
-  connections: createConnectionsProp(resistorPinLabels).optional(),
-})
-```
-
-### resonator
-
-```typescript
-export interface ResonatorProps extends CommonComponentProps {
-  frequency: number | string
-  loadCapacitance: number | string
-  pinVariant?: ResonatorPinVariant
-}
-export const resonatorProps = commonComponentProps.extend({
-  frequency: frequency,
-  loadCapacitance: capacitance,
-  pinVariant: z.enum(["no_ground", "ground_pin", "two_ground_pins"]).optional(),
-})
-```
-
-### schematic-box
-
-```typescript
-export const schematicBoxProps = z
-  .object({
-    schX: distance,
-    schY: distance,
-    width: distance.optional(),
-    height: distance.optional(),
-    overlay: z.array(z.string()).optional(),
-
-    padding: distance.optional(),
-    paddingLeft: distance.optional(),
-    paddingRight: distance.optional(),
-    paddingTop: distance.optional(),
-    paddingBottom: distance.optional(),
-
-    title: z.string().optional(),
-    titleAlignment: ninePointAnchor.default("center"),
-    titleColor: z.string().optional(),
-    titleFontSize: distance.optional(),
-    titleInside: z.boolean().default(false),
-    strokeStyle: z.enum(["solid", "dashed"]).default("solid"),
+.extend({
+    connections: connectionsProp.optional(),
+    variant: diodeVariant.optional().default("standard"),
+    standard: z.boolean().optional(),
+    schottky: z.boolean().optional(),
+    zener: z.boolean().optional(),
+    photo: z.boolean().optional(),
+    tvs: z.boolean().optional(),
   })
+export interface DiodeProps extends CommonComponentProps {
+  connections?: {
+    anode?: string | string[] | readonly string[]
+    cathode?: string | string[] | readonly string[]
+    pin1?: string | string[] | readonly string[]
+    pin2?: string | string[] | readonly string[]
+    pos?: string | string[] | readonly string[]
+    neg?: string | string[] | readonly string[]
+  }
+  variant?: "standard" | "schottky" | "zener" | "photo" | "tvs"
+  standard?: boolean
+  schottky?: boolean
+  zener?: boolean
+  photo?: boolean
+  tvs?: boolean
+}
 ```
 
-### schematic-line
+### mosfet
 
 ```typescript
-export const schematicLineProps = z.object({
-  x1: distance,
-  y1: distance,
-  x2: distance,
-  y2: distance,
+export interface MosfetProps extends CommonComponentProps {
+  channelType: "n" | "p"
+  mosfetMode: "enhancement" | "depletion"
+}
+export const mosfetProps = commonComponentProps.extend({
+  channelType: z.enum(["n", "p"]),
+  mosfetMode: z.enum(["enhancement", "depletion"]),
 })
+export const mosfetPins = [
+  "pin1",
+  "drain",
+  "pin2",
+  "source",
+  "pin3",
+  "gate",
+] as const
 ```
 
-### schematic-path
+### fabrication-note-path
 
 ```typescript
-export const schematicPathProps = z.object({
-  points: z.array(point),
-  isFilled: z.boolean().optional().default(false),
-  fillColor: z.enum(["red", "blue"]).optional(),
-})
-```
-
-### schematic-text
-
-```typescript
-export const schematicTextProps = z.object({
-  schX: distance,
-  schY: distance,
-  text: z.string(),
-  fontSize: z.number().default(1),
-  anchor: z
-    .union([fivePointAnchor.describe("legacy"), ninePointAnchor])
-    .default("center"),
-  color: z.string().default("#000000"),
-  schRotation: rotation.default(0),
-})
-```
-
-### silkscreen-circle
-
-```typescript
-export const silkscreenCircleProps = pcbLayoutProps
-  .omit({ pcbRotation: true })
-  .extend({
-    isFilled: z.boolean().optional(),
-    isOutline: z.boolean().optional(),
-    strokeWidth: distance.optional(),
-    radius: distance,
-  })
-```
-
-### silkscreen-line
-
-```typescript
-export const silkscreenLineProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
-  .extend({
-    strokeWidth: distance,
-    x1: distance,
-    y1: distance,
-    x2: distance,
-    y2: distance,
-  })
-```
-
-### silkscreen-path
-
-```typescript
-export const silkscreenPathProps = pcbLayoutProps
+export const fabricationNotePathProps = pcbLayoutProps
   .omit({ pcbX: true, pcbY: true, pcbRotation: true })
   .extend({
     route: z.array(route_hint_point),
     strokeWidth: length.optional(),
+    color: z.string().optional(),
   })
 ```
 
-### silkscreen-rect
+### solderpaste
 
 ```typescript
-export const silkscreenRectProps = pcbLayoutProps
+export interface RectSolderPasteProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "rect"
+  width: Distance
+  height: Distance
+}
+export interface CircleSolderPasteProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "circle"
+  radius: Distance
+}
+export const rectSolderPasteProps = pcbLayoutProps
   .omit({ pcbRotation: true })
   .extend({
-    filled: z.boolean().default(true).optional(),
-    stroke: z.enum(["dashed", "solid", "none"]).optional(),
-    strokeWidth: distance.optional(),
+    shape: z.literal("rect"),
     width: distance,
     height: distance,
+  })
+export const circleSolderPasteProps = pcbLayoutProps
+  .omit({ pcbRotation: true })
+  .extend({
+    shape: z.literal("circle"),
+    radius: distance,
   })
 ```
 
@@ -1467,6 +774,38 @@ export const silkscreenTextProps = pcbLayoutProps.extend({
   anchorAlignment: ninePointAnchor.default("center"),
   font: z.enum(["tscircuit2024"]).optional(),
   fontSize: length.optional(),
+})
+```
+
+### fuse
+
+```typescript
+export interface FuseProps extends CommonComponentProps {
+  currentRating: number | string
+
+  voltageRating?: number | string
+
+  schShowRatings?: boolean
+
+  connections?: Connections<FusePinLabels>
+}
+/**
+ * Schema for validating fuse props
+ */
+export const fuseProps = commonComponentProps.extend({
+  currentRating: z.union([z.number(), z.string()]),
+  voltageRating: z.union([z.number(), z.string()]).optional(),
+  schShowRatings: z.boolean().optional(),
+  connections: z
+    .record(
+      z.string(),
+      z.union([
+        z.string(),
+        z.array(z.string()).readonly(),
+        z.array(z.string()),
+      ]),
+    )
+    .optional(),
 })
 ```
 
@@ -1547,75 +886,86 @@ export const polygonSmtPadProps = pcbLayoutProps
   })
 ```
 
-### solderjumper
+### power-source
 
 ```typescript
-export interface SolderJumperProps extends JumperProps {
-  bridgedPins?: string[][]
-}
-/**
-   * Pins that are bridged with solder by default
-   */
-export const solderjumperProps = jumperProps.extend({
-  bridgedPins: z.array(z.array(z.string())).optional(),
+export const powerSourceProps = commonComponentProps.extend({
+  voltage,
 })
 ```
 
-### solderpaste
+### capacitor
 
 ```typescript
-export interface RectSolderPasteProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "rect"
-  width: Distance
-  height: Distance
+export const capacitorPinLabels = [
+  "pin1",
+  "pin2",
+  "pos",
+  "neg",
+  "anode",
+  "cathode",
+] as const
+export interface CapacitorProps extends CommonComponentProps {
+  capacitance: number | string
+  maxVoltageRating?: number | string
+  schShowRatings?: boolean
+  polarized?: boolean
+  decouplingFor?: string
+  decouplingTo?: string
+  bypassFor?: string
+  bypassTo?: string
+  maxDecouplingTraceLength?: number
+  connections?: Connections<CapacitorPinLabels>
 }
-export interface CircleSolderPasteProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "circle"
-  radius: Distance
-}
-export const rectSolderPasteProps = pcbLayoutProps
-  .omit({ pcbRotation: true })
-  .extend({
+export const capacitorProps = commonComponentProps.extend({
+  capacitance,
+  maxVoltageRating: voltage.optional(),
+  schShowRatings: z.boolean().optional().default(false),
+  polarized: z.boolean().optional().default(false),
+  decouplingFor: z.string().optional(),
+  decouplingTo: z.string().optional(),
+  bypassFor: z.string().optional(),
+  bypassTo: z.string().optional(),
+  maxDecouplingTraceLength: z.number().optional(),
+  connections: createConnectionsProp(capacitorPinLabels).optional(),
+})
+```
+
+### pcb-keepout
+
+```typescript
+pcbLayoutProps.omit({ pcbRotation: true }).extend({
+    shape: z.literal("circle"),
+    radius: distance,
+  }),
+pcbLayoutProps.extend({
     shape: z.literal("rect"),
     width: distance,
     height: distance,
-  })
-export const circleSolderPasteProps = pcbLayoutProps
-  .omit({ pcbRotation: true })
-  .extend({
-    shape: z.literal("circle"),
-    radius: distance,
-  })
+  }),
 ```
 
-### stampboard
+### schematic-line
 
 ```typescript
-export interface StampboardProps extends BoardProps {
-  leftPinCount?: number
-  rightPinCount?: number
-  topPinCount?: number
-  bottomPinCount?: number
-  leftPins?: string[]
-  rightPins?: string[]
-  topPins?: string[]
-  bottomPins?: string[]
-  pinPitch?: number | string
-  innerHoles?: boolean
+export const schematicLineProps = z.object({
+  x1: distance,
+  y1: distance,
+  x2: distance,
+  y2: distance,
+})
+```
+
+### potentiometer
+
+```typescript
+export interface PotentiometerProps extends CommonComponentProps {
+  maxResistance: number | string
+  pinVariant?: PotentiometerPinVariant
 }
-export const stampboardProps = boardProps.extend({
-  leftPinCount: z.number().optional(),
-  rightPinCount: z.number().optional(),
-  topPinCount: z.number().optional(),
-  bottomPinCount: z.number().optional(),
-  leftPins: z.array(z.string()).optional(),
-  rightPins: z.array(z.string()).optional(),
-  topPins: z.array(z.string()).optional(),
-  bottomPins: z.array(z.string()).optional(),
-  pinPitch: distance.optional(),
-  innerHoles: z.boolean().optional(),
+export const potentiometerProps = commonComponentProps.extend({
+  maxResistance: resistance,
+  pinVariant: z.enum(["two_pin", "three_pin"]).optional(),
 })
 ```
 
@@ -1640,24 +990,108 @@ export interface SwitchProps extends CommonComponentProps {
   })
 ```
 
-### testpoint
+### constrainedlayout
 
 ```typescript
-export interface TestpointProps extends CommonComponentProps {
-  footprintVariant?: "pad" | "through_hole"
-  padShape?: "rect" | "circle"
-  padDiameter?: number | string
-  holeDiameter?: number | string
-  width?: number | string
-  height?: number | string
+export interface ConstrainedLayoutProps {
+  name?: string
+  pcbOnly?: boolean
+  schOnly?: boolean
 }
-.extend({
-    footprintVariant: z.enum(["pad", "through_hole"]).optional(),
-    padShape: z.enum(["rect", "circle"]).optional().default("circle"),
-    padDiameter: distance.optional(),
-    holeDiameter: distance.optional(),
-    width: distance.optional(),
-    height: distance.optional(),
+export const constrainedLayoutProps = z.object({
+  name: z.string().optional(),
+  pcbOnly: z.boolean().optional(),
+  schOnly: z.boolean().optional(),
+})
+```
+
+### inductor
+
+```typescript
+export const inductorProps = commonComponentProps.extend({
+  inductance,
+})
+```
+
+### netlabel
+
+```typescript
+export interface NetLabelProps {
+  net?: string
+  connection?: string
+  schX?: number | string
+  schY?: number | string
+  schRotation?: number | string
+  anchorSide?: "left" | "up" | "right" | "down"
+}
+export const netLabelProps = z.object({
+  net: z.string().optional(),
+  connection: z.string().optional(),
+  schX: distance.optional(),
+  schY: distance.optional(),
+  schRotation: rotation.optional(),
+  anchorSide: z.enum(["left", "up", "right", "down"]).optional(),
+})
+```
+
+### schematic-text
+
+```typescript
+export const schematicTextProps = z.object({
+  schX: distance,
+  schY: distance,
+  text: z.string(),
+  fontSize: z.number().default(1),
+  anchor: z
+    .union([fivePointAnchor.describe("legacy"), ninePointAnchor])
+    .default("center"),
+  color: z.string().default("#000000"),
+  schRotation: rotation.default(0),
+})
+```
+
+### connector
+
+```typescript
+export interface ConnectorProps extends CommonComponentProps {
+  manufacturerPartNumber?: string
+  pinLabels?: Record<number | string, string | string[]>
+  schPinStyle?: SchematicPinStyle
+  schPinSpacing?: number | string
+  schWidth?: number | string
+  schHeight?: number | string
+  schDirection?: "left" | "right"
+  schPortArrangement?: SchematicPortArrangement
+  internallyConnectedPins?: string[][]
+  standard?: "usb_c" | "m2"
+}
+/**
+   * Connector standard, e.g. usb_c, m2
+   */
+export const connectorProps = commonComponentProps.extend({
+  manufacturerPartNumber: z.string().optional(),
+  pinLabels: z
+    .record(z.number().or(z.string()), z.string().or(z.array(z.string())))
+    .optional(),
+  schPinStyle: schematicPinStyle.optional(),
+  schPinSpacing: distance.optional(),
+  schWidth: distance.optional(),
+  schHeight: distance.optional(),
+  schDirection: z.enum(["left", "right"]).optional(),
+  schPortArrangement: schematicPortArrangement.optional(),
+  internallyConnectedPins: z.array(z.array(z.string())).optional(),
+  standard: z.enum(["usb_c", "m2"]).optional(),
+})
+```
+
+### silkscreen-path
+
+```typescript
+export const silkscreenPathProps = pcbLayoutProps
+  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .extend({
+    route: z.array(route_hint_point),
+    strokeWidth: length.optional(),
   })
 ```
 
@@ -1687,40 +1121,6 @@ export const traceHintProps = z.object({
 })
 ```
 
-### trace
-
-```typescript
-export const portRef = z.union([
-  z.string(),
-  z.custom<{ getPortSelector: () => string }>((v) =>
-baseTraceProps.extend({
-    path: z.array(portRef),
-  }),
-baseTraceProps.extend({
-    from: portRef,
-    to: portRef,
-  }),
-```
-
-### transistor
-
-```typescript
-export interface TransistorProps extends CommonComponentProps {
-  type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet"
-}
-export const transistorProps = commonComponentProps.extend({
-  type: z.enum(["npn", "pnp", "bjt", "jfet", "mosfet"]),
-})
-export const transistorPins = [
-  "pin1",
-  "emitter",
-  "pin2",
-  "collector",
-  "pin3",
-  "base",
-] as const
-```
-
 ### via
 
 ```typescript
@@ -1729,6 +1129,606 @@ export const viaProps = commonLayoutProps.extend({
   toLayer: layer_ref,
   holeDiameter: distance,
   outerDiameter: distance,
+})
+```
+
+### led
+
+```typescript
+export const ledProps = commonComponentProps.extend({
+  color: z.string().optional(),
+  wavelength: z.string().optional(),
+  schDisplayValue: z.string().optional(),
+})
+```
+
+### breakout
+
+```typescript
+export interface BreakoutProps
+  extends Omit<SubcircuitGroupProps, "subcircuit"> {
+  padding?: Distance
+  paddingLeft?: Distance
+  paddingRight?: Distance
+  paddingTop?: Distance
+  paddingBottom?: Distance
+}
+export const breakoutProps = subcircuitGroupProps.extend({
+  padding: distance.optional(),
+  paddingLeft: distance.optional(),
+  paddingRight: distance.optional(),
+  paddingTop: distance.optional(),
+  paddingBottom: distance.optional(),
+})
+```
+
+### solderjumper
+
+```typescript
+export interface SolderJumperProps extends JumperProps {
+  bridgedPins?: string[][]
+}
+/**
+   * Pins that are bridged with solder by default
+   */
+export const solderjumperProps = jumperProps.extend({
+  bridgedPins: z.array(z.array(z.string())).optional(),
+})
+```
+
+### resonator
+
+```typescript
+export interface ResonatorProps extends CommonComponentProps {
+  frequency: number | string
+  loadCapacitance: number | string
+  pinVariant?: ResonatorPinVariant
+}
+export const resonatorProps = commonComponentProps.extend({
+  frequency: frequency,
+  loadCapacitance: capacitance,
+  pinVariant: z.enum(["no_ground", "ground_pin", "two_ground_pins"]).optional(),
+})
+```
+
+### silkscreen-rect
+
+```typescript
+export const silkscreenRectProps = pcbLayoutProps
+  .omit({ pcbRotation: true })
+  .extend({
+    filled: z.boolean().default(true).optional(),
+    stroke: z.enum(["dashed", "solid", "none"]).optional(),
+    strokeWidth: distance.optional(),
+    width: distance,
+    height: distance,
+  })
+```
+
+### port
+
+```typescript
+export const portProps = commonLayoutProps.extend({
+  name: z.string(),
+  pinNumber: z.number().optional(),
+  aliases: z.array(z.string()).optional(),
+  direction: direction,
+})
+```
+
+### schematic-box
+
+```typescript
+export const schematicBoxProps = z
+  .object({
+    schX: distance,
+    schY: distance,
+    width: distance.optional(),
+    height: distance.optional(),
+    overlay: z.array(z.string()).optional(),
+
+    padding: distance.optional(),
+    paddingLeft: distance.optional(),
+    paddingRight: distance.optional(),
+    paddingTop: distance.optional(),
+    paddingBottom: distance.optional(),
+
+    title: z.string().optional(),
+    titleAlignment: ninePointAnchor.default("center"),
+    titleColor: z.string().optional(),
+    titleFontSize: distance.optional(),
+    titleInside: z.boolean().default(false),
+    strokeStyle: z.enum(["solid", "dashed"]).default("solid"),
+  })
+```
+
+### pin-header
+
+```typescript
+export interface PinHeaderProps extends CommonComponentProps {
+  pinCount: number
+
+  pitch?: number | string
+
+  schFacingDirection?: "up" | "down" | "left" | "right"
+
+  gender?: "male" | "female"
+
+  showSilkscreenPinLabels?: boolean
+
+  doubleRow?: boolean
+
+  holeDiameter?: number | string
+
+  platedDiameter?: number | string
+
+  pinLabels?: string[]
+
+  connections?: Connections<string>
+
+  facingDirection?: "left" | "right"
+
+  schPinArrangement?: SchematicPinArrangement
+}
+/**
+   * Pin arrangement in schematic view
+   */
+export const pinHeaderProps = commonComponentProps.extend({
+  pinCount: z.number(),
+  pitch: distance.optional(),
+  schFacingDirection: z.enum(["up", "down", "left", "right"]).optional(),
+  gender: z.enum(["male", "female"]).optional().default("male"),
+  showSilkscreenPinLabels: z.boolean().optional(),
+  doubleRow: z.boolean().optional(),
+  holeDiameter: distance.optional(),
+  platedDiameter: distance.optional(),
+  pinLabels: z.array(z.string()).optional(),
+  connections: z
+    .custom<Connections>()
+    .pipe(z.record(z.string(), connectionTarget))
+    .optional(),
+  facingDirection: z.enum(["left", "right"]).optional(),
+  schPinArrangement: schematicPinArrangement.optional(),
+})
+```
+
+### board
+
+```typescript
+export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
+  width?: number | string
+  height?: number | string
+  outline?: Point[]
+  outlineOffsetX?: number | string
+  outlineOffsetY?: number | string
+  material?: "fr4" | "fr1"
+}
+export const boardProps = subcircuitGroupProps.extend({
+  width: distance.optional(),
+  height: distance.optional(),
+  outline: z.array(point).optional(),
+  outlineOffsetX: distance.optional(),
+  outlineOffsetY: distance.optional(),
+  material: z.enum(["fr4", "fr1"]).default("fr4"),
+})
+```
+
+### cutout
+
+```typescript
+export interface RectCutoutProps
+  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
+  name?: string
+  shape: "rect"
+  width: Distance
+  height: Distance
+}
+export const rectCutoutProps = pcbLayoutProps
+  .omit({
+    layer: true,
+    pcbRotation: true,
+  })
+  .extend({
+    name: z.string().optional(),
+    shape: z.literal("rect"),
+    width: distance,
+    height: distance,
+  })
+export interface CircleCutoutProps
+  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
+  name?: string
+  shape: "circle"
+  radius: Distance
+}
+export const circleCutoutProps = pcbLayoutProps
+  .omit({
+    layer: true,
+    pcbRotation: true,
+  })
+  .extend({
+    name: z.string().optional(),
+    shape: z.literal("circle"),
+    radius: distance,
+  })
+export interface PolygonCutoutProps
+  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
+  name?: string
+  shape: "polygon"
+  points: Point[]
+}
+export const polygonCutoutProps = pcbLayoutProps
+  .omit({
+    layer: true,
+    pcbRotation: true,
+  })
+  .extend({
+    name: z.string().optional(),
+    shape: z.literal("polygon"),
+    points: z.array(point),
+  })
+```
+
+### footprint
+
+```typescript
+export interface FootprintProps {
+  originalLayer?: LayerRef
+}
+/**
+   * The layer that the footprint is designed for. If you set this to "top"
+   * then it means the children were intended to represent the top layer. If
+   * the <chip /> with this footprint is moved to the bottom layer, then the
+   * components will be mirrored.
+   *
+   * Generally, you shouldn't set this except where it can help prevent
+   * confusion because you have a complex multi-layer footprint. Default is
+   * "top" and this is most intuitive.
+   */
+export const footprintProps = z.object({
+  originalLayer: layer_ref.default("top").optional(),
+})
+```
+
+### testpoint
+
+```typescript
+export interface TestpointProps extends CommonComponentProps {
+  footprintVariant?: "pad" | "through_hole"
+  padShape?: "rect" | "circle"
+  padDiameter?: number | string
+  holeDiameter?: number | string
+  width?: number | string
+  height?: number | string
+}
+.extend({
+    footprintVariant: z.enum(["pad", "through_hole"]).optional(),
+    padShape: z.enum(["rect", "circle"]).optional().default("circle"),
+    padDiameter: distance.optional(),
+    holeDiameter: distance.optional(),
+    width: distance.optional(),
+    height: distance.optional(),
+  })
+```
+
+### net
+
+```typescript
+export interface NetProps {
+  name: string
+}
+export const netProps = z.object({
+  name: z.string(),
+})
+```
+
+### group
+
+```typescript
+export const layoutConfig = z.object({
+  layoutMode: z.enum(["grid", "flex", "match-adapt", "none"]).optional(),
+  position: z.enum(["absolute", "relative"]).optional(),
+
+  grid: z.boolean().optional(),
+  gridCols: z.number().or(z.string()).optional(),
+  gridRows: z.number().or(z.string()).optional(),
+  gridTemplateRows: z.string().optional(),
+  gridTemplateColumns: z.string().optional(),
+  gridTemplate: z.string().optional(),
+  gridGap: z.number().or(z.string()).optional(),
+
+  flex: z.boolean().or(z.string()).optional(),
+  flexDirection: z.enum(["row", "column"]).optional(),
+  alignItems: z.enum(["start", "center", "end", "stretch"]).optional(),
+  justifyContent: z.enum(["start", "center", "end", "stretch"]).optional(),
+  flexRow: z.boolean().optional(),
+  flexColumn: z.boolean().optional(),
+  gap: z.number().or(z.string()).optional(),
+
+  width: length.optional(),
+  height: length.optional(),
+
+  matchAdapt: z.boolean().optional(),
+  matchAdaptTemplate: z.any().optional(),
+})
+export interface LayoutConfig {
+  layoutMode?: "grid" | "flex" | "match-adapt" | "none"
+  position?: "absolute" | "relative"
+
+  grid?: boolean
+  gridCols?: number | string
+  gridRows?: number | string
+  gridTemplateRows?: string
+  gridTemplateColumns?: string
+  gridTemplate?: string
+  gridGap?: number | string
+
+  flex?: boolean | string
+  flexDirection?: "row" | "column"
+  alignItems?: "start" | "center" | "end" | "stretch"
+  justifyContent?: "start" | "center" | "end" | "stretch"
+  flexRow?: boolean
+  flexColumn?: boolean
+  gap?: number | string
+
+  width?: Distance
+  height?: Distance
+
+  matchAdapt?: boolean
+  matchAdaptTemplate?: any
+}
+export interface Border {
+  strokeWidth?: Distance
+  dashed?: boolean
+  solid?: boolean
+}
+export const border = z.object({
+  strokeWidth: length.optional(),
+  dashed: z.boolean().optional(),
+  solid: z.boolean().optional(),
+})
+export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
+  name?: string
+  key?: any
+  children?: any
+
+  pcbWidth?: Distance
+  pcbHeight?: Distance
+  schWidth?: Distance
+  schHeight?: Distance
+
+  pcbLayout?: LayoutConfig
+  schLayout?: LayoutConfig
+  cellBorder?: Border
+  border?: Border
+}
+export type PartsEngine = {
+  findPart: (params: {
+    sourceComponent: AnySourceComponent
+    footprinterString?: string
+  }) => Promise<SupplierPartNumbers> | SupplierPartNumbers
+}
+export interface PcbRouteCache {
+  pcbTraces: PcbTrace[]
+  cacheKey: string
+}
+export interface AutorouterConfig {
+  serverUrl?: string
+  inputFormat?: "simplified" | "circuit-json"
+  serverMode?: "job" | "solve-endpoint"
+  serverCacheEnabled?: boolean
+  cache?: PcbRouteCache
+  groupMode?: "sequential-trace" | "subcircuit"
+  local?: boolean
+  algorithmFn?: (simpleRouteJson: any) => Promise<any>
+}
+export const autorouterConfig = z.object({
+  serverUrl: z.string().optional(),
+  inputFormat: z.enum(["simplified", "circuit-json"]).optional(),
+  serverMode: z.enum(["job", "solve-endpoint"]).optional(),
+  serverCacheEnabled: z.boolean().optional(),
+  cache: z.custom<PcbRouteCache>((v) => true).optional(),
+  groupMode: z.enum(["sequential-trace", "subcircuit"]).optional(),
+  algorithmFn: z
+    .custom<(simpleRouteJson: any) => Promise<any>>(
+      (v) => typeof v === "function" || v === undefined,
+    )
+    .optional(),
+  local: z.boolean().optional(),
+})
+export interface SubcircuitGroupProps extends BaseGroupProps {
+  layout?: LayoutBuilder
+  manualEdits?: ManualEditsFileInput
+  routingDisabled?: boolean
+  defaultTraceWidth?: Distance
+  minTraceWidth?: Distance
+  pcbRouteCache?: PcbRouteCache
+
+  autorouter?: AutorouterProp
+
+  schAutoLayoutEnabled?: boolean
+
+  schTraceAutoLabelEnabled?: boolean
+
+  partsEngine?: PartsEngine
+}
+/**
+   * If true, net labels will automatically be created for complex traces
+   */
+export interface SubcircuitGroupPropsWithBool extends SubcircuitGroupProps {
+  subcircuit: true
+}
+export interface NonSubcircuitGroupProps extends BaseGroupProps {
+  subcircuit?: false | undefined
+}
+export const baseGroupProps = commonLayoutProps.extend({
+  name: z.string().optional(),
+  children: z.any().optional(),
+  key: z.any().optional(),
+
+  ...layoutConfig.shape,
+  pcbWidth: length.optional(),
+  pcbHeight: length.optional(),
+  schWidth: length.optional(),
+  schHeight: length.optional(),
+  pcbLayout: layoutConfig.optional(),
+  schLayout: layoutConfig.optional(),
+  cellBorder: border.optional(),
+  border: border.optional(),
+})
+export const subcircuitGroupProps = baseGroupProps.extend({
+  layout: z.custom<LayoutBuilder>((v) => true).optional(),
+  manualEdits: manual_edits_file.optional(),
+  schAutoLayoutEnabled: z.boolean().optional(),
+  schTraceAutoLabelEnabled: z.boolean().optional(),
+  routingDisabled: z.boolean().optional(),
+  defaultTraceWidth: length.optional(),
+  minTraceWidth: length.optional(),
+  partsEngine: partsEngine.optional(),
+  pcbRouteCache: z.custom<PcbRouteCache>((v) => true).optional(),
+  autorouter: autorouterProp.optional(),
+})
+export const subcircuitGroupPropsWithBool = subcircuitGroupProps.extend({
+  subcircuit: z.literal(true),
+})
+```
+
+### crystal
+
+```typescript
+export interface CrystalProps extends CommonComponentProps {
+  frequency: number | string
+  loadCapacitance: number | string
+  pinVariant?: PinVariant
+}
+export const crystalProps = commonComponentProps.extend({
+  frequency: frequency,
+  loadCapacitance: capacitance,
+  pinVariant: z.enum(["two_pin", "four_pin"]).optional(),
+})
+```
+
+### hole
+
+```typescript
+export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
+  diameter?: Distance
+  radius?: Distance
+}
+export const holeProps = pcbLayoutProps
+  .omit({ pcbRotation: true })
+  .extend({
+    name: z.string().optional(),
+    diameter: distance.optional(),
+    radius: distance.optional(),
+  })
+```
+
+### constraint
+
+```typescript
+export type PcbXDistConstraint = {
+  pcb?: true
+  xDist: Distance
+
+  left: string
+
+  right: string
+
+  edgeToEdge?: true
+
+  centerToCenter?: true
+}
+/**
+   * If true, the provided distance is the distance between the centers of the
+   * left and right components
+   */
+export type PcbYDistConstraint = {
+  pcb?: true
+  yDist: Distance
+
+  top: string
+
+  bottom: string
+
+  edgeToEdge?: true
+  centerToCenter?: true
+}
+/**
+   * Selector for bottom component, e.g. ".U1" or ".R1", you can also specify the
+   * edge or center of the component e.g. ".R1 bottomedge", ".R1 center"
+   */
+export type PcbSameYConstraint = {
+  pcb?: true
+  sameY?: true
+
+  for: string[]
+}
+/**
+   * Selector for components, e.g. [".U1", ".R1"], you can also specify the
+   * edge or center of the component e.g. [".R1 leftedge", ".U1 center"]
+   */
+export type PcbSameXConstraint = {
+  pcb?: true
+  sameX?: true
+  for: string[]
+}
+export const pcbXDistConstraintProps = z.object({
+  pcb: z.literal(true).optional(),
+  xDist: distance,
+  left: z.string(),
+  right: z.string(),
+
+  edgeToEdge: z.literal(true).optional(),
+  centerToCenter: z.literal(true).optional(),
+})
+export const pcbYDistConstraintProps = z.object({
+  pcb: z.literal(true).optional(),
+  yDist: distance,
+  top: z.string(),
+  bottom: z.string(),
+
+  edgeToEdge: z.literal(true).optional(),
+  centerToCenter: z.literal(true).optional(),
+})
+export const pcbSameYConstraintProps = z.object({
+  pcb: z.literal(true).optional(),
+  sameY: z.literal(true).optional(),
+  for: z.array(z.string()),
+})
+export const pcbSameXConstraintProps = z.object({
+  pcb: z.literal(true).optional(),
+  sameX: z.literal(true).optional(),
+  for: z.array(z.string()),
+})
+```
+
+### stampboard
+
+```typescript
+export interface StampboardProps extends BoardProps {
+  leftPinCount?: number
+  rightPinCount?: number
+  topPinCount?: number
+  bottomPinCount?: number
+  leftPins?: string[]
+  rightPins?: string[]
+  topPins?: string[]
+  bottomPins?: string[]
+  pinPitch?: number | string
+  innerHoles?: boolean
+}
+export const stampboardProps = boardProps.extend({
+  leftPinCount: z.number().optional(),
+  rightPinCount: z.number().optional(),
+  topPinCount: z.number().optional(),
+  bottomPinCount: z.number().optional(),
+  leftPins: z.array(z.string()).optional(),
+  rightPins: z.array(z.string()).optional(),
+  topPins: z.array(z.string()).optional(),
+  bottomPins: z.array(z.string()).optional(),
+  pinPitch: distance.optional(),
+  innerHoles: z.boolean().optional(),
 })
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -807,6 +807,16 @@ export interface LayoutConfig {
   matchAdapt?: boolean
   matchAdaptTemplate?: any
 }
+export interface CellBorder {
+  strokeWidth?: Distance
+  dashed?: boolean
+  solid?: boolean
+}
+export const cellBorder = z.object({
+  strokeWidth: length.optional(),
+  dashed: z.boolean().optional(),
+  solid: z.boolean().optional(),
+})
 export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   name?: string
   key?: any
@@ -819,6 +829,8 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
 
   pcbLayout?: LayoutConfig
   schLayout?: LayoutConfig
+  cellBorder?: CellBorder
+  border?: CellBorder
 }
 export type PartsEngine = {
   findPart: (params: {
@@ -891,6 +903,8 @@ export const baseGroupProps = commonLayoutProps.extend({
   schHeight: length.optional(),
   pcbLayout: layoutConfig.optional(),
   schLayout: layoutConfig.optional(),
+  cellBorder: cellBorder.optional(),
+  border: cellBorder.optional(),
 })
 export const subcircuitGroupProps = baseGroupProps.extend({
   layout: z.custom<LayoutBuilder>((v) => true).optional(),
@@ -1348,7 +1362,7 @@ export const schematicBoxProps = z
     paddingBottom: distance.optional(),
 
     title: z.string().optional(),
-    titleAlignment: nine_point_anchor.default("center"),
+    titleAlignment: ninePointAnchor.default("center"),
     titleColor: z.string().optional(),
     titleFontSize: distance.optional(),
     titleInside: z.boolean().default(false),
@@ -1386,7 +1400,7 @@ export const schematicTextProps = z.object({
   text: z.string(),
   fontSize: z.number().default(1),
   anchor: z
-    .union([five_point_anchor.describe("legacy"), nine_point_anchor])
+    .union([fivePointAnchor.describe("legacy"), ninePointAnchor])
     .default("center"),
   color: z.string().default("#000000"),
   schRotation: rotation.default(0),
@@ -1450,7 +1464,7 @@ export const silkscreenRectProps = pcbLayoutProps
 ```typescript
 export const silkscreenTextProps = pcbLayoutProps.extend({
   text: z.string(),
-  anchorAlignment: nine_point_anchor.default("center"),
+  anchorAlignment: ninePointAnchor.default("center"),
   font: z.enum(["tscircuit2024"]).optional(),
   fontSize: length.optional(),
 })

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-06-09T20:18:44.102Z
+> Generated at 2025-06-14T14:30:31.360Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -18,6 +18,114 @@ const validatedProps = chipProps.parse(unknownProps)
 ## Available Props
 
 ```ts
+export interface ManualPcbPlacement {
+  selector: string
+  relative_to: string
+  center: Point
+}
+
+
+export interface ManualEditsFile {
+  pcb_placements?: ManualPcbPlacement[]
+  manual_trace_hints?: ManualTraceHint[]
+  schematic_placements?: ManualSchematicPlacement[]
+}
+
+
+export interface ManualTraceHint {
+  pcb_port_selector: string
+  offsets: Array<RouteHintPoint>
+}
+
+
+export interface ManualSchematicPlacement {
+  selector: string
+  relative_to: string
+  center: Point
+}
+
+
+export interface EditTraceHintEvent extends BaseManualEditEvent {
+  /** @deprecated */
+  pcb_edit_event_type: "edit_trace_hint"
+  edit_event_type?: "edit_pcb_trace_hint"
+  pcb_port_id: string
+  pcb_trace_hint_id?: string
+  route: Array<{ x: number; y: number; via?: boolean }>
+}
+
+
+export interface EditPcbGroupLocationEvent extends BaseManualEditEvent {
+  edit_event_type: "edit_pcb_group_location"
+  pcb_group_id: string
+  original_center: { x: number; y: number }
+  new_center: { x: number; y: number }
+}
+
+
+export interface BaseManualEditEvent {
+  edit_event_id: string
+  in_progress?: boolean
+  created_at: number
+}
+
+
+export interface EditSchematicComponentLocationEvent
+  extends BaseManualEditEvent {
+  edit_event_type: "edit_schematic_component_location"
+  schematic_component_id: string
+  original_center: { x: number; y: number }
+  new_center: { x: number; y: number }
+}
+
+
+export interface EditPcbComponentLocationEvent extends BaseManualEditEvent {
+  edit_event_type: "edit_pcb_component_location"
+  /** @deprecated */
+  pcb_edit_event_type: "edit_component_location"
+  pcb_component_id: string
+  original_center: { x: number; y: number }
+  new_center: { x: number; y: number }
+}
+
+
+export interface EditSchematicGroupLocationEvent extends BaseManualEditEvent {
+  edit_event_type: "edit_schematic_group_location"
+  schematic_group_id: string
+  original_center: { x: number; y: number }
+  new_center: { x: number; y: number }
+}
+
+
+export interface PlatformConfig {
+  partsEngine?: PartsEngine
+
+  autorouter?: AutorouterProp
+
+  // TODO this follows a subset of the localStorage interface
+  localCacheEngine?: any
+
+  registryApiUrl?: string
+
+  cloudAutorouterUrl?: string
+
+  pcbDisabled?: boolean
+  schematicDisabled?: boolean
+  partsEngineDisabled?: boolean
+
+  footprintLibraryMap?: Record<
+    string,
+    Record<
+      string,
+      | any[]
+      | ((path: string) => Promise<{
+          footprintCircuitJson: any[]
+        }>)
+    >
+  >
+}
+
+
 export interface CadModelBase {
   rotationOffset?:
     | number
@@ -44,6 +152,40 @@ export interface CadModelObj extends CadModelBase {
 
 export interface CadModelJscad extends CadModelBase {
   jscad: Record<string, any>
+}
+
+
+export interface SchematicPortArrangementWithSizes {
+  leftSize?: number
+  topSize?: number
+  rightSize?: number
+  bottomSize?: number
+}
+
+
+export interface SchematicPortArrangementWithPinCounts {
+  leftPinCount?: number
+  topPinCount?: number
+  rightPinCount?: number
+  bottomPinCount?: number
+}
+
+
+export interface PinSideDefinition {
+  pins: Array<number | string>
+  direction:
+    | "top-to-bottom"
+    | "left-to-right"
+    | "bottom-to-top"
+    | "right-to-left"
+}
+
+
+export interface SchematicPortArrangementWithSides {
+  leftSide?: PinSideDefinition
+  topSide?: PinSideDefinition
+  rightSide?: PinSideDefinition
+  bottomSide?: PinSideDefinition
 }
 
 
@@ -85,52 +227,72 @@ export interface CommonComponentProps extends CommonLayoutProps {
 }
 
 
-export interface SchematicPortArrangementWithSizes {
-  leftSize?: number
-  topSize?: number
-  rightSize?: number
-  bottomSize?: number
+export interface CrystalProps extends CommonComponentProps {
+  frequency: number | string
+  loadCapacitance: number | string
+  pinVariant?: PinVariant
 }
 
 
-export interface SchematicPortArrangementWithPinCounts {
-  leftPinCount?: number
-  topPinCount?: number
-  rightPinCount?: number
-  bottomPinCount?: number
+export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "rect"
+  width: Distance
+  height: Distance
+  portHints?: PortHints
 }
 
 
-export interface PinSideDefinition {
-  pins: Array<number | string>
-  direction:
-    | "top-to-bottom"
-    | "left-to-right"
-    | "bottom-to-top"
-    | "right-to-left"
+export interface RotatedRectSmtPadProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "rotated_rect"
+  width: Distance
+  height: Distance
+  ccwRotation: number
+  portHints?: PortHints
 }
 
 
-export interface SchematicPortArrangementWithSides {
-  leftSide?: PinSideDefinition
-  topSide?: PinSideDefinition
-  rightSide?: PinSideDefinition
-  bottomSide?: PinSideDefinition
+export interface CircleSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "circle"
+  radius: Distance
+  portHints?: PortHints
 }
 
 
-export interface BatteryProps extends CommonComponentProps {
-  capacity?: number | string
+export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "pill"
+  width: Distance
+  height: Distance
+  radius: Distance
+  portHints?: PortHints
 }
 
 
-export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
-  width?: number | string
-  height?: number | string
-  outline?: Point[]
-  outlineOffsetX?: number | string
-  outlineOffsetY?: number | string
-  material?: "fr4" | "fr1"
+export interface PolygonSmtPadProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "polygon"
+  points: Point[]
+  portHints?: PortHints
+}
+
+
+export interface ResistorProps extends CommonComponentProps {
+  resistance: number | string
+  pullupFor?: string
+  pullupTo?: string
+  pulldownFor?: string
+  pulldownTo?: string
+  connections?: Connections<ResistorPinLabels>
+}
+
+
+export interface NetLabelProps {
+  net?: string
+  connection?: string
+  schX?: number | string
+  schY?: number | string
+  schRotation?: number | string
+  anchorSide?: "left" | "up" | "right" | "down"
 }
 
 
@@ -144,9 +306,11 @@ export interface BreakoutProps
 }
 
 
-export interface BreakoutPointProps
-  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
-  connection: string
+export interface SolderJumperProps extends JumperProps {
+  /**
+   * Pins that are bridged with solder by default
+   */
+  bridgedPins?: string[][]
 }
 
 
@@ -161,359 +325,6 @@ export interface CapacitorProps extends CommonComponentProps {
   bypassTo?: string
   maxDecouplingTraceLength?: number
   connections?: Connections<CapacitorPinLabels>
-}
-
-
-export interface PinCompatibleVariant {
-  manufacturerPartNumber?: string
-  supplierPartNumber?: SupplierPartNumbers
-}
-
-
-export interface ChipPropsSU<PinLabel extends string = string>
-  extends CommonComponentProps {
-  manufacturerPartNumber?: string
-  pinLabels?: PinLabelsProp<string, PinLabel>
-  /**
-   * Whether to show pin aliases in the schematic
-   */
-  showPinAliases?: boolean
-  schPinArrangement?: SchematicPortArrangement
-  /** @deprecated Use schPinArrangement instead. */
-  schPortArrangement?: SchematicPortArrangement
-  pinCompatibleVariants?: PinCompatibleVariant[]
-  schPinStyle?: SchematicPinStyle
-  schPinSpacing?: Distance
-  schWidth?: Distance
-  schHeight?: Distance
-  noSchematicRepresentation?: boolean
-  internallyConnectedPins?: string[][]
-  externallyConnectedPins?: string[][]
-  connections?: Connections<PinLabel>
-}
-
-
-export interface ConnectorProps extends CommonComponentProps {
-  manufacturerPartNumber?: string
-  pinLabels?: Record<number | string, string | string[]>
-  schPinStyle?: SchematicPinStyle
-  schPinSpacing?: number | string
-  schWidth?: number | string
-  schHeight?: number | string
-  schDirection?: "left" | "right"
-  schPortArrangement?: SchematicPortArrangement
-  /**
-   * Groups of pins that are internally connected (bridged)
-   * e.g., [["1","2"], ["2","3"]]
-   */
-  internallyConnectedPins?: string[][]
-  /**
-   * Connector standard, e.g. usb_c, m2
-   */
-  standard?: "usb_c" | "m2"
-}
-
-
-export interface ConstrainedLayoutProps {
-  name?: string
-  pcbOnly?: boolean
-  schOnly?: boolean
-}
-
-
-export interface CrystalProps extends CommonComponentProps {
-  frequency: number | string
-  loadCapacitance: number | string
-  pinVariant?: PinVariant
-}
-
-
-export interface RectCutoutProps
-  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
-  name?: string
-  shape: "rect"
-  width: Distance
-  height: Distance
-}
-
-
-export interface CircleCutoutProps
-  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
-  name?: string
-  shape: "circle"
-  radius: Distance
-}
-
-
-export interface PolygonCutoutProps
-  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
-  name?: string
-  shape: "polygon"
-  points: Point[]
-}
-
-
-export interface DiodeProps extends CommonComponentProps {
-  connections?: {
-    anode?: string | string[] | readonly string[]
-    cathode?: string | string[] | readonly string[]
-    pin1?: string | string[] | readonly string[]
-    pin2?: string | string[] | readonly string[]
-    pos?: string | string[] | readonly string[]
-    neg?: string | string[] | readonly string[]
-  }
-  variant?: "standard" | "schottky" | "zener" | "photo" | "tvs"
-  standard?: boolean
-  schottky?: boolean
-  zener?: boolean
-  photo?: boolean
-  tvs?: boolean
-}
-
-
-export interface FootprintProps {
-  /**
-   * The layer that the footprint is designed for. If you set this to "top"
-   * then it means the children were intended to represent the top layer. If
-   * the <chip /> with this footprint is moved to the bottom layer, then the
-   * components will be mirrored.
-   *
-   * Generally, you shouldn't set this except where it can help prevent
-   * confusion because you have a complex multi-layer footprint. Default is
-   * "top" and this is most intuitive.
-   */
-  originalLayer?: LayerRef
-}
-
-
-export interface FuseProps extends CommonComponentProps {
-  /**
-   * Current rating of the fuse in amperes
-   */
-  currentRating: number | string
-
-  /**
-   * Voltage rating of the fuse
-   */
-  voltageRating?: number | string
-
-  /**
-   * Whether to show ratings on schematic
-   */
-  schShowRatings?: boolean
-
-  /**
-   * Connections to other components
-   */
-  connections?: Connections<FusePinLabels>
-}
-
-
-export interface LayoutConfig {
-  layoutMode?: "grid" | "flex" | "match-adapt" | "none"
-  position?: "absolute" | "relative"
-
-  grid?: boolean
-  gridCols?: number | string
-  gridRows?: number | string
-  gridTemplateRows?: string
-  gridTemplateColumns?: string
-  gridTemplate?: string
-  gridGap?: number | string
-
-  flex?: boolean | string
-  flexDirection?: "row" | "column"
-  alignItems?: "start" | "center" | "end" | "stretch"
-  justifyContent?: "start" | "center" | "end" | "stretch"
-  flexRow?: boolean
-  flexColumn?: boolean
-  gap?: number | string
-
-  width?: Distance
-  height?: Distance
-
-  matchAdapt?: boolean
-  matchAdaptTemplate?: any
-}
-
-
-export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
-  name?: string
-  key?: any
-  children?: any
-
-  pcbWidth?: Distance
-  pcbHeight?: Distance
-  schWidth?: Distance
-  schHeight?: Distance
-
-  pcbLayout?: LayoutConfig
-  schLayout?: LayoutConfig
-}
-
-
-export interface PcbRouteCache {
-  pcbTraces: PcbTrace[]
-  cacheKey: string
-}
-
-
-export interface AutorouterConfig {
-  serverUrl?: string
-  inputFormat?: "simplified" | "circuit-json"
-  serverMode?: "job" | "solve-endpoint"
-  serverCacheEnabled?: boolean
-  cache?: PcbRouteCache
-  groupMode?: "sequential-trace" | "subcircuit"
-  local?: boolean
-  algorithmFn?: (simpleRouteJson: any) => Promise<any>
-}
-
-
-export interface SubcircuitGroupProps extends BaseGroupProps {
-  layout?: LayoutBuilder
-  manualEdits?: ManualEditsFileInput
-  routingDisabled?: boolean
-  defaultTraceWidth?: Distance
-  minTraceWidth?: Distance
-  pcbRouteCache?: PcbRouteCache
-
-  autorouter?: AutorouterProp
-
-  /**
-   * If true, we'll automatically layout the schematic for this group. Must be
-   * a subcircuit (currently). This is eventually going to be replaced with more
-   * sophisticated layout options/modes and will be enabled by default.
-   */
-  schAutoLayoutEnabled?: boolean
-
-  /**
-   * If true, net labels will automatically be created for complex traces
-   */
-  schTraceAutoLabelEnabled?: boolean
-
-  partsEngine?: PartsEngine
-}
-
-
-export interface SubcircuitGroupPropsWithBool extends SubcircuitGroupProps {
-  subcircuit: true
-}
-
-
-export interface NonSubcircuitGroupProps extends BaseGroupProps {
-  subcircuit?: false | undefined
-}
-
-
-export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
-  name?: string
-  diameter?: Distance
-  radius?: Distance
-}
-
-
-export interface JumperProps extends CommonComponentProps {
-  manufacturerPartNumber?: string
-  pinLabels?: Record<number | string, string | string[]>
-  schPinStyle?: SchematicPinStyle
-  schPinSpacing?: number | string
-  schWidth?: number | string
-  schHeight?: number | string
-  schDirection?: "left" | "right"
-  schPortArrangement?: SchematicPortArrangement
-  /**
-   * Number of pins on the jumper (2 or 3)
-   */
-  pinCount?: 2 | 3
-  /**
-   * Groups of pins that are internally connected (bridged)
-   * e.g., [["1","2"], ["2","3"]]
-   */
-  internallyConnectedPins?: string[][]
-}
-
-
-export interface MosfetProps extends CommonComponentProps {
-  channelType: "n" | "p"
-  mosfetMode: "enhancement" | "depletion"
-}
-
-
-export interface NetProps {
-  name: string
-}
-
-
-export interface NetAliasProps {
-  net?: string
-  schX?: number | string
-  schY?: number | string
-  schRotation?: number | string
-  anchorSide?: "left" | "up" | "right" | "down"
-}
-
-
-export interface PinHeaderProps extends CommonComponentProps {
-  /**
-   * Number of pins in the header
-   */
-  pinCount: number
-
-  /**
-   * Distance between pins
-   */
-  pitch?: number | string
-
-  /**
-   * Schematic facing direction
-   */
-  schFacingDirection?: "up" | "down" | "left" | "right"
-
-  /**
-   * Whether the header is male or female
-   */
-  gender?: "male" | "female"
-
-  /**
-   * Whether to show pin labels in silkscreen
-   */
-  showSilkscreenPinLabels?: boolean
-
-  /**
-   * Whether the header has two rows of pins
-   */
-  doubleRow?: boolean
-
-  /**
-   * Diameter of the through-hole for each pin
-   */
-  holeDiameter?: number | string
-
-  /**
-   * Diameter of the plated area around each hole
-   */
-  platedDiameter?: number | string
-
-  /**
-   * Labels for each pin
-   */
-  pinLabels?: string[]
-
-  /**
-   * Connections to other components
-   */
-  connections?: Connections<string>
-
-  /**
-   * Direction the header is facing
-   */
-  facingDirection?: "left" | "right"
-
-  /**
-   * Pin arrangement in schematic view
-   */
-  schPinArrangement?: SchematicPinArrangement
 }
 
 
@@ -589,91 +400,58 @@ export interface PillWithRectPadPlatedHoleProps
 }
 
 
-export interface PotentiometerProps extends CommonComponentProps {
-  maxResistance: number | string
-  pinVariant?: PotentiometerPinVariant
-}
-
-
-export interface ResistorProps extends CommonComponentProps {
-  resistance: number | string
-  pullupFor?: string
-  pullupTo?: string
-  pulldownFor?: string
-  pulldownTo?: string
-  connections?: Connections<ResistorPinLabels>
-}
-
-
-export interface ResonatorProps extends CommonComponentProps {
-  frequency: number | string
-  loadCapacitance: number | string
-  pinVariant?: ResonatorPinVariant
-}
-
-
-export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+export interface RectCutoutProps
+  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
+  name?: string
   shape: "rect"
   width: Distance
   height: Distance
-  portHints?: PortHints
 }
 
 
-export interface RotatedRectSmtPadProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "rotated_rect"
-  width: Distance
-  height: Distance
-  ccwRotation: number
-  portHints?: PortHints
-}
-
-
-export interface CircleSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+export interface CircleCutoutProps
+  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
+  name?: string
   shape: "circle"
   radius: Distance
-  portHints?: PortHints
 }
 
 
-export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "pill"
-  width: Distance
-  height: Distance
-  radius: Distance
-  portHints?: PortHints
-}
-
-
-export interface PolygonSmtPadProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
+export interface PolygonCutoutProps
+  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
+  name?: string
   shape: "polygon"
   points: Point[]
-  portHints?: PortHints
 }
 
 
-export interface SolderJumperProps extends JumperProps {
-  /**
-   * Pins that are bridged with solder by default
-   */
-  bridgedPins?: string[][]
+export interface NetProps {
+  name: string
 }
 
 
-export interface RectSolderPasteProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "rect"
-  width: Distance
-  height: Distance
+export interface NetAliasProps {
+  net?: string
+  connection?: string
+  schX?: number | string
+  schY?: number | string
+  schRotation?: number | string
+  anchorSide?: "left" | "up" | "right" | "down"
 }
 
 
-export interface CircleSolderPasteProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "circle"
-  radius: Distance
+export interface SwitchProps extends CommonComponentProps {
+  type?: "spst" | "spdt" | "dpst" | "dpdt"
+  isNormallyClosed?: boolean
+  spdt?: boolean
+  spst?: boolean
+  dpst?: boolean
+  dpdt?: boolean
+}
+
+
+export interface BatteryProps extends CommonComponentProps {
+  capacity?: number | string
 }
 
 
@@ -691,13 +469,296 @@ export interface StampboardProps extends BoardProps {
 }
 
 
-export interface SwitchProps extends CommonComponentProps {
-  type?: "spst" | "spdt" | "dpst" | "dpdt"
-  isNormallyClosed?: boolean
-  spdt?: boolean
-  spst?: boolean
-  dpst?: boolean
-  dpdt?: boolean
+export interface ConnectorProps extends CommonComponentProps {
+  manufacturerPartNumber?: string
+  pinLabels?: Record<number | string, string | string[]>
+  schPinStyle?: SchematicPinStyle
+  schPinSpacing?: number | string
+  schWidth?: number | string
+  schHeight?: number | string
+  schDirection?: "left" | "right"
+  schPortArrangement?: SchematicPortArrangement
+  /**
+   * Groups of pins that are internally connected (bridged)
+   * e.g., [["1","2"], ["2","3"]]
+   */
+  internallyConnectedPins?: string[][]
+  /**
+   * Connector standard, e.g. usb_c, m2
+   */
+  standard?: "usb_c" | "m2"
+}
+
+
+export interface MosfetProps extends CommonComponentProps {
+  channelType: "n" | "p"
+  mosfetMode: "enhancement" | "depletion"
+}
+
+
+export interface ResonatorProps extends CommonComponentProps {
+  frequency: number | string
+  loadCapacitance: number | string
+  pinVariant?: ResonatorPinVariant
+}
+
+
+export interface ConstrainedLayoutProps {
+  name?: string
+  pcbOnly?: boolean
+  schOnly?: boolean
+}
+
+
+export interface PinCompatibleVariant {
+  manufacturerPartNumber?: string
+  supplierPartNumber?: SupplierPartNumbers
+}
+
+
+export interface ChipPropsSU<PinLabel extends string = string>
+  extends CommonComponentProps {
+  manufacturerPartNumber?: string
+  pinLabels?: PinLabelsProp<string, PinLabel>
+  /**
+   * Whether to show pin aliases in the schematic
+   */
+  showPinAliases?: boolean
+  schPinArrangement?: SchematicPortArrangement
+  /** @deprecated Use schPinArrangement instead. */
+  schPortArrangement?: SchematicPortArrangement
+  pinCompatibleVariants?: PinCompatibleVariant[]
+  schPinStyle?: SchematicPinStyle
+  schPinSpacing?: Distance
+  schWidth?: Distance
+  schHeight?: Distance
+  noSchematicRepresentation?: boolean
+  internallyConnectedPins?: string[][]
+  externallyConnectedPins?: string[][]
+  connections?: Connections<PinLabel>
+}
+
+
+export interface PinHeaderProps extends CommonComponentProps {
+  /**
+   * Number of pins in the header
+   */
+  pinCount: number
+
+  /**
+   * Distance between pins
+   */
+  pitch?: number | string
+
+  /**
+   * Schematic facing direction
+   */
+  schFacingDirection?: "up" | "down" | "left" | "right"
+
+  /**
+   * Whether the header is male or female
+   */
+  gender?: "male" | "female"
+
+  /**
+   * Whether to show pin labels in silkscreen
+   */
+  showSilkscreenPinLabels?: boolean
+
+  /**
+   * Whether the header has two rows of pins
+   */
+  doubleRow?: boolean
+
+  /**
+   * Diameter of the through-hole for each pin
+   */
+  holeDiameter?: number | string
+
+  /**
+   * Diameter of the plated area around each hole
+   */
+  platedDiameter?: number | string
+
+  /**
+   * Labels for each pin
+   */
+  pinLabels?: string[]
+
+  /**
+   * Connections to other components
+   */
+  connections?: Connections<string>
+
+  /**
+   * Direction the header is facing
+   */
+  facingDirection?: "left" | "right"
+
+  /**
+   * Pin arrangement in schematic view
+   */
+  schPinArrangement?: SchematicPinArrangement
+}
+
+
+export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
+  width?: number | string
+  height?: number | string
+  outline?: Point[]
+  outlineOffsetX?: number | string
+  outlineOffsetY?: number | string
+  material?: "fr4" | "fr1"
+}
+
+
+export interface DiodeProps extends CommonComponentProps {
+  connections?: {
+    anode?: string | string[] | readonly string[]
+    cathode?: string | string[] | readonly string[]
+    pin1?: string | string[] | readonly string[]
+    pin2?: string | string[] | readonly string[]
+    pos?: string | string[] | readonly string[]
+    neg?: string | string[] | readonly string[]
+  }
+  variant?: "standard" | "schottky" | "zener" | "photo" | "tvs"
+  standard?: boolean
+  schottky?: boolean
+  zener?: boolean
+  photo?: boolean
+  tvs?: boolean
+}
+
+
+export interface LayoutConfig {
+  layoutMode?: "grid" | "flex" | "match-adapt" | "none"
+  position?: "absolute" | "relative"
+
+  grid?: boolean
+  gridCols?: number | string
+  gridRows?: number | string
+  gridTemplateRows?: string
+  gridTemplateColumns?: string
+  gridTemplate?: string
+  gridGap?: number | string
+
+  flex?: boolean | string
+  flexDirection?: "row" | "column"
+  alignItems?: "start" | "center" | "end" | "stretch"
+  justifyContent?: "start" | "center" | "end" | "stretch"
+  flexRow?: boolean
+  flexColumn?: boolean
+  gap?: number | string
+
+  width?: Distance
+  height?: Distance
+
+  matchAdapt?: boolean
+  matchAdaptTemplate?: any
+}
+
+
+export interface CellBorder {
+  strokeWidth?: Distance
+  dashed?: boolean
+  solid?: boolean
+}
+
+
+export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
+  name?: string
+  key?: any
+  children?: any
+
+  pcbWidth?: Distance
+  pcbHeight?: Distance
+  schWidth?: Distance
+  schHeight?: Distance
+
+  pcbLayout?: LayoutConfig
+  schLayout?: LayoutConfig
+  cellBorder?: CellBorder
+  border?: CellBorder
+}
+
+
+export interface PcbRouteCache {
+  pcbTraces: PcbTrace[]
+  cacheKey: string
+}
+
+
+export interface AutorouterConfig {
+  serverUrl?: string
+  inputFormat?: "simplified" | "circuit-json"
+  serverMode?: "job" | "solve-endpoint"
+  serverCacheEnabled?: boolean
+  cache?: PcbRouteCache
+  groupMode?: "sequential-trace" | "subcircuit"
+  local?: boolean
+  algorithmFn?: (simpleRouteJson: any) => Promise<any>
+}
+
+
+export interface SubcircuitGroupProps extends BaseGroupProps {
+  layout?: LayoutBuilder
+  manualEdits?: ManualEditsFileInput
+  routingDisabled?: boolean
+  defaultTraceWidth?: Distance
+  minTraceWidth?: Distance
+  pcbRouteCache?: PcbRouteCache
+
+  autorouter?: AutorouterProp
+
+  /**
+   * If true, we'll automatically layout the schematic for this group. Must be
+   * a subcircuit (currently). This is eventually going to be replaced with more
+   * sophisticated layout options/modes and will be enabled by default.
+   */
+  schAutoLayoutEnabled?: boolean
+
+  /**
+   * If true, net labels will automatically be created for complex traces
+   */
+  schTraceAutoLabelEnabled?: boolean
+
+  partsEngine?: PartsEngine
+}
+
+
+export interface SubcircuitGroupPropsWithBool extends SubcircuitGroupProps {
+  subcircuit: true
+}
+
+
+export interface NonSubcircuitGroupProps extends BaseGroupProps {
+  subcircuit?: false | undefined
+}
+
+
+export interface JumperProps extends CommonComponentProps {
+  manufacturerPartNumber?: string
+  pinLabels?: Record<number | string, string | string[]>
+  schPinStyle?: SchematicPinStyle
+  schPinSpacing?: number | string
+  schWidth?: number | string
+  schHeight?: number | string
+  schDirection?: "left" | "right"
+  schPortArrangement?: SchematicPortArrangement
+  /**
+   * Number of pins on the jumper (2 or 3)
+   */
+  pinCount?: 2 | 3
+  /**
+   * Groups of pins that are internally connected (bridged)
+   * e.g., [["1","2"], ["2","3"]]
+   */
+  internallyConnectedPins?: string[][]
+}
+
+
+export interface TransistorProps extends CommonComponentProps {
+  type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet"
 }
 
 
@@ -729,116 +790,75 @@ export interface TestpointProps extends CommonComponentProps {
 }
 
 
-export interface TransistorProps extends CommonComponentProps {
-  type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet"
+export interface BreakoutPointProps
+  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
+  connection: string
 }
 
 
-export interface BaseManualEditEvent {
-  edit_event_id: string
-  in_progress?: boolean
-  created_at: number
+export interface FootprintProps {
+  /**
+   * The layer that the footprint is designed for. If you set this to "top"
+   * then it means the children were intended to represent the top layer. If
+   * the <chip /> with this footprint is moved to the bottom layer, then the
+   * components will be mirrored.
+   *
+   * Generally, you shouldn't set this except where it can help prevent
+   * confusion because you have a complex multi-layer footprint. Default is
+   * "top" and this is most intuitive.
+   */
+  originalLayer?: LayerRef
 }
 
 
-export interface EditPcbComponentLocationEvent extends BaseManualEditEvent {
-  edit_event_type: "edit_pcb_component_location"
-  /** @deprecated */
-  pcb_edit_event_type: "edit_component_location"
-  pcb_component_id: string
-  original_center: { x: number; y: number }
-  new_center: { x: number; y: number }
+export interface FuseProps extends CommonComponentProps {
+  /**
+   * Current rating of the fuse in amperes
+   */
+  currentRating: number | string
+
+  /**
+   * Voltage rating of the fuse
+   */
+  voltageRating?: number | string
+
+  /**
+   * Whether to show ratings on schematic
+   */
+  schShowRatings?: boolean
+
+  /**
+   * Connections to other components
+   */
+  connections?: Connections<FusePinLabels>
 }
 
 
-export interface EditPcbGroupLocationEvent extends BaseManualEditEvent {
-  edit_event_type: "edit_pcb_group_location"
-  pcb_group_id: string
-  original_center: { x: number; y: number }
-  new_center: { x: number; y: number }
+export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
+  diameter?: Distance
+  radius?: Distance
 }
 
 
-export interface EditSchematicComponentLocationEvent
-  extends BaseManualEditEvent {
-  edit_event_type: "edit_schematic_component_location"
-  schematic_component_id: string
-  original_center: { x: number; y: number }
-  new_center: { x: number; y: number }
+export interface RectSolderPasteProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "rect"
+  width: Distance
+  height: Distance
 }
 
 
-export interface EditSchematicGroupLocationEvent extends BaseManualEditEvent {
-  edit_event_type: "edit_schematic_group_location"
-  schematic_group_id: string
-  original_center: { x: number; y: number }
-  new_center: { x: number; y: number }
+export interface CircleSolderPasteProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "circle"
+  radius: Distance
 }
 
 
-export interface EditTraceHintEvent extends BaseManualEditEvent {
-  /** @deprecated */
-  pcb_edit_event_type: "edit_trace_hint"
-  edit_event_type?: "edit_pcb_trace_hint"
-  pcb_port_id: string
-  pcb_trace_hint_id?: string
-  route: Array<{ x: number; y: number; via?: boolean }>
-}
-
-
-export interface ManualEditsFile {
-  pcb_placements?: ManualPcbPlacement[]
-  manual_trace_hints?: ManualTraceHint[]
-  schematic_placements?: ManualSchematicPlacement[]
-}
-
-
-export interface ManualPcbPlacement {
-  selector: string
-  relative_to: string
-  center: Point
-}
-
-
-export interface ManualSchematicPlacement {
-  selector: string
-  relative_to: string
-  center: Point
-}
-
-
-export interface ManualTraceHint {
-  pcb_port_selector: string
-  offsets: Array<RouteHintPoint>
-}
-
-
-export interface PlatformConfig {
-  partsEngine?: PartsEngine
-
-  autorouter?: AutorouterProp
-
-  // TODO this follows a subset of the localStorage interface
-  localCacheEngine?: any
-
-  registryApiUrl?: string
-
-  cloudAutorouterUrl?: string
-
-  pcbDisabled?: boolean
-  schematicDisabled?: boolean
-  partsEngineDisabled?: boolean
-
-  footprintLibraryMap?: Record<
-    string,
-    Record<
-      string,
-      | any[]
-      | ((path: string) => Promise<{
-          footprintCircuitJson: any[]
-        }>)
-    >
-  >
+export interface PotentiometerProps extends CommonComponentProps {
+  maxResistance: number | string
+  pinVariant?: PotentiometerPinVariant
 }
 
 ```

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-06-14T14:30:31.360Z
+> Generated at 2025-06-14T17:01:25.424Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -18,6 +18,58 @@ const validatedProps = chipProps.parse(unknownProps)
 ## Available Props
 
 ```ts
+export interface EditSchematicGroupLocationEvent extends BaseManualEditEvent {
+  edit_event_type: "edit_schematic_group_location"
+  schematic_group_id: string
+  original_center: { x: number; y: number }
+  new_center: { x: number; y: number }
+}
+
+
+export interface BaseManualEditEvent {
+  edit_event_id: string
+  in_progress?: boolean
+  created_at: number
+}
+
+
+export interface EditTraceHintEvent extends BaseManualEditEvent {
+  /** @deprecated */
+  pcb_edit_event_type: "edit_trace_hint"
+  edit_event_type?: "edit_pcb_trace_hint"
+  pcb_port_id: string
+  pcb_trace_hint_id?: string
+  route: Array<{ x: number; y: number; via?: boolean }>
+}
+
+
+export interface EditPcbGroupLocationEvent extends BaseManualEditEvent {
+  edit_event_type: "edit_pcb_group_location"
+  pcb_group_id: string
+  original_center: { x: number; y: number }
+  new_center: { x: number; y: number }
+}
+
+
+export interface EditPcbComponentLocationEvent extends BaseManualEditEvent {
+  edit_event_type: "edit_pcb_component_location"
+  /** @deprecated */
+  pcb_edit_event_type: "edit_component_location"
+  pcb_component_id: string
+  original_center: { x: number; y: number }
+  new_center: { x: number; y: number }
+}
+
+
+export interface EditSchematicComponentLocationEvent
+  extends BaseManualEditEvent {
+  edit_event_type: "edit_schematic_component_location"
+  schematic_component_id: string
+  original_center: { x: number; y: number }
+  new_center: { x: number; y: number }
+}
+
+
 export interface ManualPcbPlacement {
   selector: string
   relative_to: string
@@ -42,87 +94,6 @@ export interface ManualSchematicPlacement {
   selector: string
   relative_to: string
   center: Point
-}
-
-
-export interface EditTraceHintEvent extends BaseManualEditEvent {
-  /** @deprecated */
-  pcb_edit_event_type: "edit_trace_hint"
-  edit_event_type?: "edit_pcb_trace_hint"
-  pcb_port_id: string
-  pcb_trace_hint_id?: string
-  route: Array<{ x: number; y: number; via?: boolean }>
-}
-
-
-export interface EditPcbGroupLocationEvent extends BaseManualEditEvent {
-  edit_event_type: "edit_pcb_group_location"
-  pcb_group_id: string
-  original_center: { x: number; y: number }
-  new_center: { x: number; y: number }
-}
-
-
-export interface BaseManualEditEvent {
-  edit_event_id: string
-  in_progress?: boolean
-  created_at: number
-}
-
-
-export interface EditSchematicComponentLocationEvent
-  extends BaseManualEditEvent {
-  edit_event_type: "edit_schematic_component_location"
-  schematic_component_id: string
-  original_center: { x: number; y: number }
-  new_center: { x: number; y: number }
-}
-
-
-export interface EditPcbComponentLocationEvent extends BaseManualEditEvent {
-  edit_event_type: "edit_pcb_component_location"
-  /** @deprecated */
-  pcb_edit_event_type: "edit_component_location"
-  pcb_component_id: string
-  original_center: { x: number; y: number }
-  new_center: { x: number; y: number }
-}
-
-
-export interface EditSchematicGroupLocationEvent extends BaseManualEditEvent {
-  edit_event_type: "edit_schematic_group_location"
-  schematic_group_id: string
-  original_center: { x: number; y: number }
-  new_center: { x: number; y: number }
-}
-
-
-export interface PlatformConfig {
-  partsEngine?: PartsEngine
-
-  autorouter?: AutorouterProp
-
-  // TODO this follows a subset of the localStorage interface
-  localCacheEngine?: any
-
-  registryApiUrl?: string
-
-  cloudAutorouterUrl?: string
-
-  pcbDisabled?: boolean
-  schematicDisabled?: boolean
-  partsEngineDisabled?: boolean
-
-  footprintLibraryMap?: Record<
-    string,
-    Record<
-      string,
-      | any[]
-      | ((path: string) => Promise<{
-          footprintCircuitJson: any[]
-        }>)
-    >
-  >
 }
 
 
@@ -227,52 +198,38 @@ export interface CommonComponentProps extends CommonLayoutProps {
 }
 
 
-export interface CrystalProps extends CommonComponentProps {
-  frequency: number | string
-  loadCapacitance: number | string
-  pinVariant?: PinVariant
+export interface BreakoutPointProps
+  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
+  connection: string
 }
 
 
-export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "rect"
-  width: Distance
-  height: Distance
-  portHints?: PortHints
+export interface PinCompatibleVariant {
+  manufacturerPartNumber?: string
+  supplierPartNumber?: SupplierPartNumbers
 }
 
 
-export interface RotatedRectSmtPadProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "rotated_rect"
-  width: Distance
-  height: Distance
-  ccwRotation: number
-  portHints?: PortHints
-}
-
-
-export interface CircleSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "circle"
-  radius: Distance
-  portHints?: PortHints
-}
-
-
-export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "pill"
-  width: Distance
-  height: Distance
-  radius: Distance
-  portHints?: PortHints
-}
-
-
-export interface PolygonSmtPadProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "polygon"
-  points: Point[]
-  portHints?: PortHints
+export interface ChipPropsSU<PinLabel extends string = string>
+  extends CommonComponentProps {
+  manufacturerPartNumber?: string
+  pinLabels?: PinLabelsProp<string, PinLabel>
+  /**
+   * Whether to show pin aliases in the schematic
+   */
+  showPinAliases?: boolean
+  schPinArrangement?: SchematicPortArrangement
+  /** @deprecated Use schPinArrangement instead. */
+  schPortArrangement?: SchematicPortArrangement
+  pinCompatibleVariants?: PinCompatibleVariant[]
+  schPinStyle?: SchematicPinStyle
+  schPinSpacing?: Distance
+  schWidth?: Distance
+  schHeight?: Distance
+  noSchematicRepresentation?: boolean
+  internallyConnectedPins?: string[][]
+  externallyConnectedPins?: string[][]
+  connections?: Connections<PinLabel>
 }
 
 
@@ -286,7 +243,7 @@ export interface ResistorProps extends CommonComponentProps {
 }
 
 
-export interface NetLabelProps {
+export interface NetAliasProps {
   net?: string
   connection?: string
   schX?: number | string
@@ -296,35 +253,34 @@ export interface NetLabelProps {
 }
 
 
-export interface BreakoutProps
-  extends Omit<SubcircuitGroupProps, "subcircuit"> {
-  padding?: Distance
-  paddingLeft?: Distance
-  paddingRight?: Distance
-  paddingTop?: Distance
-  paddingBottom?: Distance
-}
-
-
-export interface SolderJumperProps extends JumperProps {
+export interface JumperProps extends CommonComponentProps {
+  manufacturerPartNumber?: string
+  pinLabels?: Record<number | string, string | string[]>
+  schPinStyle?: SchematicPinStyle
+  schPinSpacing?: number | string
+  schWidth?: number | string
+  schHeight?: number | string
+  schDirection?: "left" | "right"
+  schPortArrangement?: SchematicPortArrangement
   /**
-   * Pins that are bridged with solder by default
+   * Number of pins on the jumper (2 or 3)
    */
-  bridgedPins?: string[][]
+  pinCount?: 2 | 3
+  /**
+   * Groups of pins that are internally connected (bridged)
+   * e.g., [["1","2"], ["2","3"]]
+   */
+  internallyConnectedPins?: string[][]
 }
 
 
-export interface CapacitorProps extends CommonComponentProps {
-  capacitance: number | string
-  maxVoltageRating?: number | string
-  schShowRatings?: boolean
-  polarized?: boolean
-  decouplingFor?: string
-  decouplingTo?: string
-  bypassFor?: string
-  bypassTo?: string
-  maxDecouplingTraceLength?: number
-  connections?: Connections<CapacitorPinLabels>
+export interface BatteryProps extends CommonComponentProps {
+  capacity?: number | string
+}
+
+
+export interface TransistorProps extends CommonComponentProps {
+  type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet"
 }
 
 
@@ -400,43 +356,127 @@ export interface PillWithRectPadPlatedHoleProps
 }
 
 
-export interface RectCutoutProps
-  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
-  name?: string
+export interface DiodeProps extends CommonComponentProps {
+  connections?: {
+    anode?: string | string[] | readonly string[]
+    cathode?: string | string[] | readonly string[]
+    pin1?: string | string[] | readonly string[]
+    pin2?: string | string[] | readonly string[]
+    pos?: string | string[] | readonly string[]
+    neg?: string | string[] | readonly string[]
+  }
+  variant?: "standard" | "schottky" | "zener" | "photo" | "tvs"
+  standard?: boolean
+  schottky?: boolean
+  zener?: boolean
+  photo?: boolean
+  tvs?: boolean
+}
+
+
+export interface MosfetProps extends CommonComponentProps {
+  channelType: "n" | "p"
+  mosfetMode: "enhancement" | "depletion"
+}
+
+
+export interface RectSolderPasteProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
   shape: "rect"
   width: Distance
   height: Distance
 }
 
 
-export interface CircleCutoutProps
-  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
-  name?: string
+export interface CircleSolderPasteProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
   shape: "circle"
   radius: Distance
 }
 
 
-export interface PolygonCutoutProps
-  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
-  name?: string
+export interface FuseProps extends CommonComponentProps {
+  /**
+   * Current rating of the fuse in amperes
+   */
+  currentRating: number | string
+
+  /**
+   * Voltage rating of the fuse
+   */
+  voltageRating?: number | string
+
+  /**
+   * Whether to show ratings on schematic
+   */
+  schShowRatings?: boolean
+
+  /**
+   * Connections to other components
+   */
+  connections?: Connections<FusePinLabels>
+}
+
+
+export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "rect"
+  width: Distance
+  height: Distance
+  portHints?: PortHints
+}
+
+
+export interface RotatedRectSmtPadProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "rotated_rect"
+  width: Distance
+  height: Distance
+  ccwRotation: number
+  portHints?: PortHints
+}
+
+
+export interface CircleSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "circle"
+  radius: Distance
+  portHints?: PortHints
+}
+
+
+export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "pill"
+  width: Distance
+  height: Distance
+  radius: Distance
+  portHints?: PortHints
+}
+
+
+export interface PolygonSmtPadProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
   shape: "polygon"
   points: Point[]
+  portHints?: PortHints
 }
 
 
-export interface NetProps {
-  name: string
+export interface CapacitorProps extends CommonComponentProps {
+  capacitance: number | string
+  maxVoltageRating?: number | string
+  schShowRatings?: boolean
+  polarized?: boolean
+  decouplingFor?: string
+  decouplingTo?: string
+  bypassFor?: string
+  bypassTo?: string
+  maxDecouplingTraceLength?: number
+  connections?: Connections<CapacitorPinLabels>
 }
 
 
-export interface NetAliasProps {
-  net?: string
-  connection?: string
-  schX?: number | string
-  schY?: number | string
-  schRotation?: number | string
-  anchorSide?: "left" | "up" | "right" | "down"
+export interface PotentiometerProps extends CommonComponentProps {
+  maxResistance: number | string
+  pinVariant?: PotentiometerPinVariant
 }
 
 
@@ -450,22 +490,20 @@ export interface SwitchProps extends CommonComponentProps {
 }
 
 
-export interface BatteryProps extends CommonComponentProps {
-  capacity?: number | string
+export interface ConstrainedLayoutProps {
+  name?: string
+  pcbOnly?: boolean
+  schOnly?: boolean
 }
 
 
-export interface StampboardProps extends BoardProps {
-  leftPinCount?: number
-  rightPinCount?: number
-  topPinCount?: number
-  bottomPinCount?: number
-  leftPins?: string[]
-  rightPins?: string[]
-  topPins?: string[]
-  bottomPins?: string[]
-  pinPitch?: number | string
-  innerHoles?: boolean
+export interface NetLabelProps {
+  net?: string
+  connection?: string
+  schX?: number | string
+  schY?: number | string
+  schRotation?: number | string
+  anchorSide?: "left" | "up" | "right" | "down"
 }
 
 
@@ -490,9 +528,21 @@ export interface ConnectorProps extends CommonComponentProps {
 }
 
 
-export interface MosfetProps extends CommonComponentProps {
-  channelType: "n" | "p"
-  mosfetMode: "enhancement" | "depletion"
+export interface BreakoutProps
+  extends Omit<SubcircuitGroupProps, "subcircuit"> {
+  padding?: Distance
+  paddingLeft?: Distance
+  paddingRight?: Distance
+  paddingTop?: Distance
+  paddingBottom?: Distance
+}
+
+
+export interface SolderJumperProps extends JumperProps {
+  /**
+   * Pins that are bridged with solder by default
+   */
+  bridgedPins?: string[][]
 }
 
 
@@ -500,42 +550,6 @@ export interface ResonatorProps extends CommonComponentProps {
   frequency: number | string
   loadCapacitance: number | string
   pinVariant?: ResonatorPinVariant
-}
-
-
-export interface ConstrainedLayoutProps {
-  name?: string
-  pcbOnly?: boolean
-  schOnly?: boolean
-}
-
-
-export interface PinCompatibleVariant {
-  manufacturerPartNumber?: string
-  supplierPartNumber?: SupplierPartNumbers
-}
-
-
-export interface ChipPropsSU<PinLabel extends string = string>
-  extends CommonComponentProps {
-  manufacturerPartNumber?: string
-  pinLabels?: PinLabelsProp<string, PinLabel>
-  /**
-   * Whether to show pin aliases in the schematic
-   */
-  showPinAliases?: boolean
-  schPinArrangement?: SchematicPortArrangement
-  /** @deprecated Use schPinArrangement instead. */
-  schPortArrangement?: SchematicPortArrangement
-  pinCompatibleVariants?: PinCompatibleVariant[]
-  schPinStyle?: SchematicPinStyle
-  schPinSpacing?: Distance
-  schWidth?: Distance
-  schHeight?: Distance
-  noSchematicRepresentation?: boolean
-  internallyConnectedPins?: string[][]
-  externallyConnectedPins?: string[][]
-  connections?: Connections<PinLabel>
 }
 
 
@@ -612,21 +626,76 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
 }
 
 
-export interface DiodeProps extends CommonComponentProps {
-  connections?: {
-    anode?: string | string[] | readonly string[]
-    cathode?: string | string[] | readonly string[]
-    pin1?: string | string[] | readonly string[]
-    pin2?: string | string[] | readonly string[]
-    pos?: string | string[] | readonly string[]
-    neg?: string | string[] | readonly string[]
-  }
-  variant?: "standard" | "schottky" | "zener" | "photo" | "tvs"
-  standard?: boolean
-  schottky?: boolean
-  zener?: boolean
-  photo?: boolean
-  tvs?: boolean
+export interface RectCutoutProps
+  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
+  name?: string
+  shape: "rect"
+  width: Distance
+  height: Distance
+}
+
+
+export interface CircleCutoutProps
+  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
+  name?: string
+  shape: "circle"
+  radius: Distance
+}
+
+
+export interface PolygonCutoutProps
+  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
+  name?: string
+  shape: "polygon"
+  points: Point[]
+}
+
+
+export interface FootprintProps {
+  /**
+   * The layer that the footprint is designed for. If you set this to "top"
+   * then it means the children were intended to represent the top layer. If
+   * the <chip /> with this footprint is moved to the bottom layer, then the
+   * components will be mirrored.
+   *
+   * Generally, you shouldn't set this except where it can help prevent
+   * confusion because you have a complex multi-layer footprint. Default is
+   * "top" and this is most intuitive.
+   */
+  originalLayer?: LayerRef
+}
+
+
+export interface TestpointProps extends CommonComponentProps {
+  /**
+   * The footprint variant of the testpoint either a surface pad or through-hole
+   */
+  footprintVariant?: "pad" | "through_hole"
+  /**
+   * The shape of the pad if using a pad variant
+   */
+  padShape?: "rect" | "circle"
+  /**
+   * Diameter of the copper pad (applies to both SMD pads and plated holes)
+   */
+  padDiameter?: number | string
+  /**
+   * Diameter of the hole if using a through-hole testpoint
+   */
+  holeDiameter?: number | string
+  /**
+   * Width of the pad when padShape is rect
+   */
+  width?: number | string
+  /**
+   * Height of the pad when padShape is rect
+   */
+  height?: number | string
+}
+
+
+export interface NetProps {
+  name: string
 }
 
 
@@ -658,7 +727,7 @@ export interface LayoutConfig {
 }
 
 
-export interface CellBorder {
+export interface Border {
   strokeWidth?: Distance
   dashed?: boolean
   solid?: boolean
@@ -677,8 +746,8 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
 
   pcbLayout?: LayoutConfig
   schLayout?: LayoutConfig
-  cellBorder?: CellBorder
-  border?: CellBorder
+  cellBorder?: Border
+  border?: Border
 }
 
 
@@ -736,101 +805,10 @@ export interface NonSubcircuitGroupProps extends BaseGroupProps {
 }
 
 
-export interface JumperProps extends CommonComponentProps {
-  manufacturerPartNumber?: string
-  pinLabels?: Record<number | string, string | string[]>
-  schPinStyle?: SchematicPinStyle
-  schPinSpacing?: number | string
-  schWidth?: number | string
-  schHeight?: number | string
-  schDirection?: "left" | "right"
-  schPortArrangement?: SchematicPortArrangement
-  /**
-   * Number of pins on the jumper (2 or 3)
-   */
-  pinCount?: 2 | 3
-  /**
-   * Groups of pins that are internally connected (bridged)
-   * e.g., [["1","2"], ["2","3"]]
-   */
-  internallyConnectedPins?: string[][]
-}
-
-
-export interface TransistorProps extends CommonComponentProps {
-  type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet"
-}
-
-
-export interface TestpointProps extends CommonComponentProps {
-  /**
-   * The footprint variant of the testpoint either a surface pad or through-hole
-   */
-  footprintVariant?: "pad" | "through_hole"
-  /**
-   * The shape of the pad if using a pad variant
-   */
-  padShape?: "rect" | "circle"
-  /**
-   * Diameter of the copper pad (applies to both SMD pads and plated holes)
-   */
-  padDiameter?: number | string
-  /**
-   * Diameter of the hole if using a through-hole testpoint
-   */
-  holeDiameter?: number | string
-  /**
-   * Width of the pad when padShape is rect
-   */
-  width?: number | string
-  /**
-   * Height of the pad when padShape is rect
-   */
-  height?: number | string
-}
-
-
-export interface BreakoutPointProps
-  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
-  connection: string
-}
-
-
-export interface FootprintProps {
-  /**
-   * The layer that the footprint is designed for. If you set this to "top"
-   * then it means the children were intended to represent the top layer. If
-   * the <chip /> with this footprint is moved to the bottom layer, then the
-   * components will be mirrored.
-   *
-   * Generally, you shouldn't set this except where it can help prevent
-   * confusion because you have a complex multi-layer footprint. Default is
-   * "top" and this is most intuitive.
-   */
-  originalLayer?: LayerRef
-}
-
-
-export interface FuseProps extends CommonComponentProps {
-  /**
-   * Current rating of the fuse in amperes
-   */
-  currentRating: number | string
-
-  /**
-   * Voltage rating of the fuse
-   */
-  voltageRating?: number | string
-
-  /**
-   * Whether to show ratings on schematic
-   */
-  schShowRatings?: boolean
-
-  /**
-   * Connections to other components
-   */
-  connections?: Connections<FusePinLabels>
+export interface CrystalProps extends CommonComponentProps {
+  frequency: number | string
+  loadCapacitance: number | string
+  pinVariant?: PinVariant
 }
 
 
@@ -841,24 +819,46 @@ export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
 }
 
 
-export interface RectSolderPasteProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "rect"
-  width: Distance
-  height: Distance
+export interface StampboardProps extends BoardProps {
+  leftPinCount?: number
+  rightPinCount?: number
+  topPinCount?: number
+  bottomPinCount?: number
+  leftPins?: string[]
+  rightPins?: string[]
+  topPins?: string[]
+  bottomPins?: string[]
+  pinPitch?: number | string
+  innerHoles?: boolean
 }
 
 
-export interface CircleSolderPasteProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "circle"
-  radius: Distance
-}
+export interface PlatformConfig {
+  partsEngine?: PartsEngine
 
+  autorouter?: AutorouterProp
 
-export interface PotentiometerProps extends CommonComponentProps {
-  maxResistance: number | string
-  pinVariant?: PotentiometerPinVariant
+  // TODO this follows a subset of the localStorage interface
+  localCacheEngine?: any
+
+  registryApiUrl?: string
+
+  cloudAutorouterUrl?: string
+
+  pcbDisabled?: boolean
+  schematicDisabled?: boolean
+  partsEngineDisabled?: boolean
+
+  footprintLibraryMap?: Record<
+    string,
+    Record<
+      string,
+      | any[]
+      | ((path: string) => Promise<{
+          footprintCircuitJson: any[]
+        }>)
+    >
+  >
 }
 
 ```

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -96,6 +96,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbLayout?: LayoutConfig
   schLayout?: LayoutConfig
   cellBorder?: CellBorder
+  border?: CellBorder
 }
 
 export type PartsEngine = {
@@ -201,6 +202,7 @@ export const baseGroupProps = commonLayoutProps.extend({
   pcbLayout: layoutConfig.optional(),
   schLayout: layoutConfig.optional(),
   cellBorder: cellBorder.optional(),
+  border: cellBorder.optional(),
 })
 
 export const partsEngine = z.custom<PartsEngine>((v) => "findPart" in v)

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -71,13 +71,13 @@ export interface LayoutConfig {
 
 expectTypesMatch<LayoutConfig, z.input<typeof layoutConfig>>(true)
 
-export interface CellBorder {
+export interface Border {
   strokeWidth?: Distance
   dashed?: boolean
   solid?: boolean
 }
 
-export const cellBorder = z.object({
+export const border = z.object({
   strokeWidth: length.optional(),
   dashed: z.boolean().optional(),
   solid: z.boolean().optional(),
@@ -95,8 +95,8 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
 
   pcbLayout?: LayoutConfig
   schLayout?: LayoutConfig
-  cellBorder?: CellBorder
-  border?: CellBorder
+  cellBorder?: Border
+  border?: Border
 }
 
 export type PartsEngine = {
@@ -201,8 +201,8 @@ export const baseGroupProps = commonLayoutProps.extend({
   schHeight: length.optional(),
   pcbLayout: layoutConfig.optional(),
   schLayout: layoutConfig.optional(),
-  cellBorder: cellBorder.optional(),
-  border: cellBorder.optional(),
+  cellBorder: border.optional(),
+  border: border.optional(),
 })
 
 export const partsEngine = z.custom<PartsEngine>((v) => "findPart" in v)

--- a/tests/group.test.ts
+++ b/tests/group.test.ts
@@ -14,3 +14,17 @@ test("should parse cellBorder", () => {
   expect(parsed.cellBorder?.strokeWidth).toBe(2)
   expect(parsed.cellBorder?.dashed).toBe(true)
 })
+
+test("should parse border", () => {
+  const raw: BaseGroupProps = {
+    name: "g",
+    border: {
+      strokeWidth: "1mm",
+      solid: true,
+    },
+  }
+
+  const parsed = baseGroupProps.parse(raw)
+  expect(parsed.border?.strokeWidth).toBe(1)
+  expect(parsed.border?.solid).toBe(true)
+})


### PR DESCRIPTION
## Summary
- support `border` on `<group/>`
- document `border` prop in README and generated docs
- test that `border` parses correctly

## Testing
- `bun test tests/group.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_684d86f63db8832e8631de9ab09b5be9