### PR TITLE
Add additional packOrderStrategy enums

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -336,9 +336,12 @@ export const batteryProps = commonComponentProps.extend({
 ```typescript
 export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   material?: "fr4" | "fr1"
+  layers?: 2 | 4
 }
+/** Number of layers for the PCB */
 export const boardProps = subcircuitGroupProps.extend({
   material: z.enum(["fr4", "fr1"]).default("fr4"),
+  layers: z.union([z.literal(2), z.literal(4)]).default(2),
 })
 ```
 
@@ -811,7 +814,9 @@ export const fuseProps = commonComponentProps.extend({
 
 ```typescript
 export const layoutConfig = z.object({
-  layoutMode: z.enum(["grid", "flex", "match-adapt", "relative", "none"]).optional(),
+  layoutMode: z
+    .enum(["grid", "flex", "match-adapt", "relative", "none"])
+    .optional(),
   position: z.enum(["absolute", "relative"]).optional(),
 
   grid: z.boolean().optional(),
@@ -844,7 +849,9 @@ export const layoutConfig = z.object({
     .boolean()
     .optional()
     .describe("Pack the contents of this group using a packing strategy"),
-  packOrderStrategy: z.enum(["largest_to_smallest"]).optional(),
+  packOrderStrategy: z
+    .enum(["largest_to_smallest", "first_to_last", "highest_to_lowest_pin_count"])
+    .optional(),
   packPlacementStrategy: z
     .enum(["shortest_connection_along_outline"])
     .optional(),
@@ -891,7 +898,10 @@ export interface LayoutConfig {
   gap?: number | string
 
   pack?: boolean
-  packOrderStrategy?: "largest_to_smallest"
+  packOrderStrategy?:
+    | "largest_to_smallest"
+    | "first_to_last"
+    | "highest_to_lowest_pin_count"
   packPlacementStrategy?: "shortest_connection_along_outline"
 
   padding?: Distance

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-07-24T19:30:46.888Z
+> Generated at 2025-07-26T21:59:11.159Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -80,6 +80,8 @@ export interface BatteryProps<PinLabel extends string = string>
 
 export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   material?: "fr4" | "fr1"
+  /** Number of layers for the PCB */
+  layers?: 2 | 4
 }
 
 
@@ -491,7 +493,10 @@ export interface LayoutConfig {
   gap?: number | string
 
   pack?: boolean
-  packOrderStrategy?: "largest_to_smallest"
+  packOrderStrategy?:
+    | "largest_to_smallest"
+    | "first_to_last"
+    | "highest_to_lowest_pin_count"
   packPlacementStrategy?: "shortest_connection_along_outline"
 
   padding?: Distance

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -51,7 +51,13 @@ export const layoutConfig = z.object({
     .boolean()
     .optional()
     .describe("Pack the contents of this group using a packing strategy"),
-  packOrderStrategy: z.enum(["largest_to_smallest"]).optional(),
+  packOrderStrategy: z
+    .enum([
+      "largest_to_smallest",
+      "first_to_last",
+      "highest_to_lowest_pin_count",
+    ])
+    .optional(),
   packPlacementStrategy: z
     .enum(["shortest_connection_along_outline"])
     .optional(),
@@ -99,7 +105,10 @@ export interface LayoutConfig {
   gap?: number | string
 
   pack?: boolean
-  packOrderStrategy?: "largest_to_smallest"
+  packOrderStrategy?:
+    | "largest_to_smallest"
+    | "first_to_last"
+    | "highest_to_lowest_pin_count"
   packPlacementStrategy?: "shortest_connection_along_outline"
 
   padding?: Distance

--- a/tests/group.test.ts
+++ b/tests/group.test.ts
@@ -110,3 +110,19 @@ test("should parse relative layout mode", () => {
   const parsed = baseGroupProps.parse(raw)
   expect(parsed.layoutMode).toBe("relative")
 })
+
+test("should parse new packOrderStrategy enums", () => {
+  const rawFirst: BaseGroupProps = {
+    name: "g",
+    packOrderStrategy: "first_to_last",
+  }
+  const parsedFirst = baseGroupProps.parse(rawFirst)
+  expect(parsedFirst.packOrderStrategy).toBe("first_to_last")
+
+  const rawHighest: BaseGroupProps = {
+    name: "g",
+    packOrderStrategy: "highest_to_lowest_pin_count",
+  }
+  const parsedHighest = baseGroupProps.parse(rawHighest)
+  expect(parsedHighest.packOrderStrategy).toBe("highest_to_lowest_pin_count")
+})


### PR DESCRIPTION
## Summary
- support `first_to_last` and `highest_to_lowest_pin_count` pack order strategies
- update generated documentation
- test new enum values

## Testing
- `bun test tests/group.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68854ed24950832e9b70d407bf60a400