### PR TITLE
Add layers prop to board

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ export interface BatteryProps<PinLabel extends string = string>
 ```ts
 export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   material?: "fr4" | "fr1";
+  layers?: 2 | 4;
 }
 ```
 

--- a/lib/components/board.ts
+++ b/lib/components/board.ts
@@ -4,10 +4,13 @@ import { subcircuitGroupProps, type SubcircuitGroupProps } from "./group"
 
 export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   material?: "fr4" | "fr1"
+  /** Number of layers for the PCB */
+  layers?: 2 | 4
 }
 
 export const boardProps = subcircuitGroupProps.extend({
   material: z.enum(["fr4", "fr1"]).default("fr4"),
+  layers: z.union([z.literal(2), z.literal(4)]).default(2),
 })
 
 type InferredBoardProps = z.input<typeof boardProps>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/react": "^18.3.2",
     "ava": "^6.1.3",
     "circuit-json": "^0.0.186",
-    "expect-type": "^0.20.0",
+    "expect-type": "^1.2.2",
     "glob": "^11.0.0",
     "madge": "^8.0.0",
     "prettier": "^3.3.3",

--- a/tests/board.test.ts
+++ b/tests/board.test.ts
@@ -15,3 +15,9 @@ test("should parse square and area props", () => {
   expect(parsed.emptyArea).toBe("20%")
   expect(parsed.filledArea).toBe("30%")
 })
+
+test("should parse layers prop", () => {
+  const raw: BoardProps = { name: "board", layers: 4 }
+  const parsed = boardProps.parse(raw)
+  expect(parsed.layers).toBe(4)
+})


### PR DESCRIPTION
## Summary
- add `layers` option in `BoardProps` with `2` or `4` as allowed values
- test board `layers` option
- update documentation
- upgrade `expect-type` dev dependency

## Testing
- `bun test tests/board.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_6882d5a26780832eba03c2c9561d7006