### PR TITLE
Add connectsTo prop to platedhole

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ resistorProps.parse({ resistance: "10k" } as ResistorPropsInput)
 | `<switch />` | [`SwitchProps`](#switchprops-switch) |
 | `<testpoint />` | [`TestpointProps`](#testpointprops-testpoint) |
 | `<transistor />` | [`TransistorProps`](#transistorprops-transistor) |
+| `<via />` | [`ViaProps`](#viaprops-via) |
 <!-- COMPONENT_TABLE_END -->
 
 <!-- USAGE_EXAMPLES_START -->
@@ -133,6 +134,7 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
 ```ts
 export interface BatteryProps extends CommonComponentProps {
   capacity?: number | string
+  schOrientation?: SchematicOrientation
 }
 ```
 
@@ -196,6 +198,7 @@ export interface CapacitorProps extends CommonComponentProps {
   bypassFor?: string
   bypassTo?: string
   maxDecouplingTraceLength?: number
+  schOrientation?: SchematicOrientation
   connections?: Connections<CapacitorPinLabels>
 }
 ```
@@ -279,6 +282,7 @@ export interface CrystalProps extends CommonComponentProps {
   frequency: number | string
   loadCapacitance: number | string
   pinVariant?: PinVariant
+  schOrientation?: SchematicOrientation
 }
 ```
 
@@ -318,6 +322,7 @@ export interface DiodeProps extends CommonComponentProps {
   zener?: boolean
   photo?: boolean
   tvs?: boolean
+  schOrientation?: SchematicOrientation
 }
 ```
 
@@ -363,6 +368,8 @@ export interface FuseProps extends CommonComponentProps {
    * Whether to show ratings on schematic
    */
   schShowRatings?: boolean
+
+  schOrientation?: SchematicOrientation
 
   /**
    * Connections to other components
@@ -421,6 +428,7 @@ export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
 export interface InductorProps extends CommonComponentProps {
   inductance: number | string
   maxCurrentRating?: number | string
+  schOrientation?: SchematicOrientation
 }
 ```
 
@@ -609,6 +617,7 @@ export interface PinHeaderProps extends CommonComponentProps {
 export interface CirclePlatedHoleProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "circle"
   holeDiameter: number | string
   outerDiameter: number | string
@@ -640,6 +649,7 @@ export interface ResistorProps extends CommonComponentProps {
   pullupTo?: string
   pulldownFor?: string
   pulldownTo?: string
+  schOrientation?: SchematicOrientation
   connections?: Connections<ResistorPinLabels>
 }
 ```
@@ -664,6 +674,7 @@ export interface ResonatorProps extends CommonComponentProps {
 
 ```ts
 export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "rect"
   width: Distance
   height: Distance
@@ -781,6 +792,22 @@ export interface TransistorProps extends CommonComponentProps {
 ```
 
 [Source](https://github.com/tscircuit/props/blob/main/lib/components/transistor.ts)
+
+
+### ViaProps `<via />`
+
+```ts
+export interface ViaProps extends CommonLayoutProps {
+  name?: string
+  fromLayer: LayerRefInput
+  toLayer: LayerRefInput
+  holeDiameter: number | string
+  outerDiameter: number | string
+  connectsTo?: string | string[]
+}
+```
+
+[Source](https://github.com/tscircuit/props/blob/main/lib/components/via.ts)
 
 <!-- INTERFACE_DEFINITIONS_END -->
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -284,9 +284,11 @@ export const schematicPinStyle = z.record(
 /** @deprecated use battery_capacity from circuit-json when circuit-json is updated */
 export interface BatteryProps extends CommonComponentProps {
   capacity?: number | string
+  schOrientation?: SchematicOrientation
 }
 export const batteryProps = commonComponentProps.extend({
   capacity: capacity.optional(),
+  schOrientation: schematicOrientation.optional(),
 })
 ```
 
@@ -366,6 +368,7 @@ export interface CapacitorProps extends CommonComponentProps {
   bypassFor?: string
   bypassTo?: string
   maxDecouplingTraceLength?: number
+  schOrientation?: SchematicOrientation
   connections?: Connections<CapacitorPinLabels>
 }
 export const capacitorProps = commonComponentProps.extend({
@@ -378,6 +381,7 @@ export const capacitorProps = commonComponentProps.extend({
   bypassFor: z.string().optional(),
   bypassTo: z.string().optional(),
   maxDecouplingTraceLength: z.number().optional(),
+  schOrientation: schematicOrientation.optional(),
   connections: createConnectionsProp(capacitorPinLabels).optional(),
 })
 ```
@@ -580,11 +584,13 @@ export interface CrystalProps extends CommonComponentProps {
   frequency: number | string
   loadCapacitance: number | string
   pinVariant?: PinVariant
+  schOrientation?: SchematicOrientation
 }
 export const crystalProps = commonComponentProps.extend({
   frequency: frequency,
   loadCapacitance: capacitance,
   pinVariant: z.enum(["two_pin", "four_pin"]).optional(),
+  schOrientation: schematicOrientation.optional(),
 })
 ```
 
@@ -654,6 +660,7 @@ export const polygonCutoutProps = pcbLayoutProps
     zener: z.boolean().optional(),
     photo: z.boolean().optional(),
     tvs: z.boolean().optional(),
+    schOrientation: schematicOrientation.optional(),
   })
 export interface DiodeProps extends CommonComponentProps {
   connections?: {
@@ -670,6 +677,7 @@ export interface DiodeProps extends CommonComponentProps {
   zener?: boolean
   photo?: boolean
   tvs?: boolean
+  schOrientation?: SchematicOrientation
 }
 ```
 
@@ -730,6 +738,8 @@ export interface FuseProps extends CommonComponentProps {
 
   schShowRatings?: boolean
 
+  schOrientation?: SchematicOrientation
+
   connections?: Connections<FusePinLabels>
 }
 /**
@@ -739,6 +749,7 @@ export const fuseProps = commonComponentProps.extend({
   currentRating: z.union([z.number(), z.string()]),
   voltageRating: z.union([z.number(), z.string()]).optional(),
   schShowRatings: z.boolean().optional(),
+  schOrientation: schematicOrientation.optional(),
   connections: z
     .record(
       z.string(),
@@ -972,10 +983,12 @@ export const holeProps = pcbLayoutProps
 export interface InductorProps extends CommonComponentProps {
   inductance: number | string
   maxCurrentRating?: number | string
+  schOrientation?: SchematicOrientation
 }
 export const inductorProps = commonComponentProps.extend({
   inductance,
   maxCurrentRating: z.union([z.string(), z.number()]).optional(),
+  schOrientation: schematicOrientation.optional(),
 })
 ```
 
@@ -1025,6 +1038,7 @@ export const ledProps = commonComponentProps.extend({
   color: z.string().optional(),
   wavelength: z.string().optional(),
   schDisplayValue: z.string().optional(),
+  schOrientation: schematicOrientation.optional(),
 })
 ```
 
@@ -1200,6 +1214,7 @@ export const pinHeaderProps = commonComponentProps.extend({
 export interface CirclePlatedHoleProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "circle"
   holeDiameter: number | string
   outerDiameter: number | string
@@ -1208,6 +1223,7 @@ export interface CirclePlatedHoleProps
 export interface OvalPlatedHoleProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "oval"
   outerWidth: number | string
   outerHeight: number | string
@@ -1222,6 +1238,7 @@ export interface OvalPlatedHoleProps
 export interface PillPlatedHoleProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "pill"
   outerWidth: number | string
   outerHeight: number | string
@@ -1237,6 +1254,7 @@ export interface PillPlatedHoleProps
 export interface CircularHoleWithRectPlatedProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "circular_hole_with_rect_pad"
   holeDiameter: number | string
   rectPadWidth: number | string
@@ -1248,6 +1266,7 @@ export interface CircularHoleWithRectPlatedProps
 export interface PillWithRectPadPlatedHoleProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "pill_hole_with_rect_pad"
   holeShape: "pill"
   padShape: "rect"
@@ -1272,6 +1291,7 @@ const distanceHiddenUndefined = z
   })
 pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
       name: z.string().optional(),
+      connectsTo: z.string().or(z.array(z.string())).optional(),
       shape: z.literal("circle"),
       holeDiameter: distance,
       outerDiameter: distance,
@@ -1279,6 +1299,7 @@ pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
     }),
 pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
       name: z.string().optional(),
+      connectsTo: z.string().or(z.array(z.string())).optional(),
       shape: z.literal("oval"),
       outerWidth: distance,
       outerHeight: distance,
@@ -1290,6 +1311,7 @@ pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
     }),
 pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
       name: z.string().optional(),
+      connectsTo: z.string().or(z.array(z.string())).optional(),
       shape: z.literal("pill"),
       outerWidth: distance,
       outerHeight: distance,
@@ -1301,6 +1323,7 @@ pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
     }),
 pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
       name: z.string().optional(),
+      connectsTo: z.string().or(z.array(z.string())).optional(),
       shape: z.literal("circular_hole_with_rect_pad"),
       holeDiameter: distance,
       rectPadWidth: distance,
@@ -1311,6 +1334,7 @@ pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
     }),
 pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
       name: z.string().optional(),
+      connectsTo: z.string().or(z.array(z.string())).optional(),
       shape: z.literal("pill_hole_with_rect_pad"),
       holeShape: z.literal("pill"),
       padShape: z.literal("rect"),
@@ -1363,6 +1387,7 @@ export interface ResistorProps extends CommonComponentProps {
   pullupTo?: string
   pulldownFor?: string
   pulldownTo?: string
+  schOrientation?: SchematicOrientation
   connections?: Connections<ResistorPinLabels>
 }
 export const resistorProps = commonComponentProps.extend({
@@ -1373,6 +1398,8 @@ export const resistorProps = commonComponentProps.extend({
 
   pulldownFor: z.string().optional(),
   pulldownTo: z.string().optional(),
+
+  schOrientation: schematicOrientation.optional(),
 
   connections: createConnectionsProp(resistorPinLabels).optional(),
 })
@@ -1523,6 +1550,7 @@ export const silkscreenTextProps = pcbLayoutProps.extend({
 
 ```typescript
 export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "rect"
   width: Distance
   height: Distance
@@ -1530,6 +1558,7 @@ export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
 }
 export interface RotatedRectSmtPadProps
   extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "rotated_rect"
   width: Distance
   height: Distance
@@ -1537,11 +1566,13 @@ export interface RotatedRectSmtPadProps
   portHints?: PortHints
 }
 export interface CircleSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "circle"
   radius: Distance
   portHints?: PortHints
 }
 export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "pill"
   width: Distance
   height: Distance
@@ -1550,6 +1581,7 @@ export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
 }
 export interface PolygonSmtPadProps
   extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "polygon"
   points: Point[]
   portHints?: PortHints
@@ -1778,6 +1810,14 @@ export const transistorPins = [
 ### via
 
 ```typescript
+export interface ViaProps extends CommonLayoutProps {
+  name?: string
+  fromLayer: LayerRefInput
+  toLayer: LayerRefInput
+  holeDiameter: number | string
+  outerDiameter: number | string
+  connectsTo?: string | string[]
+}
 export const viaProps = commonLayoutProps.extend({
   name: z.string().optional(),
   fromLayer: layer_ref,

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-06-19T16:51:31.121Z
+> Generated at 2025-06-22T16:05:26.367Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -61,6 +61,7 @@ export interface BaseManualEditEvent {
 
 export interface BatteryProps extends CommonComponentProps {
   capacity?: number | string
+  schOrientation?: SchematicOrientation
 }
 
 
@@ -136,6 +137,7 @@ export interface CapacitorProps extends CommonComponentProps {
   bypassFor?: string
   bypassTo?: string
   maxDecouplingTraceLength?: number
+  schOrientation?: SchematicOrientation
   connections?: Connections<CapacitorPinLabels>
 }
 
@@ -174,6 +176,7 @@ export interface CircleCutoutProps
 export interface CirclePlatedHoleProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "circle"
   holeDiameter: number | string
   outerDiameter: number | string
@@ -182,6 +185,7 @@ export interface CirclePlatedHoleProps
 
 
 export interface CircleSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "circle"
   radius: Distance
   portHints?: PortHints
@@ -198,6 +202,7 @@ export interface CircleSolderPasteProps
 export interface CircularHoleWithRectPlatedProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "circular_hole_with_rect_pad"
   holeDiameter: number | string
   rectPadWidth: number | string
@@ -265,6 +270,7 @@ export interface CrystalProps extends CommonComponentProps {
   frequency: number | string
   loadCapacitance: number | string
   pinVariant?: PinVariant
+  schOrientation?: SchematicOrientation
 }
 
 
@@ -283,6 +289,7 @@ export interface DiodeProps extends CommonComponentProps {
   zener?: boolean
   photo?: boolean
   tvs?: boolean
+  schOrientation?: SchematicOrientation
 }
 
 
@@ -362,6 +369,8 @@ export interface FuseProps extends CommonComponentProps {
    */
   schShowRatings?: boolean
 
+  schOrientation?: SchematicOrientation
+
   /**
    * Connections to other components
    */
@@ -379,6 +388,7 @@ export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
 export interface InductorProps extends CommonComponentProps {
   inductance: number | string
   maxCurrentRating?: number | string
+  schOrientation?: SchematicOrientation
 }
 
 
@@ -400,6 +410,10 @@ export interface JumperProps extends CommonComponentProps {
    * e.g., [["1","2"], ["2","3"]]
    */
   internallyConnectedPins?: string[][]
+  /**
+   * Connections to other components
+   */
+  connections?: Connections<string>
 }
 
 
@@ -506,6 +520,7 @@ export interface NonSubcircuitGroupProps extends BaseGroupProps {
 export interface OvalPlatedHoleProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "oval"
   outerWidth: number | string
   outerHeight: number | string
@@ -537,6 +552,7 @@ export interface PcbRouteCache {
 export interface PillPlatedHoleProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "pill"
   outerWidth: number | string
   outerHeight: number | string
@@ -553,6 +569,7 @@ export interface PillPlatedHoleProps
 
 
 export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "pill"
   width: Distance
   height: Distance
@@ -564,6 +581,7 @@ export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
 export interface PillWithRectPadPlatedHoleProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "pill_hole_with_rect_pad"
   holeShape: "pill"
   padShape: "rect"
@@ -713,6 +731,7 @@ export interface PolygonCutoutProps
 
 export interface PolygonSmtPadProps
   extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "polygon"
   points: Point[]
   portHints?: PortHints
@@ -735,6 +754,7 @@ export interface RectCutoutProps
 
 
 export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "rect"
   width: Distance
   height: Distance
@@ -756,6 +776,7 @@ export interface ResistorProps extends CommonComponentProps {
   pullupTo?: string
   pulldownFor?: string
   pulldownTo?: string
+  schOrientation?: SchematicOrientation
   connections?: Connections<ResistorPinLabels>
 }
 
@@ -769,6 +790,7 @@ export interface ResonatorProps extends CommonComponentProps {
 
 export interface RotatedRectSmtPadProps
   extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
   shape: "rotated_rect"
   width: Distance
   height: Distance
@@ -899,6 +921,16 @@ export interface TestpointProps extends CommonComponentProps {
 
 export interface TransistorProps extends CommonComponentProps {
   type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet" | "igbt"
+}
+
+
+export interface ViaProps extends CommonLayoutProps {
+  name?: string
+  fromLayer: LayerRefInput
+  toLayer: LayerRefInput
+  holeDiameter: number | string
+  outerDiameter: number | string
+  connectsTo?: string | string[]
 }
 
 ```

--- a/lib/components/platedhole.ts
+++ b/lib/components/platedhole.ts
@@ -8,6 +8,7 @@ import { z } from "zod"
 export interface CirclePlatedHoleProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "circle"
   holeDiameter: number | string
   outerDiameter: number | string
@@ -17,6 +18,7 @@ export interface CirclePlatedHoleProps
 export interface OvalPlatedHoleProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "oval"
   outerWidth: number | string
   outerHeight: number | string
@@ -33,6 +35,7 @@ export interface OvalPlatedHoleProps
 export interface PillPlatedHoleProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "pill"
   outerWidth: number | string
   outerHeight: number | string
@@ -50,6 +53,7 @@ export interface PillPlatedHoleProps
 export interface CircularHoleWithRectPlatedProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "circular_hole_with_rect_pad"
   holeDiameter: number | string
   rectPadWidth: number | string
@@ -62,6 +66,7 @@ export interface CircularHoleWithRectPlatedProps
 export interface PillWithRectPadPlatedHoleProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
+  connectsTo?: string | string[]
   shape: "pill_hole_with_rect_pad"
   holeShape: "pill"
   padShape: "rect"
@@ -90,6 +95,7 @@ export const platedHoleProps = z
   .discriminatedUnion("shape", [
     pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
       name: z.string().optional(),
+      connectsTo: z.string().or(z.array(z.string())).optional(),
       shape: z.literal("circle"),
       holeDiameter: distance,
       outerDiameter: distance,
@@ -97,6 +103,7 @@ export const platedHoleProps = z
     }),
     pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
       name: z.string().optional(),
+      connectsTo: z.string().or(z.array(z.string())).optional(),
       shape: z.literal("oval"),
       outerWidth: distance,
       outerHeight: distance,
@@ -108,6 +115,7 @@ export const platedHoleProps = z
     }),
     pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
       name: z.string().optional(),
+      connectsTo: z.string().or(z.array(z.string())).optional(),
       shape: z.literal("pill"),
       outerWidth: distance,
       outerHeight: distance,
@@ -119,6 +127,7 @@ export const platedHoleProps = z
     }),
     pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
       name: z.string().optional(),
+      connectsTo: z.string().or(z.array(z.string())).optional(),
       shape: z.literal("circular_hole_with_rect_pad"),
       holeDiameter: distance,
       rectPadWidth: distance,
@@ -129,6 +138,7 @@ export const platedHoleProps = z
     }),
     pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
       name: z.string().optional(),
+      connectsTo: z.string().or(z.array(z.string())).optional(),
       shape: z.literal("pill_hole_with_rect_pad"),
       holeShape: z.literal("pill"),
       padShape: z.literal("rect"),

--- a/tests/platedhole.test.ts
+++ b/tests/platedhole.test.ts
@@ -98,3 +98,24 @@ test("should parse OvalPlatedHoleProps with all required fields", () => {
     throw new Error("Expected OvalPlatedHoleProps, but got a different shape")
   }
 })
+
+test("should parse PlatedHoleProps with name and connectsTo", () => {
+  const raw: PlatedHoleProps = {
+    shape: "circle",
+    name: "H1",
+    holeDiameter: "1mm",
+    outerDiameter: "2mm",
+    connectsTo: ["net1"],
+  }
+
+  expectTypeOf(raw).toMatchTypeOf<z.input<typeof platedHoleProps>>()
+
+  const parsed = platedHoleProps.parse(raw)
+  if (parsed.shape === "circle") {
+    expect(parsed.name).toBe("H1")
+    expect(parsed.connectsTo).toEqual(["net1"])
+    expect(parsed.outerDiameter).toBe(2)
+  } else {
+    throw new Error("Expected CirclePlatedHoleProps, but got a different shape")
+  }
+})


### PR DESCRIPTION
## Summary
- enable `connectsTo` on plated holes
- document updates
- test parsing of plated hole connection props

## Testing
- `bun test tests/platedhole.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_685828e9e2ec832ea36e6080a7ef8d05