### PR TITLE
make schX and schY optional in schematic-text and schematic-box props & add tests

### DIFF
--- a/lib/components/schematic-box.ts
+++ b/lib/components/schematic-box.ts
@@ -4,8 +4,8 @@ import { ninePointAnchor } from "lib/common/ninePointAnchor"
 
 export const schematicBoxProps = z
   .object({
-    schX: distance,
-    schY: distance,
+    schX: distance.optional(),
+    schY: distance.optional(),
     width: distance.optional(),
     height: distance.optional(),
     overlay: z.array(z.string()).optional(),

--- a/lib/components/schematic-text.ts
+++ b/lib/components/schematic-text.ts
@@ -4,8 +4,8 @@ import { ninePointAnchor } from "lib/common/ninePointAnchor"
 import { fivePointAnchor } from "lib/common/fivePointAnchor"
 
 export const schematicTextProps = z.object({
-  schX: distance,
-  schY: distance,
+  schX: distance.optional(),
+  schY: distance.optional(),
   text: z.string(),
   fontSize: z.number().default(1),
   anchor: z

--- a/tests/schematic-box.test.ts
+++ b/tests/schematic-box.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test"
+import {
+  schematicBoxProps,
+  type SchematicBoxProps,
+} from "lib/components/schematic-box"
+import { expectTypeOf } from "expect-type"
+
+test("should parse schematic box with schX and schY", () => {
+  const raw: SchematicBoxProps = {
+    schX: 5,
+    schY: 10,
+    width: 20,
+    height: 30,
+  }
+  expectTypeOf(raw).toMatchTypeOf<SchematicBoxProps>()
+  const parsed = schematicBoxProps.parse(raw)
+  expect(parsed.schX).toBe(5)
+  expect(parsed.schY).toBe(10)
+  expect(parsed.width).toBe(20)
+  expect(parsed.height).toBe(30)
+})
+
+test("should parse schematic box with only overlay", () => {
+  const raw: SchematicBoxProps = {
+    overlay: ["custom"],
+  }
+  const parsed = schematicBoxProps.parse(raw)
+  expect(parsed.overlay).toEqual(["custom"])
+  expect(parsed.schX).toBeUndefined()
+  expect(parsed.schY).toBeUndefined()
+})
+
+test("should fail if neither width/height nor overlay is provided", () => {
+  const raw: SchematicBoxProps = {}
+  expect(() => schematicBoxProps.parse(raw)).toThrow()
+})
+
+test("should fail if both width/height and overlay are provided", () => {
+  const raw: SchematicBoxProps = {
+    width: 10,
+    height: 10,
+    overlay: ["custom"],
+  }
+  expect(() => schematicBoxProps.parse(raw)).toThrow()
+})

--- a/tests/schematic-text.test.ts
+++ b/tests/schematic-text.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test"
+import {
+  schematicTextProps,
+  type SchematicTextProps,
+} from "lib/components/schematic-text"
+import { expectTypeOf } from "expect-type"
+
+test("should parse schematic text with all fields", () => {
+  const raw: SchematicTextProps = {
+    schX: 10,
+    schY: 20,
+    text: "Label",
+    fontSize: 2,
+    anchor: "center",
+    color: "#FF0000",
+    schRotation: 90,
+  }
+  expectTypeOf(raw).toMatchTypeOf<SchematicTextProps>()
+  const parsed = schematicTextProps.parse(raw)
+  expect(parsed.schX).toBe(10)
+  expect(parsed.schY).toBe(20)
+  expect(parsed.text).toBe("Label")
+  expect(parsed.fontSize).toBe(2)
+  expect(parsed.anchor).toBe("center")
+  expect(parsed.color).toBe("#FF0000")
+  expect(parsed.schRotation).toBe(90)
+})
+
+test("should parse schematic text with only required fields", () => {
+  const raw: SchematicTextProps = {
+    text: "Only required",
+  }
+  const parsed = schematicTextProps.parse(raw)
+  expect(parsed.text).toBe("Only required")
+  expect(parsed.schX).toBeUndefined()
+  expect(parsed.schY).toBeUndefined()
+  expect(parsed.fontSize).toBe(1)
+  expect(parsed.anchor).toBe("center")
+  expect(parsed.color).toBe("#000000")
+  expect(parsed.schRotation).toBe(0)
+})


### PR DESCRIPTION
Closes tscircuit/core#952

