### PR TITLE
Add connections prop to jumper

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,10 @@ export interface JumperProps extends CommonComponentProps {
    * e.g., [["1","2"], ["2","3"]]
    */
   internallyConnectedPins?: string[][]
+  /**
+   * Connections to other components
+   */
+  connections?: Connections<string>
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -993,10 +993,10 @@ export interface JumperProps extends CommonComponentProps {
   schPortArrangement?: SchematicPortArrangement
   pinCount?: 2 | 3
   internallyConnectedPins?: string[][]
+  connections?: Connections<string>
 }
 /**
-   * Groups of pins that are internally connected
-   * e.g., [["1","2"], ["2","3"]]
+   * Connections to other components
    */
 export const jumperProps = commonComponentProps.extend({
   manufacturerPartNumber: z.string().optional(),
@@ -1011,6 +1011,10 @@ export const jumperProps = commonComponentProps.extend({
   schPortArrangement: schematicPortArrangement.optional(),
   pinCount: z.union([z.literal(2), z.literal(3)]).optional(),
   internallyConnectedPins: z.array(z.array(z.string())).optional(),
+  connections: z
+    .custom<Connections>()
+    .pipe(z.record(z.string(), connectionTarget))
+    .optional(),
 })
 ```
 

--- a/lib/components/jumper.ts
+++ b/lib/components/jumper.ts
@@ -11,6 +11,8 @@ import {
   type SchematicPinStyle,
   schematicPinStyle,
 } from "lib/common/schematicPinStyle"
+import { connectionTarget } from "lib/common/connectionsProp"
+import type { Connections } from "lib/utility-types/connections-and-selectors"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
@@ -32,6 +34,10 @@ export interface JumperProps extends CommonComponentProps {
    * e.g., [["1","2"], ["2","3"]]
    */
   internallyConnectedPins?: string[][]
+  /**
+   * Connections to other components
+   */
+  connections?: Connections<string>
 }
 
 export const jumperProps = commonComponentProps.extend({
@@ -47,6 +53,10 @@ export const jumperProps = commonComponentProps.extend({
   schPortArrangement: schematicPortArrangement.optional(),
   pinCount: z.union([z.literal(2), z.literal(3)]).optional(),
   internallyConnectedPins: z.array(z.array(z.string())).optional(),
+  connections: z
+    .custom<Connections>()
+    .pipe(z.record(z.string(), connectionTarget))
+    .optional(),
 })
 
 type InferredJumperProps = z.input<typeof jumperProps>

--- a/tests/jumper.test.ts
+++ b/tests/jumper.test.ts
@@ -77,3 +77,44 @@ test("should fail for invalid internallyConnectedPins (not an array of arrays)",
     }),
   ).toThrow()
 })
+
+test("should parse jumper props with single string connections", () => {
+  const rawProps: JumperProps = {
+    name: "jumper",
+    pinCount: 2,
+    connections: {
+      1: "net.VCC",
+      2: "net.GND",
+    },
+  }
+  const parsed = jumperProps.parse(rawProps)
+  expect(parsed.connections).toEqual({
+    1: "net.VCC",
+    2: "net.GND",
+  })
+})
+
+test("should parse jumper props with array connections", () => {
+  const rawProps: JumperProps = {
+    name: "jumper",
+    pinCount: 3,
+    connections: {
+      1: ["net.VCC", "net.POWER"],
+      2: ["net.GND"],
+    },
+  }
+  const parsed = jumperProps.parse(rawProps)
+  expect(parsed.connections).toEqual({
+    1: ["net.VCC", "net.POWER"],
+    2: ["net.GND"],
+  })
+})
+
+test("should allow optional connections", () => {
+  const rawProps: JumperProps = {
+    name: "jumper",
+    pinCount: 2,
+  }
+  const parsed = jumperProps.parse(rawProps)
+  expect(parsed.connections).toBeUndefined()
+})


### PR DESCRIPTION
## Summary
- add `connections` support to `<jumper />`
- document `connections` property for jumper
- regenerate component docs
- test jumper `connections` prop

## Testing
- `bun test tests/jumper.test.ts`
- `bun test tests`
- `bun update --latest zod` *(fails: GET https://registry.npmjs.org/zod - 403)*


------
https://chatgpt.com/codex/tasks/task_b_6854e6315410832e847a59cc7dce9e04