### PR TITLE
Add pcb layout group props

### DIFF
--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -164,6 +164,34 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   schPaddingRight?: Distance
   schPaddingTop?: Distance
   schPaddingBottom?: Distance
+
+  /** @deprecated Use `pcbGrid` */
+  grid?: boolean
+  /** @deprecated Use `pcbFlex` */
+  flex?: boolean | string
+
+  pcbGrid?: boolean
+  pcbGridCols?: number | string
+  pcbGridRows?: number | string
+  pcbGridTemplateRows?: string
+  pcbGridTemplateColumns?: string
+  pcbGridTemplate?: string
+  pcbGridGap?: number | string
+
+  pcbFlex?: boolean | string
+  pcbFlexDirection?: "row" | "column"
+  pcbAlignItems?: "start" | "center" | "end" | "stretch"
+  pcbJustifyContent?:
+    | "start"
+    | "center"
+    | "end"
+    | "stretch"
+    | "space-between"
+    | "space-around"
+    | "space-evenly"
+  pcbFlexRow?: boolean
+  pcbFlexColumn?: boolean
+  pcbGap?: number | string
 }
 
 export type PartsEngine = {
@@ -292,6 +320,32 @@ export const baseGroupProps = commonLayoutProps.extend({
   key: z.any().optional(),
 
   ...layoutConfig.shape,
+  grid: layoutConfig.shape.grid.describe("@deprecated use pcbGrid"),
+  flex: layoutConfig.shape.flex.describe("@deprecated use pcbFlex"),
+  pcbGrid: z.boolean().optional(),
+  pcbGridCols: z.number().or(z.string()).optional(),
+  pcbGridRows: z.number().or(z.string()).optional(),
+  pcbGridTemplateRows: z.string().optional(),
+  pcbGridTemplateColumns: z.string().optional(),
+  pcbGridTemplate: z.string().optional(),
+  pcbGridGap: z.number().or(z.string()).optional(),
+  pcbFlex: z.boolean().or(z.string()).optional(),
+  pcbFlexDirection: z.enum(["row", "column"]).optional(),
+  pcbAlignItems: z.enum(["start", "center", "end", "stretch"]).optional(),
+  pcbJustifyContent: z
+    .enum([
+      "start",
+      "center",
+      "end",
+      "stretch",
+      "space-between",
+      "space-around",
+      "space-evenly",
+    ])
+    .optional(),
+  pcbFlexRow: z.boolean().optional(),
+  pcbFlexColumn: z.boolean().optional(),
+  pcbGap: z.number().or(z.string()).optional(),
   pcbWidth: length.optional(),
   pcbHeight: length.optional(),
   schWidth: length.optional(),

--- a/tests/group.test.ts
+++ b/tests/group.test.ts
@@ -126,3 +126,20 @@ test("should parse new packOrderStrategy enums", () => {
   const parsedHighest = baseGroupProps.parse(rawHighest)
   expect(parsedHighest.packOrderStrategy).toBe("highest_to_lowest_pin_count")
 })
+
+test("should parse pcb layout props", () => {
+  const raw: BaseGroupProps = {
+    name: "g",
+    pcbGrid: true,
+    pcbGridCols: 2,
+    pcbGridGap: "1mm",
+    pcbFlex: true,
+    pcbGap: "2mm",
+  }
+  const parsed = baseGroupProps.parse(raw)
+  expect(parsed.pcbGrid).toBe(true)
+  expect(parsed.pcbGridCols).toBe(2)
+  expect(parsed.pcbGridGap).toBe("1mm")
+  expect(parsed.pcbFlex).toBe(true)
+  expect(parsed.pcbGap).toBe("2mm")
+})


### PR DESCRIPTION
## Summary
- extend `BaseGroupProps` with pcb layout props
- flag `grid` and `flex` as deprecated
- test parsing of new pcb layout props

## Testing
- `bun test tests/group.test.ts`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68868b2986bc832e861900b416aa8d63