### PR TITLE
Allow connections by pin number in ChipProps

### DIFF
--- a/lib/components/chip.ts
+++ b/lib/components/chip.ts
@@ -57,7 +57,7 @@ export interface ChipPropsSU<PinLabel extends string = string>
 export type ChipProps<PinLabelMap extends PinLabelsProp | string = string> =
   ChipPropsSU<
     PinLabelMap extends PinLabelsProp
-      ? PinLabelFromPinLabelMap<PinLabelMap>
+      ? PinLabelFromPinLabelMap<PinLabelMap> | (keyof PinLabelMap & string)
       : PinLabelMap
   >
 

--- a/tests/chip3-type-tests.test.tsx
+++ b/tests/chip3-type-tests.test.tsx
@@ -155,3 +155,21 @@ test("[typetest] pinAttributes type matches pin labels", () => {
   )
   void element
 })
+
+test("[typetest] connections can reference pin numbers", () => {
+  const myPinLabels = {
+    pin1: "A",
+    pin2: "B",
+  } as const
+
+  const MyChip = (props: ChipProps<typeof myPinLabels>) => <chip {...props} />
+
+  const byLabel = (
+    <MyChip name="U1" pinLabels={myPinLabels} connections={{ A: "net.A" }} />
+  )
+  const byNumber = (
+    <MyChip name="U1" pinLabels={myPinLabels} connections={{ pin2: "net.B" }} />
+  )
+  void byLabel
+  void byNumber
+})


### PR DESCRIPTION
## Summary
- allow `<chip>` components to specify connections using either pin numbers or labels
- cover connections by pin number in type tests

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_686ed13bce6c833190be2a37af9ab91b