### PR TITLE
Add layout padding props

### DIFF
--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -35,6 +35,14 @@ export const layoutConfig = z.object({
   flexColumn: z.boolean().optional(),
   gap: z.number().or(z.string()).optional(),
 
+  padding: length.optional(),
+  paddingLeft: length.optional(),
+  paddingRight: length.optional(),
+  paddingTop: length.optional(),
+  paddingBottom: length.optional(),
+  paddingX: length.optional(),
+  paddingY: length.optional(),
+
   width: length.optional(),
   height: length.optional(),
 
@@ -61,6 +69,14 @@ export interface LayoutConfig {
   flexRow?: boolean
   flexColumn?: boolean
   gap?: number | string
+
+  padding?: Distance
+  paddingLeft?: Distance
+  paddingRight?: Distance
+  paddingTop?: Distance
+  paddingBottom?: Distance
+  paddingX?: Distance
+  paddingY?: Distance
 
   width?: Distance
   height?: Distance

--- a/tests/group.test.ts
+++ b/tests/group.test.ts
@@ -60,3 +60,19 @@ test("should parse schPadding", () => {
   expect(parsed.schPadding).toBe(1)
   expect(parsed.schPaddingLeft).toBe(2)
 })
+
+test("should parse layout padding", () => {
+  const raw: BaseGroupProps = {
+    name: "g",
+    padding: "1mm",
+    paddingLeft: "0.5mm",
+    paddingX: "2mm",
+    paddingY: 1,
+  }
+
+  const parsed = baseGroupProps.parse(raw)
+  expect(parsed.padding).toBe(1)
+  expect(parsed.paddingLeft).toBe(0.5)
+  expect(parsed.paddingX).toBe(2)
+  expect(parsed.paddingY).toBe(1)
+})


### PR DESCRIPTION
## Summary
- add padding props to `LayoutConfig`
- test base group layout padding parsing

## Testing
- `bun update --latest zod` *(fails: GET https://registry.npmjs.org/zod - 403)*
- `bun test tests/group.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_6851952f0748832eae4b1f1b97c6ed44