### PR TITLE
feat: add manufacturerPartNumber and mpn to crystal

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ export interface CrystalProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   frequency: number | string;
   loadCapacitance: number | string;
+  manufacturerPartNumber?: string;
+  mpn?: string;
   pinVariant?: PinVariant;
   schOrientation?: SchematicOrientation;
   connections?: Connections<CrystalPinLabels>;

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -626,6 +626,8 @@ export interface CrystalProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   frequency: number | string
   loadCapacitance: number | string
+  manufacturerPartNumber?: string
+  mpn?: string
   pinVariant?: PinVariant
   schOrientation?: SchematicOrientation
   connections?: Connections<CrystalPinLabels>
@@ -633,6 +635,8 @@ export interface CrystalProps<PinLabel extends string = string>
 export const crystalProps = commonComponentProps.extend({
   frequency: frequency,
   loadCapacitance: capacitance,
+  manufacturerPartNumber: z.string().optional(),
+  mpn: z.string().optional(),
   pinVariant: z.enum(["two_pin", "four_pin"]).optional(),
   schOrientation: schematicOrientation.optional(),
   connections: createConnectionsProp(crystalPins).optional(),
@@ -1266,6 +1270,7 @@ export interface JumperProps extends CommonComponentProps {
   schWidth?: number | string
   schHeight?: number | string
   schDirection?: "left" | "right"
+  schPinArrangement?: SchematicPortArrangement
   schPortArrangement?: SchematicPortArrangement
   pcbPinLabels?: Record<string, string>
   pinCount?: 2 | 3
@@ -1288,6 +1293,7 @@ export const jumperProps = commonComponentProps.extend({
   schWidth: distance.optional(),
   schHeight: distance.optional(),
   schDirection: z.enum(["left", "right"]).optional(),
+  schPinArrangement: schematicPinArrangement.optional(),
   schPortArrangement: schematicPortArrangement.optional(),
   pcbPinLabels: z.record(z.string(), z.string()).optional(),
   pinCount: z.union([z.literal(2), z.literal(3)]).optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-08-01T19:56:01.986Z
+> Generated at 2025-08-13T02:57:40.359Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -372,6 +372,8 @@ export interface CrystalProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   frequency: number | string
   loadCapacitance: number | string
+  manufacturerPartNumber?: string
+  mpn?: string
   pinVariant?: PinVariant
   schOrientation?: SchematicOrientation
   connections?: Connections<CrystalPinLabels>
@@ -511,6 +513,10 @@ export interface JumperProps extends CommonComponentProps {
   schWidth?: number | string
   schHeight?: number | string
   schDirection?: "left" | "right"
+  schPinArrangement?: SchematicPortArrangement
+  /**
+   * @deprecated Use schPinArrangement instead.
+   */
   schPortArrangement?: SchematicPortArrangement
   /**
    * Labels for PCB pins

--- a/lib/components/crystal.ts
+++ b/lib/components/crystal.ts
@@ -22,6 +22,8 @@ export interface CrystalProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   frequency: number | string
   loadCapacitance: number | string
+  manufacturerPartNumber?: string
+  mpn?: string
   pinVariant?: PinVariant
   schOrientation?: SchematicOrientation
   connections?: Connections<CrystalPinLabels>
@@ -30,6 +32,8 @@ export interface CrystalProps<PinLabel extends string = string>
 export const crystalProps = commonComponentProps.extend({
   frequency: frequency,
   loadCapacitance: capacitance,
+  manufacturerPartNumber: z.string().optional(),
+  mpn: z.string().optional(),
   pinVariant: z.enum(["two_pin", "four_pin"]).optional(),
   schOrientation: schematicOrientation.optional(),
   connections: createConnectionsProp(crystalPins).optional(),

--- a/tests/crystal.test.ts
+++ b/tests/crystal.test.ts
@@ -15,6 +15,21 @@ test("should parse crystal props with 2pin variant", () => {
   expect(parsedProps.pinVariant).toBe("two_pin")
 })
 
+test("should parse manufacturerPartNumber and mpn", () => {
+  const rawProps: CrystalProps = {
+    name: "crystal",
+    frequency: "16MHz",
+    loadCapacitance: "20pF",
+    manufacturerPartNumber: "1234",
+    mpn: "5678",
+  }
+
+  const parsedProps = crystalProps.parse(rawProps)
+
+  expect(parsedProps.manufacturerPartNumber).toBe("1234")
+  expect(parsedProps.mpn).toBe("5678")
+})
+
 test("should parse crystal props with 4pin variant", () => {
   const rawProps: CrystalProps = {
     name: "crystal",


### PR DESCRIPTION
## Summary
- add manufacturerPartNumber and mpn props to crystal component
- document and test new crystal props

## Testing
- `bun test tests/crystal.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_689bfe9ffefc832e80c43fecc1397965