### PR TITLE
feat: add PCB path props to trace

### DIFF
--- a/lib/components/trace.ts
+++ b/lib/components/trace.ts
@@ -14,6 +14,8 @@ const baseTraceProps = z.object({
   thickness: distance.optional(),
   schematicRouteHints: z.array(point).optional(),
   pcbRouteHints: z.array(route_hint_point).optional(),
+  pcbPathRelativeTo: z.string().optional(),
+  pcbPath: z.array(point).optional(),
   schDisplayLabel: z.string().optional(),
   maxLength: distance.optional(),
 })


### PR DESCRIPTION
## Summary
- allow traces to specify a reference and explicit PCB path via `pcbPathRelativeTo` and `pcbPath`

## Testing
- `bun run generate:component-types`
- `bun run generate:readme-docs`
- `bun run format`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests`


------
https://chatgpt.com/codex/tasks/task_b_6894e76c1550832e98185c65e7b6959c