### PR TITLE
Add connectsTo to NetProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
 ### BatteryProps `<battery />`
 
 ```ts
-export interface BatteryProps extends CommonComponentProps {
+export interface BatteryProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   capacity?: number | string
   schOrientation?: SchematicOrientation
 }
@@ -188,7 +189,8 @@ export interface BreakoutPointProps
 ### CapacitorProps `<capacitor />`
 
 ```ts
-export interface CapacitorProps extends CommonComponentProps {
+export interface CapacitorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   capacitance: number | string
   maxVoltageRating?: number | string
   schShowRatings?: boolean
@@ -210,7 +212,7 @@ export interface CapacitorProps extends CommonComponentProps {
 
 ```ts
 export interface ChipPropsSU<PinLabel extends string = string>
-  extends CommonComponentProps {
+  extends CommonComponentProps<PinLabel> {
   manufacturerPartNumber?: string
   pinLabels?: PinLabelsProp<string, PinLabel>
   /**
@@ -278,7 +280,8 @@ export interface ConstrainedLayoutProps {
 ### CrystalProps `<crystal />`
 
 ```ts
-export interface CrystalProps extends CommonComponentProps {
+export interface CrystalProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   frequency: number | string
   loadCapacitance: number | string
   pinVariant?: PinVariant
@@ -307,7 +310,8 @@ export interface RectCutoutProps
 ### DiodeProps `<diode />`
 
 ```ts
-export interface DiodeProps extends CommonComponentProps {
+export interface DiodeProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   connections?: {
     anode?: string | string[] | readonly string[]
     cathode?: string | string[] | readonly string[]
@@ -353,7 +357,8 @@ export interface FootprintProps {
 ### FuseProps `<fuse />`
 
 ```ts
-export interface FuseProps extends CommonComponentProps {
+export interface FuseProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   /**
    * Current rating of the fuse in amperes
    */
@@ -374,7 +379,7 @@ export interface FuseProps extends CommonComponentProps {
   /**
    * Connections to other components
    */
-  connections?: Connections<FusePinLabels>
+  connections?: Connections<PinLabel>
 }
 ```
 
@@ -430,7 +435,8 @@ export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
 ### InductorProps `<inductor />`
 
 ```ts
-export interface InductorProps extends CommonComponentProps {
+export interface InductorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   inductance: number | string
   maxCurrentRating?: number | string
   schOrientation?: SchematicOrientation
@@ -474,7 +480,8 @@ export interface JumperProps extends CommonComponentProps {
 ### MosfetProps `<mosfet />`
 
 ```ts
-export interface MosfetProps extends CommonComponentProps {
+export interface MosfetProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   channelType: "n" | "p"
   mosfetMode: "enhancement" | "depletion"
 }
@@ -488,6 +495,7 @@ export interface MosfetProps extends CommonComponentProps {
 ```ts
 export interface NetProps {
   name: string
+  connectsTo?: string | string[]
 }
 ```
 
@@ -648,7 +656,8 @@ export interface PotentiometerProps extends CommonComponentProps {
 ### ResistorProps `<resistor />`
 
 ```ts
-export interface ResistorProps extends CommonComponentProps {
+export interface ResistorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   resistance: number | string
   pullupFor?: string
   pullupTo?: string
@@ -699,7 +708,7 @@ export interface SolderJumperProps extends JumperProps {
    */
   bridgedPins?: string[][]
   /**
-   * If true, all pins are bridged with cuttable traces
+   * If true, all pins are connected with cuttable traces
    */
   bridged?: boolean
 }
@@ -795,7 +804,8 @@ export interface TestpointProps extends CommonComponentProps {
 ### TransistorProps `<transistor />`
 
 ```ts
-export interface TransistorProps extends CommonComponentProps {
+export interface TransistorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet" | "igbt"
 }
 ```

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -130,9 +130,11 @@ export interface SupplierProps {
 export const supplierProps = z.object({
   supplierPartNumbers: z.record(supplier_name, z.array(z.string())).optional(),
 })
-export interface CommonComponentProps extends CommonLayoutProps {
+export interface CommonComponentProps<PinLabel extends string = string>
+  extends CommonLayoutProps {
   key?: any
   name: string
+  pinAttributes?: Record<PinLabel, Record<string, any>>
   supplierPartNumbers?: SupplierPartNumbers
   cadModel?: CadModelProp
   children?: any
@@ -146,6 +148,9 @@ export interface CommonComponentProps extends CommonLayoutProps {
     children: z.any().optional(),
     symbolName: z.string().optional(),
     doNotPlace: z.boolean().optional(),
+    pinAttributes: z
+      .record(z.string(), z.record(z.string(), z.any()))
+      .optional(),
   })
 export const lrPolarPins = [
   "pin1",
@@ -282,7 +287,8 @@ export const schematicPinStyle = z.record(
 
 ```typescript
 /** @deprecated use battery_capacity from circuit-json when circuit-json is updated */
-export interface BatteryProps extends CommonComponentProps {
+export interface BatteryProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   capacity?: number | string
   schOrientation?: SchematicOrientation
 }
@@ -358,7 +364,8 @@ export const capacitorPinLabels = [
   "anode",
   "cathode",
 ] as const
-export interface CapacitorProps extends CommonComponentProps {
+export interface CapacitorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   capacitance: number | string
   maxVoltageRating?: number | string
   schShowRatings?: boolean
@@ -394,7 +401,7 @@ export interface PinCompatibleVariant {
   supplierPartNumber?: SupplierPartNumbers
 }
 export interface ChipPropsSU<PinLabel extends string = string>
-  extends CommonComponentProps {
+  extends CommonComponentProps<PinLabel> {
   manufacturerPartNumber?: string
   pinLabels?: PinLabelsProp<string, PinLabel>
   showPinAliases?: boolean
@@ -580,7 +587,8 @@ export const pcbSameXConstraintProps = z.object({
 ### crystal
 
 ```typescript
-export interface CrystalProps extends CommonComponentProps {
+export interface CrystalProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   frequency: number | string
   loadCapacitance: number | string
   pinVariant?: PinVariant
@@ -662,7 +670,8 @@ export const polygonCutoutProps = pcbLayoutProps
     tvs: z.boolean().optional(),
     schOrientation: schematicOrientation.optional(),
   })
-export interface DiodeProps extends CommonComponentProps {
+export interface DiodeProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   connections?: {
     anode?: string | string[] | readonly string[]
     cathode?: string | string[] | readonly string[]
@@ -731,7 +740,8 @@ export const footprintProps = z.object({
 ### fuse
 
 ```typescript
-export interface FuseProps extends CommonComponentProps {
+export interface FuseProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   currentRating: number | string
 
   voltageRating?: number | string
@@ -740,7 +750,7 @@ export interface FuseProps extends CommonComponentProps {
 
   schOrientation?: SchematicOrientation
 
-  connections?: Connections<FusePinLabels>
+  connections?: Connections<PinLabel>
 }
 /**
  * Schema for validating fuse props
@@ -986,7 +996,8 @@ export const holeProps = pcbLayoutProps
 ### inductor
 
 ```typescript
-export interface InductorProps extends CommonComponentProps {
+export interface InductorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   inductance: number | string
   maxCurrentRating?: number | string
   schOrientation?: SchematicOrientation
@@ -1045,13 +1056,15 @@ export const ledProps = commonComponentProps.extend({
   wavelength: z.string().optional(),
   schDisplayValue: z.string().optional(),
   schOrientation: schematicOrientation.optional(),
+  connections: createConnectionsProp(lrPolarPins).optional(),
 })
 ```
 
 ### mosfet
 
 ```typescript
-export interface MosfetProps extends CommonComponentProps {
+export interface MosfetProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   channelType: "n" | "p"
   mosfetMode: "enhancement" | "depletion"
 }
@@ -1074,9 +1087,11 @@ export const mosfetPins = [
 ```typescript
 export interface NetProps {
   name: string
+  connectsTo?: string | string[]
 }
 export const netProps = z.object({
   name: z.string(),
+  connectsTo: z.string().or(z.array(z.string())).optional(),
 })
 ```
 
@@ -1387,7 +1402,8 @@ export const powerSourceProps = commonComponentProps.extend({
 ### resistor
 
 ```typescript
-export interface ResistorProps extends CommonComponentProps {
+export interface ResistorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   resistance: number | string
   pullupFor?: string
   pullupTo?: string
@@ -1647,7 +1663,7 @@ export interface SolderJumperProps extends JumperProps {
   bridged?: boolean
 }
 /**
-   * Pins that are bridged with solder by default
+   * If true, all pins are connected with cuttable traces
    */
 export const solderjumperProps = jumperProps.extend({
   bridgedPins: z.array(z.array(z.string())).optional(),
@@ -1799,7 +1815,8 @@ baseTraceProps.extend({
 ### transistor
 
 ```typescript
-export interface TransistorProps extends CommonComponentProps {
+export interface TransistorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet" | "igbt"
 }
 export const transistorProps = commonComponentProps.extend({

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-06-23T17:02:17.759Z
+> Generated at 2025-07-01T17:01:48.260Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -64,7 +64,8 @@ export interface BaseManualEditEvent {
 }
 
 
-export interface BatteryProps extends CommonComponentProps {
+export interface BatteryProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   capacity?: number | string
   schOrientation?: SchematicOrientation
 }
@@ -132,7 +133,8 @@ export interface CadModelStl extends CadModelBase {
 }
 
 
-export interface CapacitorProps extends CommonComponentProps {
+export interface CapacitorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   capacitance: number | string
   maxVoltageRating?: number | string
   schShowRatings?: boolean
@@ -148,7 +150,7 @@ export interface CapacitorProps extends CommonComponentProps {
 
 
 export interface ChipPropsSU<PinLabel extends string = string>
-  extends CommonComponentProps {
+  extends CommonComponentProps<PinLabel> {
   manufacturerPartNumber?: string
   pinLabels?: PinLabelsProp<string, PinLabel>
   /**
@@ -218,9 +220,11 @@ export interface CircularHoleWithRectPlatedProps
 }
 
 
-export interface CommonComponentProps extends CommonLayoutProps {
+export interface CommonComponentProps<PinLabel extends string = string>
+  extends CommonLayoutProps {
   key?: any
   name: string
+  pinAttributes?: Record<PinLabel, Record<string, any>>
   supplierPartNumbers?: SupplierPartNumbers
   cadModel?: CadModelProp
   children?: any
@@ -271,7 +275,8 @@ export interface ConstrainedLayoutProps {
 }
 
 
-export interface CrystalProps extends CommonComponentProps {
+export interface CrystalProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   frequency: number | string
   loadCapacitance: number | string
   pinVariant?: PinVariant
@@ -279,7 +284,8 @@ export interface CrystalProps extends CommonComponentProps {
 }
 
 
-export interface DiodeProps extends CommonComponentProps {
+export interface DiodeProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   connections?: {
     anode?: string | string[] | readonly string[]
     cathode?: string | string[] | readonly string[]
@@ -358,7 +364,8 @@ export interface FootprintProps {
 }
 
 
-export interface FuseProps extends CommonComponentProps {
+export interface FuseProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   /**
    * Current rating of the fuse in amperes
    */
@@ -379,7 +386,7 @@ export interface FuseProps extends CommonComponentProps {
   /**
    * Connections to other components
    */
-  connections?: Connections<FusePinLabels>
+  connections?: Connections<PinLabel>
 }
 
 
@@ -390,7 +397,8 @@ export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
 }
 
 
-export interface InductorProps extends CommonComponentProps {
+export interface InductorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   inductance: number | string
   maxCurrentRating?: number | string
   schOrientation?: SchematicOrientation
@@ -485,7 +493,8 @@ export interface ManualTraceHint {
 }
 
 
-export interface MosfetProps extends CommonComponentProps {
+export interface MosfetProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   channelType: "n" | "p"
   mosfetMode: "enhancement" | "depletion"
 }
@@ -514,6 +523,7 @@ export interface NetLabelProps {
 
 export interface NetProps {
   name: string
+  connectsTo?: string | string[]
 }
 
 
@@ -709,6 +719,11 @@ export interface PlatformConfig {
 
   cloudAutorouterUrl?: string
 
+  projectName?: string
+  version?: string
+  url?: string
+  printBoardInformationToSilkscreen?: boolean
+
   pcbDisabled?: boolean
   schematicDisabled?: boolean
   partsEngineDisabled?: boolean
@@ -775,7 +790,8 @@ export interface RectSolderPasteProps
 }
 
 
-export interface ResistorProps extends CommonComponentProps {
+export interface ResistorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   resistance: number | string
   pullupFor?: string
   pullupTo?: string
@@ -834,7 +850,7 @@ export interface SolderJumperProps extends JumperProps {
    */
   bridgedPins?: string[][]
   /**
-   * If true, all pins are bridged with cuttable traces
+   * If true, all pins are connected with cuttable traces
    */
   bridged?: boolean
 }
@@ -928,7 +944,8 @@ export interface TestpointProps extends CommonComponentProps {
 }
 
 
-export interface TransistorProps extends CommonComponentProps {
+export interface TransistorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet" | "igbt"
 }
 

--- a/lib/components/net.ts
+++ b/lib/components/net.ts
@@ -3,10 +3,12 @@ import { expectTypesMatch } from "lib/typecheck"
 
 export interface NetProps {
   name: string
+  connectsTo?: string | string[]
 }
 
 export const netProps = z.object({
   name: z.string(),
+  connectsTo: z.string().or(z.array(z.string())).optional(),
 })
 
 type InferredNetProps = z.input<typeof netProps>

--- a/tests/net.test.ts
+++ b/tests/net.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test"
+import { netProps, type NetProps } from "lib/components/net"
+import { expectTypeOf } from "expect-type"
+import { z } from "zod"
+
+test("should parse NetProps with connectsTo", () => {
+  const raw: NetProps = {
+    name: "N1",
+    connectsTo: ["U1.1", "U2.2"],
+  }
+
+  expectTypeOf(raw).toMatchTypeOf<z.input<typeof netProps>>()
+
+  const parsed = netProps.parse(raw)
+  expect(parsed.name).toBe("N1")
+  expect(parsed.connectsTo).toEqual(["U1.1", "U2.2"])
+})


### PR DESCRIPTION
## Summary
- introduce `connectsTo` property for `<net>`
- document new property
- regenerate docs
- add tests for parsing `connectsTo` on nets

## Testing
- `bun test tests/net.test.ts`
- `bun test tests/via.test.ts tests/platedhole.test.ts tests/net.test.ts`
- `bun run format`
- `bun update --latest expect-type` *(fails: GET https://registry.npmjs.org/expect-type - 403)*

------
https://chatgpt.com/codex/tasks/task_b_686413c296c4832e97242036b3c4f264