### PR TITLE
Add autorouter preset options

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -899,6 +899,12 @@ export interface AutorouterConfig {
   groupMode?: "sequential-trace" | "subcircuit"
   local?: boolean
   algorithmFn?: (simpleRouteJson: any) => Promise<any>
+  preset?:
+    | "sequential-trace"
+    | "subcircuit"
+    | "auto"
+    | "auto-local"
+    | "auto-cloud"
 }
 export const autorouterConfig = z.object({
   serverUrl: z.string().optional(),
@@ -912,6 +918,15 @@ export const autorouterConfig = z.object({
     .custom<(simpleRouteJson: any) => Promise<any>>(
       (v) => typeof v === "function" || v === undefined,
     )
+    .optional(),
+  preset: z
+    .enum([
+      "sequential-trace",
+      "subcircuit",
+      "auto",
+      "auto-local",
+      "auto-cloud",
+    ])
     .optional(),
   local: z.boolean().optional(),
 })

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-07-04T14:41:45.180Z
+> Generated at 2025-07-04T22:23:07.403Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -28,6 +28,12 @@ export interface AutorouterConfig {
   groupMode?: "sequential-trace" | "subcircuit"
   local?: boolean
   algorithmFn?: (simpleRouteJson: any) => Promise<any>
+  preset?:
+    | "sequential-trace"
+    | "subcircuit"
+    | "auto"
+    | "auto-local"
+    | "auto-cloud"
 }
 
 

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -147,6 +147,12 @@ export interface AutorouterConfig {
   groupMode?: "sequential-trace" | "subcircuit"
   local?: boolean
   algorithmFn?: (simpleRouteJson: any) => Promise<any>
+  preset?:
+    | "sequential-trace"
+    | "subcircuit"
+    | "auto"
+    | "auto-local"
+    | "auto-cloud"
 }
 
 export type AutorouterProp =
@@ -169,6 +175,15 @@ export const autorouterConfig = z.object({
     .custom<(simpleRouteJson: any) => Promise<any>>(
       (v) => typeof v === "function" || v === undefined,
     )
+    .optional(),
+  preset: z
+    .enum([
+      "sequential-trace",
+      "subcircuit",
+      "auto",
+      "auto-local",
+      "auto-cloud",
+    ])
     .optional(),
   local: z.boolean().optional(),
 })


### PR DESCRIPTION
## Summary
- extend `AutorouterConfig` with `preset` options
- update generated docs accordingly

## Testing
- `bun test`
- `npx biome format . --write`

------
https://chatgpt.com/codex/tasks/task_b_686853cbe8988327bc5707db627ec7fa