### PR TITLE
Add schematic layout properties for `schFlex`, `schPack` and `schGrid` to group

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,12 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   schPaddingTop?: Distance;
   schPaddingBottom?: Distance;
 
+  pcbPadding?: Distance;
+  pcbPaddingLeft?: Distance;
+  pcbPaddingRight?: Distance;
+  pcbPaddingTop?: Distance;
+  pcbPaddingBottom?: Distance;
+
   /** @deprecated Use `pcbGrid` */
   grid?: boolean;
   /** @deprecated Use `pcbFlex` */
@@ -445,6 +451,34 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbFlexColumn?: boolean;
   pcbGap?: number | string;
   pcbPack?: boolean;
+
+  schGrid?: boolean;
+  schGridCols?: number | string;
+  schGridRows?: number | string;
+  schGridTemplateRows?: string;
+  schGridTemplateColumns?: string;
+  schGridTemplate?: string;
+  schGridGap?: number | string;
+  schGridRowGap?: number | string;
+  schGridColumnGap?: number | string;
+
+  schFlex?: boolean | string;
+  schFlexGap?: number | string;
+  schFlexDirection?: "row" | "column";
+  schAlignItems?: "start" | "center" | "end" | "stretch";
+  schJustifyContent?:
+    | "start"
+    | "center"
+    | "end"
+    | "stretch"
+    | "space-between"
+    | "space-around"
+    | "space-evenly";
+  schFlexRow?: boolean;
+  schFlexColumn?: boolean;
+  schGap?: number | string;
+  schPack?: boolean;
+  schMatchAdapt?: boolean;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -960,6 +960,12 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   schPaddingTop?: Distance
   schPaddingBottom?: Distance
 
+  pcbPadding?: Distance
+  pcbPaddingLeft?: Distance
+  pcbPaddingRight?: Distance
+  pcbPaddingTop?: Distance
+  pcbPaddingBottom?: Distance
+
   grid?: boolean
   flex?: boolean | string
 
@@ -989,6 +995,34 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbFlexColumn?: boolean
   pcbGap?: number | string
   pcbPack?: boolean
+
+  schGrid?: boolean
+  schGridCols?: number | string
+  schGridRows?: number | string
+  schGridTemplateRows?: string
+  schGridTemplateColumns?: string
+  schGridTemplate?: string
+  schGridGap?: number | string
+  schGridRowGap?: number | string
+  schGridColumnGap?: number | string
+
+  schFlex?: boolean | string
+  schFlexGap?: number | string
+  schFlexDirection?: "row" | "column"
+  schAlignItems?: "start" | "center" | "end" | "stretch"
+  schJustifyContent?:
+    | "start"
+    | "center"
+    | "end"
+    | "stretch"
+    | "space-between"
+    | "space-around"
+    | "space-evenly"
+  schFlexRow?: boolean
+  schFlexColumn?: boolean
+  schGap?: number | string
+  schPack?: boolean
+  schMatchAdapt?: boolean
 }
 /** @deprecated Use `pcbFlex` */
 export type PartsEngine = {
@@ -1111,6 +1145,37 @@ export const baseGroupProps = commonLayoutProps.extend({
   pcbFlexColumn: z.boolean().optional(),
   pcbGap: z.number().or(z.string()).optional(),
   pcbPack: z.boolean().optional(),
+
+  schGrid: z.boolean().optional(),
+  schGridCols: z.number().or(z.string()).optional(),
+  schGridRows: z.number().or(z.string()).optional(),
+  schGridTemplateRows: z.string().optional(),
+  schGridTemplateColumns: z.string().optional(),
+  schGridTemplate: z.string().optional(),
+  schGridGap: z.number().or(z.string()).optional(),
+  schGridRowGap: z.number().or(z.string()).optional(),
+  schGridColumnGap: z.number().or(z.string()).optional(),
+
+  schFlex: z.boolean().or(z.string()).optional(),
+  schFlexGap: z.number().or(z.string()).optional(),
+  schFlexDirection: z.enum(["row", "column"]).optional(),
+  schAlignItems: z.enum(["start", "center", "end", "stretch"]).optional(),
+  schJustifyContent: z
+    .enum([
+      "start",
+      "center",
+      "end",
+      "stretch",
+      "space-between",
+      "space-around",
+      "space-evenly",
+    ])
+    .optional(),
+  schFlexRow: z.boolean().optional(),
+  schFlexColumn: z.boolean().optional(),
+  schGap: z.number().or(z.string()).optional(),
+  schPack: z.boolean().optional(),
+  schMatchAdapt: z.boolean().optional(),
   pcbWidth: length.optional(),
   pcbHeight: length.optional(),
   schWidth: length.optional(),
@@ -1124,6 +1189,11 @@ export const baseGroupProps = commonLayoutProps.extend({
   schPaddingRight: length.optional(),
   schPaddingTop: length.optional(),
   schPaddingBottom: length.optional(),
+  pcbPadding: length.optional(),
+  pcbPaddingLeft: length.optional(),
+  pcbPaddingRight: length.optional(),
+  pcbPaddingTop: length.optional(),
+  pcbPaddingBottom: length.optional(),
 })
 export const subcircuitGroupProps = baseGroupProps.extend({
   manualEdits: manual_edits_file.optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-07-31T08:19:04.264Z
+> Generated at 2025-08-01T19:56:01.986Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -62,6 +62,12 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   schPaddingTop?: Distance
   schPaddingBottom?: Distance
 
+  pcbPadding?: Distance
+  pcbPaddingLeft?: Distance
+  pcbPaddingRight?: Distance
+  pcbPaddingTop?: Distance
+  pcbPaddingBottom?: Distance
+
   /** @deprecated Use `pcbGrid` */
   grid?: boolean
   /** @deprecated Use `pcbFlex` */
@@ -93,6 +99,34 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbFlexColumn?: boolean
   pcbGap?: number | string
   pcbPack?: boolean
+
+  schGrid?: boolean
+  schGridCols?: number | string
+  schGridRows?: number | string
+  schGridTemplateRows?: string
+  schGridTemplateColumns?: string
+  schGridTemplate?: string
+  schGridGap?: number | string
+  schGridRowGap?: number | string
+  schGridColumnGap?: number | string
+
+  schFlex?: boolean | string
+  schFlexGap?: number | string
+  schFlexDirection?: "row" | "column"
+  schAlignItems?: "start" | "center" | "end" | "stretch"
+  schJustifyContent?:
+    | "start"
+    | "center"
+    | "end"
+    | "stretch"
+    | "space-between"
+    | "space-around"
+    | "space-evenly"
+  schFlexRow?: boolean
+  schFlexColumn?: boolean
+  schGap?: number | string
+  schPack?: boolean
+  schMatchAdapt?: boolean
 }
 
 

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -169,6 +169,12 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   schPaddingTop?: Distance
   schPaddingBottom?: Distance
 
+  pcbPadding?: Distance
+  pcbPaddingLeft?: Distance
+  pcbPaddingRight?: Distance
+  pcbPaddingTop?: Distance
+  pcbPaddingBottom?: Distance
+
   /** @deprecated Use `pcbGrid` */
   grid?: boolean
   /** @deprecated Use `pcbFlex` */
@@ -200,6 +206,34 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbFlexColumn?: boolean
   pcbGap?: number | string
   pcbPack?: boolean
+
+  schGrid?: boolean
+  schGridCols?: number | string
+  schGridRows?: number | string
+  schGridTemplateRows?: string
+  schGridTemplateColumns?: string
+  schGridTemplate?: string
+  schGridGap?: number | string
+  schGridRowGap?: number | string
+  schGridColumnGap?: number | string
+
+  schFlex?: boolean | string
+  schFlexGap?: number | string
+  schFlexDirection?: "row" | "column"
+  schAlignItems?: "start" | "center" | "end" | "stretch"
+  schJustifyContent?:
+    | "start"
+    | "center"
+    | "end"
+    | "stretch"
+    | "space-between"
+    | "space-around"
+    | "space-evenly"
+  schFlexRow?: boolean
+  schFlexColumn?: boolean
+  schGap?: number | string
+  schPack?: boolean
+  schMatchAdapt?: boolean
 }
 
 export type PartsEngine = {
@@ -358,6 +392,37 @@ export const baseGroupProps = commonLayoutProps.extend({
   pcbFlexColumn: z.boolean().optional(),
   pcbGap: z.number().or(z.string()).optional(),
   pcbPack: z.boolean().optional(),
+
+  schGrid: z.boolean().optional(),
+  schGridCols: z.number().or(z.string()).optional(),
+  schGridRows: z.number().or(z.string()).optional(),
+  schGridTemplateRows: z.string().optional(),
+  schGridTemplateColumns: z.string().optional(),
+  schGridTemplate: z.string().optional(),
+  schGridGap: z.number().or(z.string()).optional(),
+  schGridRowGap: z.number().or(z.string()).optional(),
+  schGridColumnGap: z.number().or(z.string()).optional(),
+
+  schFlex: z.boolean().or(z.string()).optional(),
+  schFlexGap: z.number().or(z.string()).optional(),
+  schFlexDirection: z.enum(["row", "column"]).optional(),
+  schAlignItems: z.enum(["start", "center", "end", "stretch"]).optional(),
+  schJustifyContent: z
+    .enum([
+      "start",
+      "center",
+      "end",
+      "stretch",
+      "space-between",
+      "space-around",
+      "space-evenly",
+    ])
+    .optional(),
+  schFlexRow: z.boolean().optional(),
+  schFlexColumn: z.boolean().optional(),
+  schGap: z.number().or(z.string()).optional(),
+  schPack: z.boolean().optional(),
+  schMatchAdapt: z.boolean().optional(),
   pcbWidth: length.optional(),
   pcbHeight: length.optional(),
   schWidth: length.optional(),
@@ -371,6 +436,11 @@ export const baseGroupProps = commonLayoutProps.extend({
   schPaddingRight: length.optional(),
   schPaddingTop: length.optional(),
   schPaddingBottom: length.optional(),
+  pcbPadding: length.optional(),
+  pcbPaddingLeft: length.optional(),
+  pcbPaddingRight: length.optional(),
+  pcbPaddingTop: length.optional(),
+  pcbPaddingBottom: length.optional(),
 })
 
 export const partsEngine = z.custom<PartsEngine>((v) => "findPart" in v)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tscircuit/props",
-  "version": "0.0.277",
+  "version": "0.0.278",
   "description": "Props for tscircuit builtin component types",
   "main": "dist/index.js",
   "type": "module",

--- a/tests/group.test.ts
+++ b/tests/group.test.ts
@@ -61,6 +61,18 @@ test("should parse schPadding", () => {
   expect(parsed.schPaddingLeft).toBe(2)
 })
 
+test("should parse pcbPadding", () => {
+  const raw: BaseGroupProps = {
+    name: "g",
+    pcbPadding: "1mm",
+    pcbPaddingTop: 2,
+  }
+
+  const parsed = baseGroupProps.parse(raw)
+  expect(parsed.pcbPadding).toBe(1)
+  expect(parsed.pcbPaddingTop).toBe(2)
+})
+
 test("should parse layout padding", () => {
   const raw: BaseGroupProps = {
     name: "g",
@@ -157,4 +169,25 @@ test("should parse layout grid gaps", () => {
   const parsed = baseGroupProps.parse(raw)
   expect(parsed.gridRowGap).toBe("1mm")
   expect(parsed.gridColumnGap).toBe(2)
+})
+
+test("should parse schematic layout props", () => {
+  const raw: BaseGroupProps = {
+    name: "g",
+    schGrid: true,
+    schGridCols: 3,
+    schGridGap: "0.5mm",
+    schFlex: true,
+    schFlexGap: "0.2mm",
+    schPack: true,
+    schMatchAdapt: true,
+  }
+  const parsed = baseGroupProps.parse(raw)
+  expect(parsed.schGrid).toBe(true)
+  expect(parsed.schGridCols).toBe(3)
+  expect(parsed.schGridGap).toBe("0.5mm")
+  expect(parsed.schFlex).toBe(true)
+  expect(parsed.schFlexGap).toBe("0.2mm")
+  expect(parsed.schPack).toBe(true)
+  expect(parsed.schMatchAdapt).toBe(true)
 })


### PR DESCRIPTION
## Summary
- support schematic layout with schGrid/schFlex/schPack/schMatchAdapt props
- merge latest changes from main
- document new props in generated docs and README
- test parsing of schematic layout props

## Testing
- `bun test tests/group.test.ts`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_688d1adfb7d4832eaaf1bbb08084a698