### PR TITLE
Add 'unpopulated' pin header gender

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,9 +553,9 @@ export interface PinHeaderProps extends CommonComponentProps {
   schFacingDirection?: "up" | "down" | "left" | "right";
 
   /**
-   * Whether the header is male or female
+   * Whether the header is male, female, or unpopulated
    */
-  gender?: "male" | "female";
+  gender?: "male" | "female" | "unpopulated";
 
   /**
    * Whether to show pin labels in silkscreen

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1291,7 +1291,7 @@ export interface PinHeaderProps extends CommonComponentProps {
 
   schFacingDirection?: "up" | "down" | "left" | "right"
 
-  gender?: "male" | "female"
+  gender?: "male" | "female" | "unpopulated"
 
   showSilkscreenPinLabels?: boolean
 
@@ -1326,7 +1326,10 @@ export const pinHeaderProps = commonComponentProps.extend({
   pinCount: z.number(),
   pitch: distance.optional(),
   schFacingDirection: z.enum(["up", "down", "left", "right"]).optional(),
-  gender: z.enum(["male", "female"]).optional().default("male"),
+  gender: z
+    .enum(["male", "female", "unpopulated"])
+    .optional()
+    .default("male"),
   showSilkscreenPinLabels: z.boolean().optional(),
   pcbPinLabels: z.record(z.string(), z.string()).optional(),
   doubleRow: z.boolean().optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -698,9 +698,9 @@ export interface PinHeaderProps extends CommonComponentProps {
   schFacingDirection?: "up" | "down" | "left" | "right"
 
   /**
-   * Whether the header is male or female
+   * Whether the header is male, female, or unpopulated
    */
-  gender?: "male" | "female"
+  gender?: "male" | "female" | "unpopulated"
 
   /**
    * Whether to show pin labels in silkscreen

--- a/lib/components/pin-header.ts
+++ b/lib/components/pin-header.ts
@@ -37,9 +37,9 @@ export interface PinHeaderProps extends CommonComponentProps {
   schFacingDirection?: "up" | "down" | "left" | "right"
 
   /**
-   * Whether the header is male or female
+   * Whether the header is male, female, or unpopulated
    */
-  gender?: "male" | "female"
+  gender?: "male" | "female" | "unpopulated"
 
   /**
    * Whether to show pin labels in silkscreen
@@ -111,7 +111,7 @@ export const pinHeaderProps = commonComponentProps.extend({
   pinCount: z.number(),
   pitch: distance.optional(),
   schFacingDirection: z.enum(["up", "down", "left", "right"]).optional(),
-  gender: z.enum(["male", "female"]).optional().default("male"),
+  gender: z.enum(["male", "female", "unpopulated"]).optional().default("male"),
   showSilkscreenPinLabels: z.boolean().optional(),
   pcbPinLabels: z.record(z.string(), z.string()).optional(),
   doubleRow: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- expand pin header `gender` property to include `unpopulated`
- update docs and generated docs with new gender option
- keep default gender as `male`

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/pin-header.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_6886a46034c4832e8058f4a1010eaf8c