### PR TITLE
Add board info fields to platform config

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,6 +839,11 @@ export interface PlatformConfig {
 
   cloudAutorouterUrl?: string
 
+  projectName?: string
+  version?: string
+  url?: string
+  printBoardInformationToSilkscreen?: boolean
+
   pcbDisabled?: boolean
   schematicDisabled?: boolean
   partsEngineDisabled?: boolean

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -19,6 +19,11 @@ export interface PlatformConfig {
 
   cloudAutorouterUrl?: string
 
+  projectName?: string
+  version?: string
+  url?: string
+  printBoardInformationToSilkscreen?: boolean
+
   pcbDisabled?: boolean
   schematicDisabled?: boolean
   partsEngineDisabled?: boolean
@@ -47,6 +52,10 @@ export const platformConfig = z.object({
   autorouter: autorouterProp.optional(),
   registryApiUrl: z.string().optional(),
   cloudAutorouterUrl: z.string().optional(),
+  projectName: z.string().optional(),
+  version: z.string().optional(),
+  url: z.string().optional(),
+  printBoardInformationToSilkscreen: z.boolean().optional(),
   localCacheEngine: z.any().optional(),
   pcbDisabled: z.boolean().optional(),
   schematicDisabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- add board information fields to `PlatformConfig`
- document board information options in the README

## Testing
- `bun run format:check`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_685c43ad803c8327bd6edf6e494fe20e