### PR TITLE
Add pinAttributes base prop with typing

### DIFF
--- a/lib/common/layout.ts
+++ b/lib/common/layout.ts
@@ -70,9 +70,11 @@ export const supplierProps = z.object({
 
 expectTypesMatch<SupplierProps, z.input<typeof supplierProps>>(true)
 
-export interface CommonComponentProps extends CommonLayoutProps {
+export interface CommonComponentProps<PinLabel extends string = string>
+  extends CommonLayoutProps {
   key?: any
   name: string
+  pinAttributes?: Record<PinLabel, Record<string, any>>
   supplierPartNumbers?: SupplierPartNumbers
   cadModel?: CadModelProp
   children?: any
@@ -89,6 +91,9 @@ export const commonComponentProps = commonLayoutProps
     children: z.any().optional(),
     symbolName: z.string().optional(),
     doNotPlace: z.boolean().optional(),
+    pinAttributes: z
+      .record(z.string(), z.record(z.string(), z.any()))
+      .optional(),
   })
 
 type InferredCommonComponentProps = z.input<typeof commonComponentProps>

--- a/lib/components/battery.ts
+++ b/lib/components/battery.ts
@@ -28,7 +28,8 @@ const capacity = z
   })
   .describe("Battery capacity in mAh")
 
-export interface BatteryProps extends CommonComponentProps {
+export interface BatteryProps
+  extends CommonComponentProps<(typeof batteryPins)[number]> {
   capacity?: number | string
   schOrientation?: SchematicOrientation
 }

--- a/lib/components/capacitor.ts
+++ b/lib/components/capacitor.ts
@@ -23,7 +23,8 @@ export const capacitorPinLabels = [
 ] as const
 export type CapacitorPinLabels = (typeof capacitorPinLabels)[number]
 
-export interface CapacitorProps extends CommonComponentProps {
+export interface CapacitorProps
+  extends CommonComponentProps<CapacitorPinLabels> {
   capacitance: number | string
   maxVoltageRating?: number | string
   schShowRatings?: boolean

--- a/lib/components/chip.ts
+++ b/lib/components/chip.ts
@@ -33,7 +33,7 @@ export interface PinCompatibleVariant {
 }
 
 export interface ChipPropsSU<PinLabel extends string = string>
-  extends CommonComponentProps {
+  extends CommonComponentProps<PinLabel> {
   manufacturerPartNumber?: string
   pinLabels?: PinLabelsProp<string, PinLabel>
   /**

--- a/lib/components/crystal.ts
+++ b/lib/components/crystal.ts
@@ -13,7 +13,7 @@ import { z } from "zod"
 
 export type PinVariant = "two_pin" | "four_pin"
 
-export interface CrystalProps extends CommonComponentProps {
+export interface CrystalProps extends CommonComponentProps<CrystalPinLabels> {
   frequency: number | string
   loadCapacitance: number | string
   pinVariant?: PinVariant
@@ -27,6 +27,7 @@ export const crystalProps = commonComponentProps.extend({
   schOrientation: schematicOrientation.optional(),
 })
 export const crystalPins = lrPins
+export type CrystalPinLabels = (typeof crystalPins)[number]
 
 type InferredCrystalProps = z.input<typeof crystalProps>
 expectTypesMatch<CrystalProps, InferredCrystalProps>(true)

--- a/lib/components/diode.ts
+++ b/lib/components/diode.ts
@@ -100,8 +100,9 @@ export const diodeProps = commonComponentProps
   })
 
 export const diodePins = lrPolarPins
+export type DiodePinLabels = (typeof diodePins)[number]
 
-export interface DiodeProps extends CommonComponentProps {
+export interface DiodeProps extends CommonComponentProps<DiodePinLabels> {
   connections?: {
     anode?: string | string[] | readonly string[]
     cathode?: string | string[] | readonly string[]

--- a/lib/components/fuse.ts
+++ b/lib/components/fuse.ts
@@ -16,7 +16,7 @@ export const fusePinLabels = ["pin1", "pin2"] as const
 
 export type FusePinLabels = (typeof fusePinLabels)[number]
 
-export interface FuseProps extends CommonComponentProps {
+export interface FuseProps extends CommonComponentProps<FusePinLabels> {
   /**
    * Current rating of the fuse in amperes
    */

--- a/lib/components/inductor.ts
+++ b/lib/components/inductor.ts
@@ -11,7 +11,7 @@ import {
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
-export interface InductorProps extends CommonComponentProps {
+export interface InductorProps extends CommonComponentProps<InductorPinLabels> {
   inductance: number | string
   maxCurrentRating?: number | string
   schOrientation?: SchematicOrientation
@@ -24,6 +24,7 @@ export const inductorProps = commonComponentProps.extend({
 })
 
 export const inductorPins = lrPins
+export type InductorPinLabels = (typeof inductorPins)[number]
 
 type InferredInductorProps = z.input<typeof inductorProps>
 

--- a/lib/components/mosfet.ts
+++ b/lib/components/mosfet.ts
@@ -5,7 +5,7 @@ import {
 import { expectTypesMatch } from "../typecheck"
 import { z } from "zod"
 
-export interface MosfetProps extends CommonComponentProps {
+export interface MosfetProps extends CommonComponentProps<MosfetPinLabels> {
   channelType: "n" | "p"
   mosfetMode: "enhancement" | "depletion"
 }
@@ -23,6 +23,7 @@ export const mosfetPins = [
   "pin3",
   "gate",
 ] as const
+export type MosfetPinLabels = (typeof mosfetPins)[number]
 
 type InferredMosfetProps = z.input<typeof mosfetProps>
 expectTypesMatch<MosfetProps, InferredMosfetProps>(true)

--- a/lib/components/resistor.ts
+++ b/lib/components/resistor.ts
@@ -16,7 +16,7 @@ import { z } from "zod"
 export const resistorPinLabels = ["pin1", "pin2", "pos", "neg"] as const
 export type ResistorPinLabels = (typeof resistorPinLabels)[number]
 
-export interface ResistorProps extends CommonComponentProps {
+export interface ResistorProps extends CommonComponentProps<ResistorPinLabels> {
   resistance: number | string
   pullupFor?: string
   pullupTo?: string

--- a/lib/components/transistor.ts
+++ b/lib/components/transistor.ts
@@ -5,7 +5,8 @@ import {
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
-export interface TransistorProps extends CommonComponentProps {
+export interface TransistorProps
+  extends CommonComponentProps<TransistorPinLabels> {
   type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet" | "igbt"
 }
 
@@ -21,6 +22,7 @@ export const transistorPins = [
   "pin3",
   "base",
 ] as const
+export type TransistorPinLabels = (typeof transistorPins)[number]
 
 type InferredTransistorProps = z.input<typeof transistorProps>
 expectTypesMatch<TransistorProps, InferredTransistorProps>(true)

--- a/tests/chip3-type-tests.test.tsx
+++ b/tests/chip3-type-tests.test.tsx
@@ -137,3 +137,21 @@ test(`[typetest] ChipConnections<ChipProps<"custompin1" | "custompin2">>`, () =>
     { custompin1: string; custompin2: string }
   >(true)
 })
+
+test("[typetest] pinAttributes type matches pin labels", () => {
+  const MyChip = (props: ChipProps<typeof pinLabels1>) => <chip {...props} />
+
+  const element = (
+    <MyChip
+      name="U1"
+      pinLabels={pinLabels1}
+      pinAttributes={{
+        VCC: { providesPower: true },
+        GND: { requiresPower: true },
+        // @ts-expect-error
+        INVALID: { foo: true },
+      }}
+    />
+  )
+  void element
+})


### PR DESCRIPTION
## Summary
- extend `CommonComponentProps` with new optional `pinAttributes` field
- propagate pin label generics to several component prop interfaces
- ensure `chip` type tests cover `pinAttributes`

## Testing
- `bun test`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_685c0d09a330832eb870c92932e77738