### PR TITLE
Fix deterministic doc generation

### DIFF
--- a/scripts/generate-component-types.ts
+++ b/scripts/generate-component-types.ts
@@ -71,12 +71,14 @@ function generateComponentTypesDoc() {
   // Get common types first
   const commonFiles = fs
     .readdirSync(commonDir)
+    .sort()
     .filter((file) => file.endsWith(".ts"))
     .map((file) => path.join(commonDir, file))
 
   // Then get component types
   const componentFiles = fs
     .readdirSync(componentsDir)
+    .sort()
     .filter((file) => file.endsWith(".ts"))
     .map((file) => path.join(componentsDir, file))
 

--- a/scripts/generate-manual-edits-docs.ts
+++ b/scripts/generate-manual-edits-docs.ts
@@ -11,10 +11,12 @@ interface ElementDoc {
 
 async function generateManualEditsDocs() {
   const pattern = "lib/manual-edits/**/*.ts"
-  const files = await glob(pattern, {
-    cwd: process.cwd(),
-    absolute: true,
-  })
+  const files = (
+    await glob(pattern, {
+      cwd: process.cwd(),
+      absolute: true,
+    })
+  ).sort()
 
   console.log("Found source files:", files)
   const sections = {

--- a/scripts/generate-props-overview.ts
+++ b/scripts/generate-props-overview.ts
@@ -7,7 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 // Read all TypeScript files in the lib directory recursively
 function getAllTypeScriptFiles(dir: string): string[] {
   const files: string[] = []
-  const items = fs.readdirSync(dir)
+  const items = fs.readdirSync(dir).sort()
 
   for (const item of items) {
     const fullPath = path.join(dir, item)
@@ -49,12 +49,18 @@ function extractInterfaces(content: string): string[] {
 
 // Main execution
 const libDir = path.join(__dirname, "../lib")
-const files = getAllTypeScriptFiles(libDir)
+const files = getAllTypeScriptFiles(libDir).sort()
 
-const allInterfaces = files.flatMap((file) => {
-  const content = fs.readFileSync(file, "utf8")
-  return extractInterfaces(content)
-})
+const allInterfaces = files
+  .flatMap((file) => {
+    const content = fs.readFileSync(file, "utf8")
+    return extractInterfaces(content)
+  })
+  .sort((a, b) => {
+    const nameA = /export interface\s+(\w+)/.exec(a)?.[1] || ""
+    const nameB = /export interface\s+(\w+)/.exec(b)?.[1] || ""
+    return nameA.localeCompare(nameB)
+  })
 
 // Generate markdown content
 const template = `# @tscircuit/props Overview

--- a/scripts/generate-readme-docs.ts
+++ b/scripts/generate-readme-docs.ts
@@ -7,7 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 // Read all TypeScript files in the lib/components directory
 function getComponentFiles(dir: string): string[] {
   const files: string[] = []
-  const items = fs.readdirSync(dir)
+  const items = fs.readdirSync(dir).sort()
 
   for (const item of items) {
     const fullPath = path.join(dir, item)


### PR DESCRIPTION
## Summary
- ensure generated docs are deterministic
- sort extracted interfaces for props overview
- sort file listings when generating docs

## Testing
- `bun test tests`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_684db6f06c80832eac563ef99d2594dd