### PR TITLE
Add pcbPinLabels prop

### DIFF
--- a/lib/common/layout.ts
+++ b/lib/common/layout.ts
@@ -75,6 +75,7 @@ export interface CommonComponentProps<PinLabel extends string = string>
   key?: any
   name: string
   pinAttributes?: Record<PinLabel, Record<string, any>>
+  pcbPinLabels?: Record<string, PinLabel>
   supplierPartNumbers?: SupplierPartNumbers
   cadModel?: CadModelProp
   children?: any
@@ -94,6 +95,7 @@ export const commonComponentProps = commonLayoutProps
     pinAttributes: z
       .record(z.string(), z.record(z.string(), z.any()))
       .optional(),
+    pcbPinLabels: z.record(z.string(), z.string()).optional(),
   })
 
 type InferredCommonComponentProps = z.input<typeof commonComponentProps>

--- a/tests/chip1-basic.test.ts
+++ b/tests/chip1-basic.test.ts
@@ -177,3 +177,12 @@ test("should work with generic type parameter for pin labels", () => {
     SIG2: [".LED1 > .anode", ".C1 > .pin1"],
   })
 })
+
+test("should parse pcbPinLabels", () => {
+  const rawProps: ChipProps = {
+    name: "chip",
+    pcbPinLabels: { pin3: "B", pin2: "A", pin1: "G" },
+  }
+  const parsed = chipProps.parse(rawProps)
+  expect(parsed.pcbPinLabels).toEqual({ pin3: "B", pin2: "A", pin1: "G" })
+})


### PR DESCRIPTION
## Summary
- add new `pcbPinLabels` common component prop
- cover chip parsing with pcbPinLabels in tests

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/chip1-basic.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test`


------
https://chatgpt.com/codex/tasks/task_b_686fcdc015b4832e83457fd0fb6241ac