### PR TITLE
Add naming and connections for vias and smtpads

### DIFF
--- a/docs/CIRCUIT_JSON_PCB_OVERVIEW.md
+++ b/docs/CIRCUIT_JSON_PCB_OVERVIEW.md
@@ -199,11 +199,13 @@ export interface PCBKeepout {
 export interface PcbVia {
   type: "pcb_via"
   pcb_via_id: string
+  name?: string
   x: Distance
   y: Distance
   outer_diameter: Distance
   hole_diameter: Distance
   layers: LayerRef[]
+  connects_to?: string | string[]
   pcb_trace_id?: string
 }
 
@@ -237,6 +239,7 @@ export interface PcbSmtPadCircle {
   type: "pcb_smtpad"
   shape: "circle"
   pcb_smtpad_id: string
+  name?: string
   x: Distance
   y: Distance
   radius: number
@@ -250,6 +253,7 @@ export interface PcbSmtPadRect {
   type: "pcb_smtpad"
   shape: "rect"
   pcb_smtpad_id: string
+  name?: string
   x: Distance
   y: Distance
   width: number

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1557,6 +1557,7 @@ export interface PolygonSmtPadProps
 export const rectSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
   .extend({
+    name: z.string().optional(),
     shape: z.literal("rect"),
     width: distance,
     height: distance,
@@ -1565,6 +1566,7 @@ export const rectSmtPadProps = pcbLayoutProps
 export const rotatedRectSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
   .extend({
+    name: z.string().optional(),
     shape: z.literal("rotated_rect"),
     width: distance,
     height: distance,
@@ -1574,6 +1576,7 @@ export const rotatedRectSmtPadProps = pcbLayoutProps
 export const circleSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
   .extend({
+    name: z.string().optional(),
     shape: z.literal("circle"),
     radius: distance,
     portHints: portHints.optional(),
@@ -1581,6 +1584,7 @@ export const circleSmtPadProps = pcbLayoutProps
 export const pillSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
   .extend({
+    name: z.string().optional(),
     shape: z.literal("pill"),
     width: distance,
     height: distance,
@@ -1590,6 +1594,7 @@ export const pillSmtPadProps = pcbLayoutProps
 export const polygonSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
   .extend({
+    name: z.string().optional(),
     shape: z.literal("polygon"),
     points: z.array(point),
     portHints: portHints.optional(),
@@ -1774,10 +1779,12 @@ export const transistorPins = [
 
 ```typescript
 export const viaProps = commonLayoutProps.extend({
+  name: z.string().optional(),
   fromLayer: layer_ref,
   toLayer: layer_ref,
   holeDiameter: distance,
   outerDiameter: distance,
+  connectsTo: z.string().or(z.array(z.string())).optional(),
 })
 ```
 

--- a/lib/components/smtpad.ts
+++ b/lib/components/smtpad.ts
@@ -10,6 +10,7 @@ import { point, type Point } from "lib/common/point"
 import { expectTypesMatch } from "lib/typecheck"
 
 export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "rect"
   width: Distance
   height: Distance
@@ -18,6 +19,7 @@ export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
 
 export interface RotatedRectSmtPadProps
   extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "rotated_rect"
   width: Distance
   height: Distance
@@ -26,12 +28,14 @@ export interface RotatedRectSmtPadProps
 }
 
 export interface CircleSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "circle"
   radius: Distance
   portHints?: PortHints
 }
 
 export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "pill"
   width: Distance
   height: Distance
@@ -41,6 +45,7 @@ export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
 
 export interface PolygonSmtPadProps
   extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "polygon"
   points: Point[]
   portHints?: PortHints
@@ -60,6 +65,7 @@ export type SmtPadProps =
 export const rectSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
   .extend({
+    name: z.string().optional(),
     shape: z.literal("rect"),
     width: distance,
     height: distance,
@@ -71,6 +77,7 @@ expectTypesMatch<InferredRectSmtPadProps, RectSmtPadProps>(true)
 export const rotatedRectSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
   .extend({
+    name: z.string().optional(),
     shape: z.literal("rotated_rect"),
     width: distance,
     height: distance,
@@ -83,6 +90,7 @@ expectTypesMatch<InferredRotatedRectSmtPadProps, RotatedRectSmtPadProps>(true)
 export const circleSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
   .extend({
+    name: z.string().optional(),
     shape: z.literal("circle"),
     radius: distance,
     portHints: portHints.optional(),
@@ -93,6 +101,7 @@ expectTypesMatch<InferredCircleSmtPadProps, CircleSmtPadProps>(true)
 export const pillSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
   .extend({
+    name: z.string().optional(),
     shape: z.literal("pill"),
     width: distance,
     height: distance,
@@ -105,6 +114,7 @@ expectTypesMatch<InferredPillSmtPadProps, PillSmtPadProps>(true)
 export const polygonSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
   .extend({
+    name: z.string().optional(),
     shape: z.literal("polygon"),
     points: z.array(point),
     portHints: portHints.optional(),

--- a/lib/components/via.ts
+++ b/lib/components/via.ts
@@ -1,11 +1,24 @@
-import { distance, layer_ref } from "circuit-json"
-import { commonLayoutProps } from "lib/common/layout"
-import type { z } from "zod"
+import { distance, layer_ref, type LayerRefInput } from "circuit-json"
+import { commonLayoutProps, type CommonLayoutProps } from "lib/common/layout"
+import { expectTypesMatch } from "lib/typecheck"
+import { z } from "zod"
+
+export interface ViaProps extends CommonLayoutProps {
+  name?: string
+  fromLayer: LayerRefInput
+  toLayer: LayerRefInput
+  holeDiameter: number | string
+  outerDiameter: number | string
+  connectsTo?: string | string[]
+}
 
 export const viaProps = commonLayoutProps.extend({
+  name: z.string().optional(),
   fromLayer: layer_ref,
   toLayer: layer_ref,
   holeDiameter: distance,
   outerDiameter: distance,
+  connectsTo: z.string().or(z.array(z.string())).optional(),
 })
-export type ViaProps = z.input<typeof viaProps>
+export type InferredViaProps = z.input<typeof viaProps>
+expectTypesMatch<ViaProps, InferredViaProps>(true)

--- a/tests/smtpad.test.ts
+++ b/tests/smtpad.test.ts
@@ -10,6 +10,7 @@ import { z } from "zod"
 
 test("should parse PolygonSmtPadProps", () => {
   const rawProps: PolygonSmtPadProps = {
+    name: "pad1",
     shape: "polygon",
     points: [
       { x: 0, y: 0 },
@@ -23,11 +24,13 @@ test("should parse PolygonSmtPadProps", () => {
   expectTypeOf(rawProps).toMatchTypeOf<z.input<typeof polygonSmtPadProps>>()
 
   const parsed = polygonSmtPadProps.parse(rawProps)
+  expect(parsed.name).toBe("pad1")
   expect(parsed.points.length).toBe(3)
   expect(parsed.pcbY).toBe(1)
 
   const parsedUnion = smtPadProps.parse(rawProps)
   if (parsedUnion.shape === "polygon") {
+    expect(parsedUnion.name).toBe("pad1")
     expect(parsedUnion.points.length).toBe(3)
   } else {
     throw new Error("Expected PolygonSmtPadProps")

--- a/tests/via.test.ts
+++ b/tests/via.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test"
+import { viaProps, type ViaProps } from "lib/components/via"
+import { expectTypeOf } from "expect-type"
+import { z } from "zod"
+
+test("should parse ViaProps with name and connectsTo", () => {
+  const raw: ViaProps = {
+    name: "v1",
+    fromLayer: "top",
+    toLayer: "bottom",
+    holeDiameter: 0.3,
+    outerDiameter: "0.8mm",
+    connectsTo: ["net1", "net2"],
+  }
+
+  expectTypeOf(raw).toMatchTypeOf<z.input<typeof viaProps>>()
+
+  const parsed = viaProps.parse(raw)
+  expect(parsed.name).toBe("v1")
+  expect(parsed.connectsTo).toEqual(["net1", "net2"])
+  expect(parsed.outerDiameter).toBe(0.8)
+})


### PR DESCRIPTION
## Summary
- allow naming of smtpads and vias
- allow vias to specify nets they connect to via `connectsTo`
- document the new props
- test via parser
- update existing smtpad tests

## Testing
- `bun test tests/smtpad.test.ts`
- `bun test tests/via.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_6856e79b02fc832e8c16059e606a4c12