### PR TITLE
Add connectsTo string support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ resistorProps.parse({ resistance: "10k" } as ResistorPropsInput)
 | `<fuse />` | [`FuseProps`](#fuseprops-fuse) |
 | `<group />` | [`BaseGroupProps`](#basegroupprops-group) |
 | `<hole />` | [`HoleProps`](#holeprops-hole) |
+| `<inductor />` | [`InductorProps`](#inductorprops-inductor) |
 | `<jumper />` | [`JumperProps`](#jumperprops-jumper) |
 | `<mosfet />` | [`MosfetProps`](#mosfetprops-mosfet) |
 | `<net />` | [`NetProps`](#netprops-net) |
@@ -390,6 +391,11 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   schLayout?: LayoutConfig
   cellBorder?: Border | null
   border?: Border | null
+  schPadding?: Distance
+  schPaddingLeft?: Distance
+  schPaddingRight?: Distance
+  schPaddingTop?: Distance
+  schPaddingBottom?: Distance
 }
 ```
 
@@ -407,6 +413,18 @@ export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
 ```
 
 [Source](https://github.com/tscircuit/props/blob/main/lib/components/hole.ts)
+
+
+### InductorProps `<inductor />`
+
+```ts
+export interface InductorProps extends CommonComponentProps {
+  inductance: number | string
+  maxCurrentRating?: number | string
+}
+```
+
+[Source](https://github.com/tscircuit/props/blob/main/lib/components/inductor.ts)
 
 
 ### JumperProps `<jumper />`
@@ -481,6 +499,7 @@ export interface NetAliasProps {
 export interface NetLabelProps {
   net?: string
   connection?: string
+  connectsTo?: string | string[]
   schX?: number | string
   schY?: number | string
   schRotation?: number | string
@@ -733,7 +752,7 @@ export interface TestpointProps extends CommonComponentProps {
 
 ```ts
 export interface TransistorProps extends CommonComponentProps {
-  type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet"
+  type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet" | "igbt"
 }
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-06-14T17:49:47.123Z
+> Generated at 2025-06-18T04:42:02.178Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -18,32 +18,82 @@ const validatedProps = chipProps.parse(unknownProps)
 ## Available Props
 
 ```ts
-export interface PlatformConfig {
-  partsEngine?: PartsEngine
+export interface AutorouterConfig {
+  serverUrl?: string
+  inputFormat?: "simplified" | "circuit-json"
+  serverMode?: "job" | "solve-endpoint"
+  serverCacheEnabled?: boolean
+  cache?: PcbRouteCache
+  groupMode?: "sequential-trace" | "subcircuit"
+  local?: boolean
+  algorithmFn?: (simpleRouteJson: any) => Promise<any>
+}
 
-  autorouter?: AutorouterProp
 
-  // TODO this follows a subset of the localStorage interface
-  localCacheEngine?: any
+export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
+  name?: string
+  key?: any
+  children?: any
 
-  registryApiUrl?: string
+  pcbWidth?: Distance
+  pcbHeight?: Distance
+  schWidth?: Distance
+  schHeight?: Distance
 
-  cloudAutorouterUrl?: string
+  pcbLayout?: LayoutConfig
+  schLayout?: LayoutConfig
+  cellBorder?: Border | null
+  border?: Border | null
+  schPadding?: Distance
+  schPaddingLeft?: Distance
+  schPaddingRight?: Distance
+  schPaddingTop?: Distance
+  schPaddingBottom?: Distance
+}
 
-  pcbDisabled?: boolean
-  schematicDisabled?: boolean
-  partsEngineDisabled?: boolean
 
-  footprintLibraryMap?: Record<
-    string,
-    Record<
-      string,
-      | any[]
-      | ((path: string) => Promise<{
-          footprintCircuitJson: any[]
-        }>)
-    >
-  >
+export interface BaseManualEditEvent {
+  edit_event_id: string
+  in_progress?: boolean
+  created_at: number
+}
+
+
+export interface BatteryProps extends CommonComponentProps {
+  capacity?: number | string
+}
+
+
+export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
+  width?: number | string
+  height?: number | string
+  outline?: Point[]
+  outlineOffsetX?: number | string
+  outlineOffsetY?: number | string
+  material?: "fr4" | "fr1"
+}
+
+
+export interface Border {
+  strokeWidth?: Distance
+  dashed?: boolean
+  solid?: boolean
+}
+
+
+export interface BreakoutPointProps
+  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
+  connection: string
+}
+
+
+export interface BreakoutProps
+  extends Omit<SubcircuitGroupProps, "subcircuit"> {
+  padding?: Distance
+  paddingLeft?: Distance
+  paddingRight?: Distance
+  paddingTop?: Distance
+  paddingBottom?: Distance
 }
 
 
@@ -60,8 +110,8 @@ export interface CadModelBase {
 }
 
 
-export interface CadModelStl extends CadModelBase {
-  stlUrl: string
+export interface CadModelJscad extends CadModelBase {
+  jscad: Record<string, any>
 }
 
 
@@ -71,187 +121,22 @@ export interface CadModelObj extends CadModelBase {
 }
 
 
-export interface CadModelJscad extends CadModelBase {
-  jscad: Record<string, any>
+export interface CadModelStl extends CadModelBase {
+  stlUrl: string
 }
 
 
-export interface PcbLayoutProps {
-  pcbX?: string | number
-  pcbY?: string | number
-  pcbRotation?: string | number
-  layer?: LayerRefInput
-}
-
-
-export interface CommonLayoutProps {
-  pcbX?: string | number
-  pcbY?: string | number
-  pcbRotation?: string | number
-
-  schX?: string | number
-  schY?: string | number
-  schRotation?: string | number
-
-  layer?: LayerRefInput
-  footprint?: Footprint
-}
-
-
-export interface SupplierProps {
-  supplierPartNumbers?: SupplierPartNumbers
-}
-
-
-export interface CommonComponentProps extends CommonLayoutProps {
-  key?: any
-  name: string
-  supplierPartNumbers?: SupplierPartNumbers
-  cadModel?: CadModelProp
-  children?: any
-  symbolName?: string
-  doNotPlace?: boolean
-}
-
-
-export interface SchematicPortArrangementWithSizes {
-  leftSize?: number
-  topSize?: number
-  rightSize?: number
-  bottomSize?: number
-}
-
-
-export interface SchematicPortArrangementWithPinCounts {
-  leftPinCount?: number
-  topPinCount?: number
-  rightPinCount?: number
-  bottomPinCount?: number
-}
-
-
-export interface PinSideDefinition {
-  pins: Array<number | string>
-  direction:
-    | "top-to-bottom"
-    | "left-to-right"
-    | "bottom-to-top"
-    | "right-to-left"
-}
-
-
-export interface SchematicPortArrangementWithSides {
-  leftSide?: PinSideDefinition
-  topSide?: PinSideDefinition
-  rightSide?: PinSideDefinition
-  bottomSide?: PinSideDefinition
-}
-
-
-export interface ManualPcbPlacement {
-  selector: string
-  relative_to: string
-  center: Point
-}
-
-
-export interface ManualTraceHint {
-  pcb_port_selector: string
-  offsets: Array<RouteHintPoint>
-}
-
-
-export interface ManualSchematicPlacement {
-  selector: string
-  relative_to: string
-  center: Point
-}
-
-
-export interface ManualEditsFile {
-  pcb_placements?: ManualPcbPlacement[]
-  manual_trace_hints?: ManualTraceHint[]
-  schematic_placements?: ManualSchematicPlacement[]
-}
-
-
-export interface EditTraceHintEvent extends BaseManualEditEvent {
-  /** @deprecated */
-  pcb_edit_event_type: "edit_trace_hint"
-  edit_event_type?: "edit_pcb_trace_hint"
-  pcb_port_id: string
-  pcb_trace_hint_id?: string
-  route: Array<{ x: number; y: number; via?: boolean }>
-}
-
-
-export interface EditSchematicComponentLocationEvent
-  extends BaseManualEditEvent {
-  edit_event_type: "edit_schematic_component_location"
-  schematic_component_id: string
-  original_center: { x: number; y: number }
-  new_center: { x: number; y: number }
-}
-
-
-export interface BaseManualEditEvent {
-  edit_event_id: string
-  in_progress?: boolean
-  created_at: number
-}
-
-
-export interface EditSchematicGroupLocationEvent extends BaseManualEditEvent {
-  edit_event_type: "edit_schematic_group_location"
-  schematic_group_id: string
-  original_center: { x: number; y: number }
-  new_center: { x: number; y: number }
-}
-
-
-export interface EditPcbComponentLocationEvent extends BaseManualEditEvent {
-  edit_event_type: "edit_pcb_component_location"
-  /** @deprecated */
-  pcb_edit_event_type: "edit_component_location"
-  pcb_component_id: string
-  original_center: { x: number; y: number }
-  new_center: { x: number; y: number }
-}
-
-
-export interface EditPcbGroupLocationEvent extends BaseManualEditEvent {
-  edit_event_type: "edit_pcb_group_location"
-  pcb_group_id: string
-  original_center: { x: number; y: number }
-  new_center: { x: number; y: number }
-}
-
-
-export interface ResistorProps extends CommonComponentProps {
-  resistance: number | string
-  pullupFor?: string
-  pullupTo?: string
-  pulldownFor?: string
-  pulldownTo?: string
-  connections?: Connections<ResistorPinLabels>
-}
-
-
-export interface NetProps {
-  name: string
-}
-
-
-export interface ConstrainedLayoutProps {
-  name?: string
-  pcbOnly?: boolean
-  schOnly?: boolean
-}
-
-
-export interface PinCompatibleVariant {
-  manufacturerPartNumber?: string
-  supplierPartNumber?: SupplierPartNumbers
+export interface CapacitorProps extends CommonComponentProps {
+  capacitance: number | string
+  maxVoltageRating?: number | string
+  schShowRatings?: boolean
+  polarized?: boolean
+  decouplingFor?: string
+  decouplingTo?: string
+  bypassFor?: string
+  bypassTo?: string
+  maxDecouplingTraceLength?: number
+  connections?: Connections<CapacitorPinLabels>
 }
 
 
@@ -278,11 +163,28 @@ export interface ChipPropsSU<PinLabel extends string = string>
 }
 
 
-export interface RectSolderPasteProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "rect"
-  width: Distance
-  height: Distance
+export interface CircleCutoutProps
+  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
+  name?: string
+  shape: "circle"
+  radius: Distance
+}
+
+
+export interface CirclePlatedHoleProps
+  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
+  name?: string
+  shape: "circle"
+  holeDiameter: number | string
+  outerDiameter: number | string
+  portHints?: PortHints
+}
+
+
+export interface CircleSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "circle"
+  radius: Distance
+  portHints?: PortHints
 }
 
 
@@ -293,31 +195,69 @@ export interface CircleSolderPasteProps
 }
 
 
-export interface TestpointProps extends CommonComponentProps {
+export interface CircularHoleWithRectPlatedProps
+  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
+  name?: string
+  shape: "circular_hole_with_rect_pad"
+  holeDiameter: number | string
+  rectPadWidth: number | string
+  rectPadHeight: number | string
+  holeShape?: "circle"
+  padShape?: "rect"
+  portHints?: PortHints
+}
+
+
+export interface CommonComponentProps extends CommonLayoutProps {
+  key?: any
+  name: string
+  supplierPartNumbers?: SupplierPartNumbers
+  cadModel?: CadModelProp
+  children?: any
+  symbolName?: string
+  doNotPlace?: boolean
+}
+
+
+export interface CommonLayoutProps {
+  pcbX?: string | number
+  pcbY?: string | number
+  pcbRotation?: string | number
+
+  schX?: string | number
+  schY?: string | number
+  schRotation?: string | number
+
+  layer?: LayerRefInput
+  footprint?: FootprintProp
+}
+
+
+export interface ConnectorProps extends CommonComponentProps {
+  manufacturerPartNumber?: string
+  pinLabels?: Record<number | string, string | string[]>
+  schPinStyle?: SchematicPinStyle
+  schPinSpacing?: number | string
+  schWidth?: number | string
+  schHeight?: number | string
+  schDirection?: "left" | "right"
+  schPortArrangement?: SchematicPortArrangement
   /**
-   * The footprint variant of the testpoint either a surface pad or through-hole
+   * Groups of pins that are internally connected (bridged)
+   * e.g., [["1","2"], ["2","3"]]
    */
-  footprintVariant?: "pad" | "through_hole"
+  internallyConnectedPins?: string[][]
   /**
-   * The shape of the pad if using a pad variant
+   * Connector standard, e.g. usb_c, m2
    */
-  padShape?: "rect" | "circle"
-  /**
-   * Diameter of the copper pad (applies to both SMD pads and plated holes)
-   */
-  padDiameter?: number | string
-  /**
-   * Diameter of the hole if using a through-hole testpoint
-   */
-  holeDiameter?: number | string
-  /**
-   * Width of the pad when padShape is rect
-   */
-  width?: number | string
-  /**
-   * Height of the pad when padShape is rect
-   */
-  height?: number | string
+  standard?: "usb_c" | "m2"
+}
+
+
+export interface ConstrainedLayoutProps {
+  name?: string
+  pcbOnly?: boolean
+  schOnly?: boolean
 }
 
 
@@ -328,23 +268,81 @@ export interface CrystalProps extends CommonComponentProps {
 }
 
 
-export interface BreakoutProps
-  extends Omit<SubcircuitGroupProps, "subcircuit"> {
-  padding?: Distance
-  paddingLeft?: Distance
-  paddingRight?: Distance
-  paddingTop?: Distance
-  paddingBottom?: Distance
+export interface DiodeProps extends CommonComponentProps {
+  connections?: {
+    anode?: string | string[] | readonly string[]
+    cathode?: string | string[] | readonly string[]
+    pin1?: string | string[] | readonly string[]
+    pin2?: string | string[] | readonly string[]
+    pos?: string | string[] | readonly string[]
+    neg?: string | string[] | readonly string[]
+  }
+  variant?: "standard" | "schottky" | "zener" | "photo" | "tvs"
+  standard?: boolean
+  schottky?: boolean
+  zener?: boolean
+  photo?: boolean
+  tvs?: boolean
 }
 
 
-export interface NetLabelProps {
-  net?: string
-  connection?: string
-  schX?: number | string
-  schY?: number | string
-  schRotation?: number | string
-  anchorSide?: "left" | "top" | "right" | "bottom"
+export interface EditPcbComponentLocationEvent extends BaseManualEditEvent {
+  edit_event_type: "edit_pcb_component_location"
+  /** @deprecated */
+  pcb_edit_event_type: "edit_component_location"
+  pcb_component_id: string
+  original_center: { x: number; y: number }
+  new_center: { x: number; y: number }
+}
+
+
+export interface EditPcbGroupLocationEvent extends BaseManualEditEvent {
+  edit_event_type: "edit_pcb_group_location"
+  pcb_group_id: string
+  original_center: { x: number; y: number }
+  new_center: { x: number; y: number }
+}
+
+
+export interface EditSchematicComponentLocationEvent
+  extends BaseManualEditEvent {
+  edit_event_type: "edit_schematic_component_location"
+  schematic_component_id: string
+  original_center: { x: number; y: number }
+  new_center: { x: number; y: number }
+}
+
+
+export interface EditSchematicGroupLocationEvent extends BaseManualEditEvent {
+  edit_event_type: "edit_schematic_group_location"
+  schematic_group_id: string
+  original_center: { x: number; y: number }
+  new_center: { x: number; y: number }
+}
+
+
+export interface EditTraceHintEvent extends BaseManualEditEvent {
+  /** @deprecated */
+  pcb_edit_event_type: "edit_trace_hint"
+  edit_event_type?: "edit_pcb_trace_hint"
+  pcb_port_id: string
+  pcb_trace_hint_id?: string
+  route: Array<{ x: number; y: number; via?: boolean }>
+}
+
+
+export interface FootprintProps {
+  /**
+   * The layer that the footprint is designed for. If you set this to "top"
+   * then it means the children were intended to represent the top layer. If
+   * the <chip /> with this footprint is moved to the bottom layer, then the
+   * components will be mirrored.
+   *
+   * Generally, you shouldn't set this except where it can help prevent
+   * confusion because you have a complex multi-layer footprint. Default is
+   * "top" and this is most intuitive.
+   */
+  originalLayer?: LayerRef
 }
 
 
@@ -371,13 +369,137 @@ export interface FuseProps extends CommonComponentProps {
 }
 
 
-export interface CirclePlatedHoleProps
-  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
+export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   name?: string
-  shape: "circle"
-  holeDiameter: number | string
-  outerDiameter: number | string
-  portHints?: PortHints
+  diameter?: Distance
+  radius?: Distance
+}
+
+
+export interface InductorProps extends CommonComponentProps {
+  inductance: number | string
+  maxCurrentRating?: number | string
+}
+
+
+export interface JumperProps extends CommonComponentProps {
+  manufacturerPartNumber?: string
+  pinLabels?: Record<number | string, string | string[]>
+  schPinStyle?: SchematicPinStyle
+  schPinSpacing?: number | string
+  schWidth?: number | string
+  schHeight?: number | string
+  schDirection?: "left" | "right"
+  schPortArrangement?: SchematicPortArrangement
+  /**
+   * Number of pins on the jumper (2 or 3)
+   */
+  pinCount?: 2 | 3
+  /**
+   * Groups of pins that are internally connected (bridged)
+   * e.g., [["1","2"], ["2","3"]]
+   */
+  internallyConnectedPins?: string[][]
+}
+
+
+export interface LayoutConfig {
+  layoutMode?: "grid" | "flex" | "match-adapt" | "none"
+  position?: "absolute" | "relative"
+
+  grid?: boolean
+  gridCols?: number | string
+  gridRows?: number | string
+  gridTemplateRows?: string
+  gridTemplateColumns?: string
+  gridTemplate?: string
+  gridGap?: number | string
+
+  flex?: boolean | string
+  flexDirection?: "row" | "column"
+  alignItems?: "start" | "center" | "end" | "stretch"
+  justifyContent?: "start" | "center" | "end" | "stretch"
+  flexRow?: boolean
+  flexColumn?: boolean
+  gap?: number | string
+
+  padding?: Distance
+  paddingLeft?: Distance
+  paddingRight?: Distance
+  paddingTop?: Distance
+  paddingBottom?: Distance
+  paddingX?: Distance
+  paddingY?: Distance
+
+  width?: Distance
+  height?: Distance
+
+  matchAdapt?: boolean
+  matchAdaptTemplate?: any
+}
+
+
+export interface ManualEditsFile {
+  pcb_placements?: ManualPcbPlacement[]
+  manual_trace_hints?: ManualTraceHint[]
+  schematic_placements?: ManualSchematicPlacement[]
+}
+
+
+export interface ManualPcbPlacement {
+  selector: string
+  relative_to: string
+  center: Point
+}
+
+
+export interface ManualSchematicPlacement {
+  selector: string
+  relative_to: string
+  center: Point
+}
+
+
+export interface ManualTraceHint {
+  pcb_port_selector: string
+  offsets: Array<RouteHintPoint>
+}
+
+
+export interface MosfetProps extends CommonComponentProps {
+  channelType: "n" | "p"
+  mosfetMode: "enhancement" | "depletion"
+}
+
+
+export interface NetAliasProps {
+  net?: string
+  connection?: string
+  schX?: number | string
+  schY?: number | string
+  schRotation?: number | string
+  anchorSide?: "left" | "top" | "right" | "bottom"
+}
+
+
+export interface NetLabelProps {
+  net?: string
+  connection?: string
+  connectsTo?: string | string[]
+  schX?: number | string
+  schY?: number | string
+  schRotation?: number | string
+  anchorSide?: "left" | "top" | "right" | "bottom"
+}
+
+
+export interface NetProps {
+  name: string
+}
+
+
+export interface NonSubcircuitGroupProps extends BaseGroupProps {
+  subcircuit?: false | undefined
 }
 
 
@@ -395,6 +517,20 @@ export interface OvalPlatedHoleProps
   innerWidth?: number | string
   /** @deprecated use holeHeight */
   innerHeight?: number | string
+}
+
+
+export interface PcbLayoutProps {
+  pcbX?: string | number
+  pcbY?: string | number
+  pcbRotation?: string | number
+  layer?: LayerRefInput
+}
+
+
+export interface PcbRouteCache {
+  pcbTraces: PcbTrace[]
+  cacheKey: string
 }
 
 
@@ -416,15 +552,11 @@ export interface PillPlatedHoleProps
 }
 
 
-export interface CircularHoleWithRectPlatedProps
-  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
-  name?: string
-  holeDiameter: number | string
-  rectPadWidth: number | string
-  rectPadHeight: number | string
-  holeShape?: "circle"
-  padShape?: "rect"
-  shape?: "circular_hole_with_rect_pad"
+export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "pill"
+  width: Distance
+  height: Distance
+  radius: Distance
   portHints?: PortHints
 }
 
@@ -443,9 +575,9 @@ export interface PillWithRectPadPlatedHoleProps
 }
 
 
-export interface PotentiometerProps extends CommonComponentProps {
-  maxResistance: number | string
-  pinVariant?: PotentiometerPinVariant
+export interface PinCompatibleVariant {
+  manufacturerPartNumber?: string
+  supplierPartNumber?: SupplierPartNumbers
 }
 
 
@@ -512,36 +644,64 @@ export interface PinHeaderProps extends CommonComponentProps {
 }
 
 
-export interface ResonatorProps extends CommonComponentProps {
-  frequency: number | string
-  loadCapacitance: number | string
-  pinVariant?: ResonatorPinVariant
+export interface PinSideDefinition {
+  pins: Array<number | string>
+  direction:
+    | "top-to-bottom"
+    | "left-to-right"
+    | "bottom-to-top"
+    | "right-to-left"
 }
 
 
-export interface BatteryProps extends CommonComponentProps {
-  capacity?: number | string
+export interface PlatformConfig {
+  partsEngine?: PartsEngine
+
+  autorouter?: AutorouterProp
+
+  // TODO this follows a subset of the localStorage interface
+  localCacheEngine?: any
+
+  registryApiUrl?: string
+
+  cloudAutorouterUrl?: string
+
+  pcbDisabled?: boolean
+  schematicDisabled?: boolean
+  partsEngineDisabled?: boolean
+
+  footprintLibraryMap?: Record<
+    string,
+    Record<
+      string,
+      | any[]
+      | ((path: string) => Promise<{
+          footprintCircuitJson: any[]
+        }>)
+    >
+  >
 }
 
 
-export interface ConnectorProps extends CommonComponentProps {
-  manufacturerPartNumber?: string
-  pinLabels?: Record<number | string, string | string[]>
-  schPinStyle?: SchematicPinStyle
-  schPinSpacing?: number | string
-  schWidth?: number | string
-  schHeight?: number | string
-  schDirection?: "left" | "right"
-  schPortArrangement?: SchematicPortArrangement
-  /**
-   * Groups of pins that are internally connected (bridged)
-   * e.g., [["1","2"], ["2","3"]]
-   */
-  internallyConnectedPins?: string[][]
-  /**
-   * Connector standard, e.g. usb_c, m2
-   */
-  standard?: "usb_c" | "m2"
+export interface PolygonCutoutProps
+  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
+  name?: string
+  shape: "polygon"
+  points: Point[]
+}
+
+
+export interface PolygonSmtPadProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "polygon"
+  points: Point[]
+  portHints?: PortHints
+}
+
+
+export interface PotentiometerProps extends CommonComponentProps {
+  maxResistance: number | string
+  pinVariant?: PotentiometerPinVariant
 }
 
 
@@ -554,142 +714,36 @@ export interface RectCutoutProps
 }
 
 
-export interface CircleCutoutProps
-  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
-  name?: string
-  shape: "circle"
-  radius: Distance
-}
-
-
-export interface PolygonCutoutProps
-  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
-  name?: string
-  shape: "polygon"
-  points: Point[]
-}
-
-
-export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
-  name?: string
-  diameter?: Distance
-  radius?: Distance
-}
-
-
-export interface DiodeProps extends CommonComponentProps {
-  connections?: {
-    anode?: string | string[] | readonly string[]
-    cathode?: string | string[] | readonly string[]
-    pin1?: string | string[] | readonly string[]
-    pin2?: string | string[] | readonly string[]
-    pos?: string | string[] | readonly string[]
-    neg?: string | string[] | readonly string[]
-  }
-  variant?: "standard" | "schottky" | "zener" | "photo" | "tvs"
-  standard?: boolean
-  schottky?: boolean
-  zener?: boolean
-  photo?: boolean
-  tvs?: boolean
-}
-
-
-export interface NetAliasProps {
-  net?: string
-  connection?: string
-  schX?: number | string
-  schY?: number | string
-  schRotation?: number | string
-  anchorSide?: "left" | "top" | "right" | "bottom"
-}
-
-
-export interface BreakoutPointProps
-  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
-  connection: string
-}
-
-
-export interface SwitchProps extends CommonComponentProps {
-  type?: "spst" | "spdt" | "dpst" | "dpdt"
-  isNormallyClosed?: boolean
-  spdt?: boolean
-  spst?: boolean
-  dpst?: boolean
-  dpdt?: boolean
-}
-
-
-export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
-  width?: number | string
-  height?: number | string
-  outline?: Point[]
-  outlineOffsetX?: number | string
-  outlineOffsetY?: number | string
-  material?: "fr4" | "fr1"
-}
-
-
-export interface CapacitorProps extends CommonComponentProps {
-  capacitance: number | string
-  maxVoltageRating?: number | string
-  schShowRatings?: boolean
-  polarized?: boolean
-  decouplingFor?: string
-  decouplingTo?: string
-  bypassFor?: string
-  bypassTo?: string
-  maxDecouplingTraceLength?: number
-  connections?: Connections<CapacitorPinLabels>
-}
-
-
-export interface MosfetProps extends CommonComponentProps {
-  channelType: "n" | "p"
-  mosfetMode: "enhancement" | "depletion"
-}
-
-
-export interface JumperProps extends CommonComponentProps {
-  manufacturerPartNumber?: string
-  pinLabels?: Record<number | string, string | string[]>
-  schPinStyle?: SchematicPinStyle
-  schPinSpacing?: number | string
-  schWidth?: number | string
-  schHeight?: number | string
-  schDirection?: "left" | "right"
-  schPortArrangement?: SchematicPortArrangement
-  /**
-   * Number of pins on the jumper (2 or 3)
-   */
-  pinCount?: 2 | 3
-  /**
-   * Groups of pins that are internally connected (bridged)
-   * e.g., [["1","2"], ["2","3"]]
-   */
-  internallyConnectedPins?: string[][]
-}
-
-
-export interface TransistorProps extends CommonComponentProps {
-  type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet"
-}
-
-
-export interface SolderJumperProps extends JumperProps {
-  /**
-   * Pins that are bridged with solder by default
-   */
-  bridgedPins?: string[][]
-}
-
-
 export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   shape: "rect"
   width: Distance
   height: Distance
   portHints?: PortHints
+}
+
+
+export interface RectSolderPasteProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "rect"
+  width: Distance
+  height: Distance
+}
+
+
+export interface ResistorProps extends CommonComponentProps {
+  resistance: number | string
+  pullupFor?: string
+  pullupTo?: string
+  pulldownFor?: string
+  pulldownTo?: string
+  connections?: Connections<ResistorPinLabels>
+}
+
+
+export interface ResonatorProps extends CommonComponentProps {
+  frequency: number | string
+  loadCapacitance: number | string
+  pinVariant?: ResonatorPinVariant
 }
 
 
@@ -703,97 +757,49 @@ export interface RotatedRectSmtPadProps
 }
 
 
-export interface CircleSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "circle"
-  radius: Distance
-  portHints?: PortHints
+export interface SchematicPortArrangementWithPinCounts {
+  leftPinCount?: number
+  topPinCount?: number
+  rightPinCount?: number
+  bottomPinCount?: number
 }
 
 
-export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "pill"
-  width: Distance
-  height: Distance
-  radius: Distance
-  portHints?: PortHints
+export interface SchematicPortArrangementWithSides {
+  leftSide?: PinSideDefinition
+  topSide?: PinSideDefinition
+  rightSide?: PinSideDefinition
+  bottomSide?: PinSideDefinition
 }
 
 
-export interface PolygonSmtPadProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
-  shape: "polygon"
-  points: Point[]
-  portHints?: PortHints
+export interface SchematicPortArrangementWithSizes {
+  leftSize?: number
+  topSize?: number
+  rightSize?: number
+  bottomSize?: number
 }
 
 
-export interface LayoutConfig {
-  layoutMode?: "grid" | "flex" | "match-adapt" | "none"
-  position?: "absolute" | "relative"
-
-  grid?: boolean
-  gridCols?: number | string
-  gridRows?: number | string
-  gridTemplateRows?: string
-  gridTemplateColumns?: string
-  gridTemplate?: string
-  gridGap?: number | string
-
-  flex?: boolean | string
-  flexDirection?: "row" | "column"
-  alignItems?: "start" | "center" | "end" | "stretch"
-  justifyContent?: "start" | "center" | "end" | "stretch"
-  flexRow?: boolean
-  flexColumn?: boolean
-  gap?: number | string
-
-  width?: Distance
-  height?: Distance
-
-  matchAdapt?: boolean
-  matchAdaptTemplate?: any
+export interface SolderJumperProps extends JumperProps {
+  /**
+   * Pins that are bridged with solder by default
+   */
+  bridgedPins?: string[][]
 }
 
 
-export interface Border {
-  strokeWidth?: Distance
-  dashed?: boolean
-  solid?: boolean
-}
-
-
-export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
-  name?: string
-  key?: any
-  children?: any
-
-  pcbWidth?: Distance
-  pcbHeight?: Distance
-  schWidth?: Distance
-  schHeight?: Distance
-
-  pcbLayout?: LayoutConfig
-  schLayout?: LayoutConfig
-  cellBorder?: Border | null
-  border?: Border | null
-}
-
-
-export interface PcbRouteCache {
-  pcbTraces: PcbTrace[]
-  cacheKey: string
-}
-
-
-export interface AutorouterConfig {
-  serverUrl?: string
-  inputFormat?: "simplified" | "circuit-json"
-  serverMode?: "job" | "solve-endpoint"
-  serverCacheEnabled?: boolean
-  cache?: PcbRouteCache
-  groupMode?: "sequential-trace" | "subcircuit"
-  local?: boolean
-  algorithmFn?: (simpleRouteJson: any) => Promise<any>
+export interface StampboardProps extends BoardProps {
+  leftPinCount?: number
+  rightPinCount?: number
+  topPinCount?: number
+  bottomPinCount?: number
+  leftPins?: string[]
+  rightPins?: string[]
+  topPins?: string[]
+  bottomPins?: string[]
+  pinPitch?: number | string
+  innerHoles?: boolean
 }
 
 
@@ -828,37 +834,51 @@ export interface SubcircuitGroupPropsWithBool extends SubcircuitGroupProps {
 }
 
 
-export interface NonSubcircuitGroupProps extends BaseGroupProps {
-  subcircuit?: false | undefined
+export interface SupplierProps {
+  supplierPartNumbers?: SupplierPartNumbers
 }
 
 
-export interface StampboardProps extends BoardProps {
-  leftPinCount?: number
-  rightPinCount?: number
-  topPinCount?: number
-  bottomPinCount?: number
-  leftPins?: string[]
-  rightPins?: string[]
-  topPins?: string[]
-  bottomPins?: string[]
-  pinPitch?: number | string
-  innerHoles?: boolean
+export interface SwitchProps extends CommonComponentProps {
+  type?: "spst" | "spdt" | "dpst" | "dpdt"
+  isNormallyClosed?: boolean
+  spdt?: boolean
+  spst?: boolean
+  dpst?: boolean
+  dpdt?: boolean
 }
 
 
-export interface FootprintProps {
+export interface TestpointProps extends CommonComponentProps {
   /**
-   * The layer that the footprint is designed for. If you set this to "top"
-   * then it means the children were intended to represent the top layer. If
-   * the <chip /> with this footprint is moved to the bottom layer, then the
-   * components will be mirrored.
-   *
-   * Generally, you shouldn't set this except where it can help prevent
-   * confusion because you have a complex multi-layer footprint. Default is
-   * "top" and this is most intuitive.
+   * The footprint variant of the testpoint either a surface pad or through-hole
    */
-  originalLayer?: LayerRef
+  footprintVariant?: "pad" | "through_hole"
+  /**
+   * The shape of the pad if using a pad variant
+   */
+  padShape?: "rect" | "circle"
+  /**
+   * Diameter of the copper pad (applies to both SMD pads and plated holes)
+   */
+  padDiameter?: number | string
+  /**
+   * Diameter of the hole if using a through-hole testpoint
+   */
+  holeDiameter?: number | string
+  /**
+   * Width of the pad when padShape is rect
+   */
+  width?: number | string
+  /**
+   * Height of the pad when padShape is rect
+   */
+  height?: number | string
+}
+
+
+export interface TransistorProps extends CommonComponentProps {
+  type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet" | "igbt"
 }
 
 ```

--- a/lib/components/netlabel.ts
+++ b/lib/components/netlabel.ts
@@ -6,6 +6,7 @@ import { rotation } from "circuit-json"
 export interface NetLabelProps {
   net?: string
   connection?: string
+  connectsTo?: string | string[]
   schX?: number | string
   schY?: number | string
   schRotation?: number | string
@@ -15,6 +16,7 @@ export interface NetLabelProps {
 export const netLabelProps = z.object({
   net: z.string().optional(),
   connection: z.string().optional(),
+  connectsTo: z.string().or(z.array(z.string())).optional(),
   schX: distance.optional(),
   schY: distance.optional(),
   schRotation: rotation.optional(),


### PR DESCRIPTION
## Summary
- expand `connectsTo` union to accept string or array
- regenerate docs for `NetLabelProps`

## Testing
- `bun test tests`
- `bun update --latest some-dep` *(fails: GET https://registry.npmjs.org/some-dep - 403)*


------
https://chatgpt.com/codex/tasks/task_b_685241fe1804832e80d04ece89b71be7