### PR TITLE
Add connections prop to crystal

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ export interface CrystalProps<PinLabel extends string = string>
   loadCapacitance: number | string;
   pinVariant?: PinVariant;
   schOrientation?: SchematicOrientation;
+  connections?: Connections<CrystalPinLabels>;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -628,12 +628,14 @@ export interface CrystalProps<PinLabel extends string = string>
   loadCapacitance: number | string
   pinVariant?: PinVariant
   schOrientation?: SchematicOrientation
+  connections?: Connections<CrystalPinLabels>
 }
 export const crystalProps = commonComponentProps.extend({
   frequency: frequency,
   loadCapacitance: capacitance,
   pinVariant: z.enum(["two_pin", "four_pin"]).optional(),
   schOrientation: schematicOrientation.optional(),
+  connections: createConnectionsProp(crystalPins).optional(),
 })
 ```
 
@@ -972,6 +974,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbGridColumnGap?: number | string
 
   pcbFlex?: boolean | string
+  pcbFlexGap?: number | string
   pcbFlexDirection?: "row" | "column"
   pcbAlignItems?: "start" | "center" | "end" | "stretch"
   pcbJustifyContent?:
@@ -985,6 +988,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbFlexRow?: boolean
   pcbFlexColumn?: boolean
   pcbGap?: number | string
+  pcbPack?: boolean
 }
 /** @deprecated Use `pcbFlex` */
 export type PartsEngine = {
@@ -1089,6 +1093,7 @@ export const baseGroupProps = commonLayoutProps.extend({
   pcbGridRowGap: z.number().or(z.string()).optional(),
   pcbGridColumnGap: z.number().or(z.string()).optional(),
   pcbFlex: z.boolean().or(z.string()).optional(),
+  pcbFlexGap: z.number().or(z.string()).optional(),
   pcbFlexDirection: z.enum(["row", "column"]).optional(),
   pcbAlignItems: z.enum(["start", "center", "end", "stretch"]).optional(),
   pcbJustifyContent: z
@@ -1105,6 +1110,7 @@ export const baseGroupProps = commonLayoutProps.extend({
   pcbFlexRow: z.boolean().optional(),
   pcbFlexColumn: z.boolean().optional(),
   pcbGap: z.number().or(z.string()).optional(),
+  pcbPack: z.boolean().optional(),
   pcbWidth: length.optional(),
   pcbHeight: length.optional(),
   schWidth: length.optional(),
@@ -1438,9 +1444,9 @@ export interface OvalPlatedHoleProps
   innerHeight?: number | string
 }
 /** @deprecated use holeHeight */
-export interface PillPlatedHoleProps
-  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
+export interface PillPlatedHoleProps extends Omit<PcbLayoutProps, "layer"> {
   name?: string
+  rectPad?: boolean
   connectsTo?: string | string[]
   shape: "pill"
   outerWidth: number | string
@@ -1512,10 +1518,11 @@ pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
       innerHeight: distance.optional().describe("DEPRECATED use holeHeight"),
       portHints: portHints.optional(),
     }),
-pcbLayoutProps.omit({ pcbRotation: true, layer: true }).extend({
+pcbLayoutProps.omit({ layer: true }).extend({
       name: z.string().optional(),
       connectsTo: z.string().or(z.array(z.string())).optional(),
       shape: z.literal("pill"),
+      rectPad: z.boolean().optional(),
       outerWidth: distance,
       outerHeight: distance,
       holeWidth: distanceHiddenUndefined,

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-07-28T00:46:56.418Z
+> Generated at 2025-07-31T08:19:04.264Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -78,6 +78,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbGridColumnGap?: number | string
 
   pcbFlex?: boolean | string
+  pcbFlexGap?: number | string
   pcbFlexDirection?: "row" | "column"
   pcbAlignItems?: "start" | "center" | "end" | "stretch"
   pcbJustifyContent?:
@@ -91,6 +92,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbFlexRow?: boolean
   pcbFlexColumn?: boolean
   pcbGap?: number | string
+  pcbPack?: boolean
 }
 
 
@@ -338,6 +340,7 @@ export interface CrystalProps<PinLabel extends string = string>
   loadCapacitance: number | string
   pinVariant?: PinVariant
   schOrientation?: SchematicOrientation
+  connections?: Connections<CrystalPinLabels>
 }
 
 
@@ -653,9 +656,9 @@ export interface PcbRouteCache {
 }
 
 
-export interface PillPlatedHoleProps
-  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
+export interface PillPlatedHoleProps extends Omit<PcbLayoutProps, "layer"> {
   name?: string
+  rectPad?: boolean
   connectsTo?: string | string[]
   shape: "pill"
   outerWidth: number | string

--- a/lib/components/crystal.ts
+++ b/lib/components/crystal.ts
@@ -4,6 +4,8 @@ import {
   commonComponentProps,
   lrPins,
 } from "lib/common/layout"
+import type { Connections } from "lib/utility-types/connections-and-selectors"
+import { createConnectionsProp } from "lib/common/connectionsProp"
 import {
   schematicOrientation,
   type SchematicOrientation,
@@ -13,12 +15,16 @@ import { z } from "zod"
 
 export type PinVariant = "two_pin" | "four_pin"
 
+export const crystalPins = lrPins
+export type CrystalPinLabels = (typeof crystalPins)[number]
+
 export interface CrystalProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   frequency: number | string
   loadCapacitance: number | string
   pinVariant?: PinVariant
   schOrientation?: SchematicOrientation
+  connections?: Connections<CrystalPinLabels>
 }
 
 export const crystalProps = commonComponentProps.extend({
@@ -26,9 +32,8 @@ export const crystalProps = commonComponentProps.extend({
   loadCapacitance: capacitance,
   pinVariant: z.enum(["two_pin", "four_pin"]).optional(),
   schOrientation: schematicOrientation.optional(),
+  connections: createConnectionsProp(crystalPins).optional(),
 })
-export const crystalPins = lrPins
-export type CrystalPinLabels = (typeof crystalPins)[number]
 
 type InferredCrystalProps = z.input<typeof crystalProps>
 expectTypesMatch<CrystalProps, InferredCrystalProps>(true)

--- a/tests/crystal.test.ts
+++ b/tests/crystal.test.ts
@@ -26,3 +26,31 @@ test("should parse crystal props with 4pin variant", () => {
   const parsedProps = crystalProps.parse(rawProps)
   expect(parsedProps.pinVariant).toBe("four_pin")
 })
+
+test("should allow optional connections", () => {
+  const rawProps: CrystalProps = {
+    name: "crystal",
+    frequency: "16MHz",
+    loadCapacitance: "20pF",
+  }
+  const parsedProps = crystalProps.parse(rawProps)
+  expect(parsedProps.connections).toBeUndefined()
+})
+
+test("should parse crystal props with connections", () => {
+  const rawProps: CrystalProps = {
+    name: "crystal",
+    frequency: "16MHz",
+    loadCapacitance: "20pF",
+    connections: {
+      left: "net.CLK_IN",
+      right: "net.CLK_OUT",
+    },
+  }
+
+  const parsedProps = crystalProps.parse(rawProps)
+  expect(parsedProps.connections).toEqual({
+    left: "net.CLK_IN",
+    right: "net.CLK_OUT",
+  })
+})


### PR DESCRIPTION
## Summary
- allow specifying connections for `<crystal />`
- document the new prop in README and generated docs
- test crystal connections parsing

## Testing
- `bunx tsc --noEmit`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_688b2602c3308327b7df9761752934c6