### PR TITLE
Add grid gaps to layout config, add pcbFlex

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbGridTemplateColumns?: string;
   pcbGridTemplate?: string;
   pcbGridGap?: number | string;
+  pcbGridRowGap?: number | string;
+  pcbGridColumnGap?: number | string;
 
   pcbFlex?: boolean | string;
   pcbFlexDirection?: "row" | "column";

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -826,6 +826,8 @@ export const layoutConfig = z.object({
   gridTemplateColumns: z.string().optional(),
   gridTemplate: z.string().optional(),
   gridGap: z.number().or(z.string()).optional(),
+  gridRowGap: z.number().or(z.string()).optional(),
+  gridColumnGap: z.number().or(z.string()).optional(),
 
   flex: z.boolean().or(z.string()).optional(),
   flexDirection: z.enum(["row", "column"]).optional(),
@@ -885,6 +887,8 @@ export interface LayoutConfig {
   gridTemplateColumns?: string
   gridTemplate?: string
   gridGap?: number | string
+  gridRowGap?: number | string
+  gridColumnGap?: number | string
 
   flex?: boolean | string
   flexDirection?: "row" | "column"
@@ -964,6 +968,8 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbGridTemplateColumns?: string
   pcbGridTemplate?: string
   pcbGridGap?: number | string
+  pcbGridRowGap?: number | string
+  pcbGridColumnGap?: number | string
 
   pcbFlex?: boolean | string
   pcbFlexDirection?: "row" | "column"
@@ -1080,6 +1086,8 @@ export const baseGroupProps = commonLayoutProps.extend({
   pcbGridTemplateColumns: z.string().optional(),
   pcbGridTemplate: z.string().optional(),
   pcbGridGap: z.number().or(z.string()).optional(),
+  pcbGridRowGap: z.number().or(z.string()).optional(),
+  pcbGridColumnGap: z.number().or(z.string()).optional(),
   pcbFlex: z.boolean().or(z.string()).optional(),
   pcbFlexDirection: z.enum(["row", "column"]).optional(),
   pcbAlignItems: z.enum(["start", "center", "end", "stretch"]).optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-07-28T00:31:57.052Z
+> Generated at 2025-07-28T00:46:56.418Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -74,6 +74,8 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbGridTemplateColumns?: string
   pcbGridTemplate?: string
   pcbGridGap?: number | string
+  pcbGridRowGap?: number | string
+  pcbGridColumnGap?: number | string
 
   pcbFlex?: boolean | string
   pcbFlexDirection?: "row" | "column"
@@ -504,6 +506,8 @@ export interface LayoutConfig {
   gridTemplateColumns?: string
   gridTemplate?: string
   gridGap?: number | string
+  gridRowGap?: number | string
+  gridColumnGap?: number | string
 
   flex?: boolean | string
   flexDirection?: "row" | "column"

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -28,6 +28,8 @@ export const layoutConfig = z.object({
   gridTemplateColumns: z.string().optional(),
   gridTemplate: z.string().optional(),
   gridGap: z.number().or(z.string()).optional(),
+  gridRowGap: z.number().or(z.string()).optional(),
+  gridColumnGap: z.number().or(z.string()).optional(),
 
   flex: z.boolean().or(z.string()).optional(),
   flexDirection: z.enum(["row", "column"]).optional(),
@@ -88,6 +90,8 @@ export interface LayoutConfig {
   gridTemplateColumns?: string
   gridTemplate?: string
   gridGap?: number | string
+  gridRowGap?: number | string
+  gridColumnGap?: number | string
 
   flex?: boolean | string
   flexDirection?: "row" | "column"
@@ -177,6 +181,8 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbGridTemplateColumns?: string
   pcbGridTemplate?: string
   pcbGridGap?: number | string
+  pcbGridRowGap?: number | string
+  pcbGridColumnGap?: number | string
 
   pcbFlex?: boolean | string
   pcbFlexDirection?: "row" | "column"
@@ -329,6 +335,8 @@ export const baseGroupProps = commonLayoutProps.extend({
   pcbGridTemplateColumns: z.string().optional(),
   pcbGridTemplate: z.string().optional(),
   pcbGridGap: z.number().or(z.string()).optional(),
+  pcbGridRowGap: z.number().or(z.string()).optional(),
+  pcbGridColumnGap: z.number().or(z.string()).optional(),
   pcbFlex: z.boolean().or(z.string()).optional(),
   pcbFlexDirection: z.enum(["row", "column"]).optional(),
   pcbAlignItems: z.enum(["start", "center", "end", "stretch"]).optional(),

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -198,6 +198,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbFlexRow?: boolean
   pcbFlexColumn?: boolean
   pcbGap?: number | string
+  pcbPack?: boolean
 }
 
 export type PartsEngine = {
@@ -354,6 +355,7 @@ export const baseGroupProps = commonLayoutProps.extend({
   pcbFlexRow: z.boolean().optional(),
   pcbFlexColumn: z.boolean().optional(),
   pcbGap: z.number().or(z.string()).optional(),
+  pcbPack: z.boolean().optional(),
   pcbWidth: length.optional(),
   pcbHeight: length.optional(),
   schWidth: length.optional(),

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "tsup": "^8.0.2",
     "tsx": "^4.10.2",
     "typescript": "^5.4.5",
-    "zod": "^4.0.10"
+    "zod": "3"
   },
   "peerDependencies": {
     "circuit-json": "*",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "tsup": "^8.0.2",
     "tsx": "^4.10.2",
     "typescript": "^5.4.5",
-    "zod": "^3.23.8"
+    "zod": "^4.0.10"
   },
   "peerDependencies": {
     "circuit-json": "*",

--- a/tests/group.test.ts
+++ b/tests/group.test.ts
@@ -133,6 +133,8 @@ test("should parse pcb layout props", () => {
     pcbGrid: true,
     pcbGridCols: 2,
     pcbGridGap: "1mm",
+    pcbGridRowGap: 3,
+    pcbGridColumnGap: "2mm",
     pcbFlex: true,
     pcbGap: "2mm",
   }
@@ -140,6 +142,19 @@ test("should parse pcb layout props", () => {
   expect(parsed.pcbGrid).toBe(true)
   expect(parsed.pcbGridCols).toBe(2)
   expect(parsed.pcbGridGap).toBe("1mm")
+  expect(parsed.pcbGridRowGap).toBe(3)
+  expect(parsed.pcbGridColumnGap).toBe("2mm")
   expect(parsed.pcbFlex).toBe(true)
   expect(parsed.pcbGap).toBe("2mm")
+})
+
+test("should parse layout grid gaps", () => {
+  const raw: BaseGroupProps = {
+    name: "g",
+    gridRowGap: "1mm",
+    gridColumnGap: 2,
+  }
+  const parsed = baseGroupProps.parse(raw)
+  expect(parsed.gridRowGap).toBe("1mm")
+  expect(parsed.gridColumnGap).toBe(2)
 })


### PR DESCRIPTION
## Summary
- add `gridRowGap` and `gridColumnGap` to layout config
- expose new PCB grid gap fields on group props
- update generated docs
- bump dev dependency `zod`
- document and test the new props

## Testing
- `bun test tests/group.test.ts`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_6886c7a61e24832ea801fa8cc9c24624