### PR TITLE
Add schTitle to group component

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,11 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   key?: any
   children?: any
 
+  /**
+   * Title to display above this group in the schematic view
+   */
+  schTitle?: string
+
   pcbWidth?: Distance
   pcbHeight?: Distance
   schWidth?: Distance

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -849,6 +849,8 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   key?: any
   children?: any
 
+  schTitle?: string
+
   pcbWidth?: Distance
   pcbHeight?: Distance
   schWidth?: Distance
@@ -864,6 +866,9 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   schPaddingTop?: Distance
   schPaddingBottom?: Distance
 }
+/**
+   * Title to display above this group in the schematic view
+   */
 export type PartsEngine = {
   findPart: (params: {
     sourceComponent: AnySourceComponent
@@ -926,6 +931,7 @@ export interface NonSubcircuitGroupProps extends BaseGroupProps {
 export const baseGroupProps = commonLayoutProps.extend({
   name: z.string().optional(),
   children: z.any().optional(),
+  schTitle: z.string().optional(),
   key: z.any().optional(),
 
   ...layoutConfig.shape,

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-06-22T16:05:26.367Z
+> Generated at 2025-06-23T17:02:17.759Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -34,6 +34,11 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   name?: string
   key?: any
   children?: any
+
+  /**
+   * Title to display above this group in the schematic view
+   */
+  schTitle?: string
 
   pcbWidth?: Distance
   pcbHeight?: Distance

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -104,6 +104,11 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   key?: any
   children?: any
 
+  /**
+   * Title to display above this group in the schematic view
+   */
+  schTitle?: string
+
   pcbWidth?: Distance
   pcbHeight?: Distance
   schWidth?: Distance
@@ -213,6 +218,7 @@ export type GroupProps = SubcircuitGroupPropsWithBool | NonSubcircuitGroupProps
 export const baseGroupProps = commonLayoutProps.extend({
   name: z.string().optional(),
   children: z.any().optional(),
+  schTitle: z.string().optional(),
   key: z.any().optional(),
 
   ...layoutConfig.shape,

--- a/tests/group.test.ts
+++ b/tests/group.test.ts
@@ -76,3 +76,13 @@ test("should parse layout padding", () => {
   expect(parsed.paddingX).toBe(2)
   expect(parsed.paddingY).toBe(1)
 })
+
+test("should parse schTitle", () => {
+  const raw: BaseGroupProps = {
+    name: "g",
+    schTitle: "My Group",
+  }
+
+  const parsed = baseGroupProps.parse(raw)
+  expect(parsed.schTitle).toBe("My Group")
+})


### PR DESCRIPTION
## Summary
- allow groups to include a schematic title
- document the new `schTitle` prop
- regenerate component docs
- test parsing of `schTitle`

## Testing
- `bun test tests/group.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_685987fea860832ebb4e92b52de784af