### PR TITLE
Add prettier step to README generation script

### DIFF
--- a/scripts/generate-readme-docs.ts
+++ b/scripts/generate-readme-docs.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { execSync } from "node:child_process"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -293,5 +294,8 @@ readmeContent = readmeContent.replace(
 
 // Write back to README
 fs.writeFileSync(readmePath, readmeContent)
+
+// Format the README using prettier
+execSync("bunx prettier --write README.md", { stdio: "inherit" })
 
 console.log("README documentation updated successfully!")


### PR DESCRIPTION
## Summary
- run prettier inside `scripts/generate-readme-docs.ts` after writing the README

## Testing
- `bun run scripts/generate-readme-docs.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_688289687d78832eac9150773e2dc799