### PR TITLE
Add bridged option for solder jumper

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,6 +698,10 @@ export interface SolderJumperProps extends JumperProps {
    * Pins that are bridged with solder by default
    */
   bridgedPins?: string[][]
+  /**
+   * If true, all pins are bridged with cuttable traces
+   */
+  bridged?: boolean
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1644,12 +1644,14 @@ export const polygonSmtPadProps = pcbLayoutProps
 ```typescript
 export interface SolderJumperProps extends JumperProps {
   bridgedPins?: string[][]
+  bridged?: boolean
 }
 /**
    * Pins that are bridged with solder by default
    */
 export const solderjumperProps = jumperProps.extend({
   bridgedPins: z.array(z.array(z.string())).optional(),
+  bridged: z.boolean().optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -833,6 +833,10 @@ export interface SolderJumperProps extends JumperProps {
    * Pins that are bridged with solder by default
    */
   bridgedPins?: string[][]
+  /**
+   * If true, all pins are bridged with cuttable traces
+   */
+  bridged?: boolean
 }
 
 

--- a/lib/components/solderjumper.ts
+++ b/lib/components/solderjumper.ts
@@ -7,10 +7,15 @@ export interface SolderJumperProps extends JumperProps {
    * Pins that are bridged with solder by default
    */
   bridgedPins?: string[][]
+  /**
+   * If true, all pins are connected with cuttable traces
+   */
+  bridged?: boolean
 }
 
 export const solderjumperProps = jumperProps.extend({
   bridgedPins: z.array(z.array(z.string())).optional(),
+  bridged: z.boolean().optional(),
 })
 
 type InferredSolderJumperProps = z.input<typeof solderjumperProps>

--- a/tests/solderjumper.test.ts
+++ b/tests/solderjumper.test.ts
@@ -36,6 +36,24 @@ test("should parse solderjumper with multiple bridges", () => {
   ])
 })
 
+test("should parse solderjumper with all pins bridged", () => {
+  const rawProps: SolderJumperProps = {
+    name: "solderjumper",
+    bridged: true,
+  }
+  const parsed = solderjumperProps.parse(rawProps)
+  expect(parsed.bridged).toBe(true)
+})
+
+test("should parse solderjumper with bridged set to false", () => {
+  const rawProps: SolderJumperProps = {
+    name: "solderjumper",
+    bridged: false,
+  }
+  const parsed = solderjumperProps.parse(rawProps)
+  expect(parsed.bridged).toBe(false)
+})
+
 test("should fail for invalid bridgedPins", () => {
   expect(() =>
     solderjumperProps.parse({


### PR DESCRIPTION
## Summary
- add `bridged` boolean to `SolderJumperProps`
- document new option in README and generated docs
- test parsing of `bridged`

## Testing
- `bun test tests/solderjumper.test.ts`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_685ae7501954832ebbef470bdf37ce77