### PR TITLE
Add relative layout flags

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -95,7 +95,12 @@ export interface PcbLayoutProps {
   pcbY?: string | number
   pcbRotation?: string | number
   layer?: LayerRefInput
+  pcbRelative?: boolean
+  relative?: boolean
 }
+/**
+   * If true, both pcb and schematic coordinates will be interpreted relative to the parent group
+   */
 export interface CommonLayoutProps {
   pcbX?: string | number
   pcbY?: string | number
@@ -107,12 +112,23 @@ export interface CommonLayoutProps {
 
   layer?: LayerRefInput
   footprint?: FootprintProp
+
+  relative?: boolean
+
+  schRelative?: boolean
+
+  pcbRelative?: boolean
 }
+/**
+   * If true, pcbX/pcbY will be interpreted relative to the parent group
+   */
 export const pcbLayoutProps = z.object({
   pcbX: distance.optional(),
   pcbY: distance.optional(),
   pcbRotation: rotation.optional(),
   layer: layer_ref.optional(),
+  pcbRelative: z.boolean().optional(),
+  relative: z.boolean().optional(),
 })
 export const commonLayoutProps = z.object({
   pcbX: distance.optional(),
@@ -123,6 +139,9 @@ export const commonLayoutProps = z.object({
   schRotation: rotation.optional(),
   layer: layer_ref.optional(),
   footprint: footprintProp.optional(),
+  relative: z.boolean().optional(),
+  schRelative: z.boolean().optional(),
+  pcbRelative: z.boolean().optional(),
 })
 export interface SupplierProps {
   supplierPartNumbers?: SupplierPartNumbers
@@ -792,7 +811,7 @@ export const fuseProps = commonComponentProps.extend({
 
 ```typescript
 export const layoutConfig = z.object({
-  layoutMode: z.enum(["grid", "flex", "match-adapt", "none"]).optional(),
+  layoutMode: z.enum(["grid", "flex", "match-adapt", "relative", "none"]).optional(),
   position: z.enum(["absolute", "relative"]).optional(),
 
   grid: z.boolean().optional(),
@@ -806,10 +825,29 @@ export const layoutConfig = z.object({
   flex: z.boolean().or(z.string()).optional(),
   flexDirection: z.enum(["row", "column"]).optional(),
   alignItems: z.enum(["start", "center", "end", "stretch"]).optional(),
-  justifyContent: z.enum(["start", "center", "end", "stretch"]).optional(),
+  justifyContent: z
+    .enum([
+      "start",
+      "center",
+      "end",
+      "stretch",
+      "space-between",
+      "space-around",
+      "space-evenly",
+    ])
+    .optional(),
   flexRow: z.boolean().optional(),
   flexColumn: z.boolean().optional(),
   gap: z.number().or(z.string()).optional(),
+
+  pack: z
+    .boolean()
+    .optional()
+    .describe("Pack the contents of this group using a packing strategy"),
+  packOrderStrategy: z.enum(["largest_to_smallest"]).optional(),
+  packPlacementStrategy: z
+    .enum(["shortest_connection_along_outline"])
+    .optional(),
 
   padding: length.optional(),
   paddingLeft: length.optional(),
@@ -826,7 +864,7 @@ export const layoutConfig = z.object({
   matchAdaptTemplate: z.any().optional(),
 })
 export interface LayoutConfig {
-  layoutMode?: "grid" | "flex" | "match-adapt" | "none"
+  layoutMode?: "grid" | "flex" | "match-adapt" | "relative" | "none"
   position?: "absolute" | "relative"
 
   grid?: boolean
@@ -840,10 +878,21 @@ export interface LayoutConfig {
   flex?: boolean | string
   flexDirection?: "row" | "column"
   alignItems?: "start" | "center" | "end" | "stretch"
-  justifyContent?: "start" | "center" | "end" | "stretch"
+  justifyContent?:
+    | "start"
+    | "center"
+    | "end"
+    | "stretch"
+    | "space-between"
+    | "space-around"
+    | "space-evenly"
   flexRow?: boolean
   flexColumn?: boolean
   gap?: number | string
+
+  pack?: boolean
+  packOrderStrategy?: "largest_to_smallest"
+  packPlacementStrategy?: "shortest_connection_along_outline"
 
   padding?: Distance
   paddingLeft?: Distance

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-07-23T04:29:29.055Z
+> Generated at 2025-07-24T19:30:46.888Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -251,6 +251,21 @@ export interface CommonLayoutProps {
 
   layer?: LayerRefInput
   footprint?: FootprintProp
+
+  /**
+   * If true, X/Y coordinates will be interpreted relative to the parent group
+   */
+  relative?: boolean
+
+  /**
+   * If true, schX/schY will be interpreted relative to the parent group
+   */
+  schRelative?: boolean
+
+  /**
+   * If true, pcbX/pcbY will be interpreted relative to the parent group
+   */
+  pcbRelative?: boolean
 }
 
 
@@ -449,7 +464,7 @@ export interface JumperProps extends CommonComponentProps {
 
 
 export interface LayoutConfig {
-  layoutMode?: "grid" | "flex" | "match-adapt" | "none"
+  layoutMode?: "grid" | "flex" | "match-adapt" | "relative" | "none"
   position?: "absolute" | "relative"
 
   grid?: boolean
@@ -463,10 +478,21 @@ export interface LayoutConfig {
   flex?: boolean | string
   flexDirection?: "row" | "column"
   alignItems?: "start" | "center" | "end" | "stretch"
-  justifyContent?: "start" | "center" | "end" | "stretch"
+  justifyContent?:
+    | "start"
+    | "center"
+    | "end"
+    | "stretch"
+    | "space-between"
+    | "space-around"
+    | "space-evenly"
   flexRow?: boolean
   flexColumn?: boolean
   gap?: number | string
+
+  pack?: boolean
+  packOrderStrategy?: "largest_to_smallest"
+  packPlacementStrategy?: "shortest_connection_along_outline"
 
   padding?: Distance
   paddingLeft?: Distance
@@ -573,6 +599,14 @@ export interface PcbLayoutProps {
   pcbY?: string | number
   pcbRotation?: string | number
   layer?: LayerRefInput
+  /**
+   * If true, pcbX/pcbY will be interpreted relative to the parent group
+   */
+  pcbRelative?: boolean
+  /**
+   * If true, both pcb and schematic coordinates will be interpreted relative to the parent group
+   */
+  relative?: boolean
 }
 
 

--- a/lib/common/layout.ts
+++ b/lib/common/layout.ts
@@ -15,6 +15,14 @@ export interface PcbLayoutProps {
   pcbY?: string | number
   pcbRotation?: string | number
   layer?: LayerRefInput
+  /**
+   * If true, pcbX/pcbY will be interpreted relative to the parent group
+   */
+  pcbRelative?: boolean
+  /**
+   * If true, both pcb and schematic coordinates will be interpreted relative to the parent group
+   */
+  relative?: boolean
 }
 
 export interface CommonLayoutProps {
@@ -28,6 +36,21 @@ export interface CommonLayoutProps {
 
   layer?: LayerRefInput
   footprint?: FootprintProp
+
+  /**
+   * If true, X/Y coordinates will be interpreted relative to the parent group
+   */
+  relative?: boolean
+
+  /**
+   * If true, schX/schY will be interpreted relative to the parent group
+   */
+  schRelative?: boolean
+
+  /**
+   * If true, pcbX/pcbY will be interpreted relative to the parent group
+   */
+  pcbRelative?: boolean
 }
 
 export const pcbLayoutProps = z.object({
@@ -35,6 +58,8 @@ export const pcbLayoutProps = z.object({
   pcbY: distance.optional(),
   pcbRotation: rotation.optional(),
   layer: layer_ref.optional(),
+  pcbRelative: z.boolean().optional(),
+  relative: z.boolean().optional(),
 })
 type InferredPcbLayoutProps = z.input<typeof pcbLayoutProps>
 expectTypesMatch<PcbLayoutProps, InferredPcbLayoutProps>(true)
@@ -48,6 +73,9 @@ export const commonLayoutProps = z.object({
   schRotation: rotation.optional(),
   layer: layer_ref.optional(),
   footprint: footprintProp.optional(),
+  relative: z.boolean().optional(),
+  schRelative: z.boolean().optional(),
+  pcbRelative: z.boolean().optional(),
 })
 
 type InferredCommonLayoutProps = z.input<typeof commonLayoutProps>

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -16,7 +16,9 @@ import {
 } from "lib/manual-edits"
 
 export const layoutConfig = z.object({
-  layoutMode: z.enum(["grid", "flex", "match-adapt", "none"]).optional(),
+  layoutMode: z
+    .enum(["grid", "flex", "match-adapt", "relative", "none"])
+    .optional(),
   position: z.enum(["absolute", "relative"]).optional(),
 
   grid: z.boolean().optional(),
@@ -70,7 +72,7 @@ export const layoutConfig = z.object({
 })
 
 export interface LayoutConfig {
-  layoutMode?: "grid" | "flex" | "match-adapt" | "none"
+  layoutMode?: "grid" | "flex" | "match-adapt" | "relative" | "none"
   position?: "absolute" | "relative"
 
   grid?: boolean

--- a/tests/group.test.ts
+++ b/tests/group.test.ts
@@ -86,3 +86,27 @@ test("should parse schTitle", () => {
   const parsed = baseGroupProps.parse(raw)
   expect(parsed.schTitle).toBe("My Group")
 })
+
+test("should parse relative flags", () => {
+  const raw: BaseGroupProps = {
+    name: "g",
+    relative: true,
+    schRelative: true,
+    pcbRelative: true,
+  }
+
+  const parsed = baseGroupProps.parse(raw)
+  expect(parsed.relative).toBe(true)
+  expect(parsed.schRelative).toBe(true)
+  expect(parsed.pcbRelative).toBe(true)
+})
+
+test("should parse relative layout mode", () => {
+  const raw: BaseGroupProps = {
+    name: "g",
+    layoutMode: "relative",
+  }
+
+  const parsed = baseGroupProps.parse(raw)
+  expect(parsed.layoutMode).toBe("relative")
+})


### PR DESCRIPTION
## Summary
- support `relative` layout mode in group layout config
- document the new layout mode
- test parsing of `relative` layout mode

## Testing
- `bun test tests/group.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68828549f398832e85d2237775a5c94c