### PR TITLE
Add rightAngle optional prop to PinHeader

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,11 @@ export interface PinHeaderProps extends CommonComponentProps {
   doubleRow?: boolean;
 
   /**
+   * If true, the header is a right-angle style connector
+   */
+  rightAngle?: boolean;
+
+  /**
    * Diameter of the through-hole for each pin
    */
   holeDiameter?: number | string;

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -850,7 +850,11 @@ export const layoutConfig = z.object({
     .optional()
     .describe("Pack the contents of this group using a packing strategy"),
   packOrderStrategy: z
-    .enum(["largest_to_smallest", "first_to_last", "highest_to_lowest_pin_count"])
+    .enum([
+      "largest_to_smallest",
+      "first_to_last",
+      "highest_to_lowest_pin_count",
+    ])
     .optional(),
   packPlacementStrategy: z
     .enum(["shortest_connection_along_outline"])
@@ -949,10 +953,34 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   schPaddingRight?: Distance
   schPaddingTop?: Distance
   schPaddingBottom?: Distance
+
+  grid?: boolean
+  flex?: boolean | string
+
+  pcbGrid?: boolean
+  pcbGridCols?: number | string
+  pcbGridRows?: number | string
+  pcbGridTemplateRows?: string
+  pcbGridTemplateColumns?: string
+  pcbGridTemplate?: string
+  pcbGridGap?: number | string
+
+  pcbFlex?: boolean | string
+  pcbFlexDirection?: "row" | "column"
+  pcbAlignItems?: "start" | "center" | "end" | "stretch"
+  pcbJustifyContent?:
+    | "start"
+    | "center"
+    | "end"
+    | "stretch"
+    | "space-between"
+    | "space-around"
+    | "space-evenly"
+  pcbFlexRow?: boolean
+  pcbFlexColumn?: boolean
+  pcbGap?: number | string
 }
-/**
-   * Title to display above this group in the schematic view
-   */
+/** @deprecated Use `pcbFlex` */
 export type PartsEngine = {
   findPart: (params: {
     sourceComponent: AnySourceComponent
@@ -1043,6 +1071,32 @@ export const baseGroupProps = commonLayoutProps.extend({
   key: z.any().optional(),
 
   ...layoutConfig.shape,
+  grid: layoutConfig.shape.grid.describe("@deprecated use pcbGrid"),
+  flex: layoutConfig.shape.flex.describe("@deprecated use pcbFlex"),
+  pcbGrid: z.boolean().optional(),
+  pcbGridCols: z.number().or(z.string()).optional(),
+  pcbGridRows: z.number().or(z.string()).optional(),
+  pcbGridTemplateRows: z.string().optional(),
+  pcbGridTemplateColumns: z.string().optional(),
+  pcbGridTemplate: z.string().optional(),
+  pcbGridGap: z.number().or(z.string()).optional(),
+  pcbFlex: z.boolean().or(z.string()).optional(),
+  pcbFlexDirection: z.enum(["row", "column"]).optional(),
+  pcbAlignItems: z.enum(["start", "center", "end", "stretch"]).optional(),
+  pcbJustifyContent: z
+    .enum([
+      "start",
+      "center",
+      "end",
+      "stretch",
+      "space-between",
+      "space-around",
+      "space-evenly",
+    ])
+    .optional(),
+  pcbFlexRow: z.boolean().optional(),
+  pcbFlexColumn: z.boolean().optional(),
+  pcbGap: z.number().or(z.string()).optional(),
   pcbWidth: length.optional(),
   pcbHeight: length.optional(),
   schWidth: length.optional(),
@@ -1299,6 +1353,8 @@ export interface PinHeaderProps extends CommonComponentProps {
 
   doubleRow?: boolean
 
+  rightAngle?: boolean
+
   holeDiameter?: number | string
 
   platedDiameter?: number | string
@@ -1326,13 +1382,11 @@ export const pinHeaderProps = commonComponentProps.extend({
   pinCount: z.number(),
   pitch: distance.optional(),
   schFacingDirection: z.enum(["up", "down", "left", "right"]).optional(),
-  gender: z
-    .enum(["male", "female", "unpopulated"])
-    .optional()
-    .default("male"),
+  gender: z.enum(["male", "female", "unpopulated"]).optional().default("male"),
   showSilkscreenPinLabels: z.boolean().optional(),
   pcbPinLabels: z.record(z.string(), z.string()).optional(),
   doubleRow: z.boolean().optional(),
+  rightAngle: z.boolean().optional(),
   holeDiameter: distance.optional(),
   platedDiameter: distance.optional(),
   pinLabels: z.array(schematicPinLabel).optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-07-26T21:59:11.159Z
+> Generated at 2025-07-28T00:31:57.052Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -61,6 +61,34 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   schPaddingRight?: Distance
   schPaddingTop?: Distance
   schPaddingBottom?: Distance
+
+  /** @deprecated Use `pcbGrid` */
+  grid?: boolean
+  /** @deprecated Use `pcbFlex` */
+  flex?: boolean | string
+
+  pcbGrid?: boolean
+  pcbGridCols?: number | string
+  pcbGridRows?: number | string
+  pcbGridTemplateRows?: string
+  pcbGridTemplateColumns?: string
+  pcbGridTemplate?: string
+  pcbGridGap?: number | string
+
+  pcbFlex?: boolean | string
+  pcbFlexDirection?: "row" | "column"
+  pcbAlignItems?: "start" | "center" | "end" | "stretch"
+  pcbJustifyContent?:
+    | "start"
+    | "center"
+    | "end"
+    | "stretch"
+    | "space-between"
+    | "space-around"
+    | "space-evenly"
+  pcbFlexRow?: boolean
+  pcbFlexColumn?: boolean
+  pcbGap?: number | string
 }
 
 
@@ -716,6 +744,11 @@ export interface PinHeaderProps extends CommonComponentProps {
    * Whether the header has two rows of pins
    */
   doubleRow?: boolean
+
+  /**
+   * If true, the header is a right-angle style connector
+   */
+  rightAngle?: boolean
 
   /**
    * Diameter of the through-hole for each pin

--- a/lib/components/pin-header.ts
+++ b/lib/components/pin-header.ts
@@ -57,6 +57,11 @@ export interface PinHeaderProps extends CommonComponentProps {
   doubleRow?: boolean
 
   /**
+   * If true, the header is a right-angle style connector
+   */
+  rightAngle?: boolean
+
+  /**
    * Diameter of the through-hole for each pin
    */
   holeDiameter?: number | string
@@ -115,6 +120,7 @@ export const pinHeaderProps = commonComponentProps.extend({
   showSilkscreenPinLabels: z.boolean().optional(),
   pcbPinLabels: z.record(z.string(), z.string()).optional(),
   doubleRow: z.boolean().optional(),
+  rightAngle: z.boolean().optional(),
   holeDiameter: distance.optional(),
   platedDiameter: distance.optional(),
   pinLabels: z.array(schematicPinLabel).optional(),

--- a/tests/pin-header.test.ts
+++ b/tests/pin-header.test.ts
@@ -48,6 +48,16 @@ test("should allow optional connections", () => {
   expect(parsed.connections).toBeUndefined()
 })
 
+test("should parse rightAngle property", () => {
+  const rawProps: PinHeaderProps = {
+    name: "header",
+    pinCount: 2,
+    rightAngle: true,
+  }
+  const parsed = pinHeaderProps.parse(rawProps)
+  expect(parsed.rightAngle).toBe(true)
+})
+
 test("should snapshot schematic props for pin header", () => {
   const rawProps: PinHeaderProps = {
     name: "header",


### PR DESCRIPTION
## Summary
- add `rightAngle` field to `PinHeaderProps`
- update zod schema for pin header
- regenerate docs
- test parsing of new prop

## Testing
- `bun test tests/pin-header.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_6886c45286f0832eb7e06051ef80edb3