### PR TITLE
feat: accept numeric internally connected pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ export interface ChipPropsSU<
   schWidth?: Distance;
   schHeight?: Distance;
   noSchematicRepresentation?: boolean;
-  internallyConnectedPins?: string[][];
+  internallyConnectedPins?: (string | number)[][];
   externallyConnectedPins?: string[][];
   connections?: Connections<PinLabel>;
 }
@@ -258,7 +258,7 @@ export interface ConnectorProps extends CommonComponentProps {
    * Groups of pins that are internally connected
    * e.g., [["1","2"], ["2","3"]]
    */
-  internallyConnectedPins?: string[][];
+  internallyConnectedPins?: (string | number)[][];
   /**
    * Connector standard, e.g. usb_c, m2
    */
@@ -542,7 +542,7 @@ export interface JumperProps extends CommonComponentProps {
    * Groups of pins that are internally connected
    * e.g., [["1","2"], ["2","3"]]
    */
-  internallyConnectedPins?: string[][];
+  internallyConnectedPins?: (string | number)[][];
   /**
    * Connections to other components
    */

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -441,7 +441,7 @@ export interface ChipPropsSU<
   schWidth?: Distance
   schHeight?: Distance
   noSchematicRepresentation?: boolean
-  internallyConnectedPins?: string[][]
+  internallyConnectedPins?: (string | number)[][]
   externallyConnectedPins?: string[][]
   connections?: Connections<PinLabel>
 }
@@ -471,7 +471,9 @@ export const chipProps = commonComponentProps.extend({
   pinLabels: pinLabelsProp.optional(),
   showPinAliases: z.boolean().optional(),
   pcbPinLabels: z.record(z.string(), z.string()).optional(),
-  internallyConnectedPins: z.array(z.array(z.string())).optional(),
+  internallyConnectedPins: z
+    .array(z.array(z.union([z.string(), z.number()])))
+    .optional(),
   externallyConnectedPins: z.array(z.array(z.string())).optional(),
   schPinArrangement: schematicPinArrangement.optional(),
   schPortArrangement: schematicPinArrangement.optional(),
@@ -500,7 +502,7 @@ export interface ConnectorProps extends CommonComponentProps {
   schHeight?: number | string
   schDirection?: "left" | "right"
   schPortArrangement?: SchematicPortArrangement
-  internallyConnectedPins?: string[][]
+  internallyConnectedPins?: (string | number)[][]
   standard?: "usb_c" | "m2"
 }
 /**
@@ -520,7 +522,9 @@ export const connectorProps = commonComponentProps.extend({
   schHeight: distance.optional(),
   schDirection: z.enum(["left", "right"]).optional(),
   schPortArrangement: schematicPortArrangement.optional(),
-  internallyConnectedPins: z.array(z.array(z.string())).optional(),
+  internallyConnectedPins: z
+    .array(z.array(z.union([z.string(), z.number()])))
+    .optional(),
   standard: z.enum(["usb_c", "m2"]).optional(),
 })
 ```
@@ -1274,7 +1278,7 @@ export interface JumperProps extends CommonComponentProps {
   schPortArrangement?: SchematicPortArrangement
   pcbPinLabels?: Record<string, string>
   pinCount?: 2 | 3
-  internallyConnectedPins?: string[][]
+  internallyConnectedPins?: (string | number)[][]
   connections?: Connections<string>
 }
 /**
@@ -1297,7 +1301,9 @@ export const jumperProps = commonComponentProps.extend({
   schPortArrangement: schematicPortArrangement.optional(),
   pcbPinLabels: z.record(z.string(), z.string()).optional(),
   pinCount: z.union([z.literal(2), z.literal(3)]).optional(),
-  internallyConnectedPins: z.array(z.array(z.string())).optional(),
+  internallyConnectedPins: z
+    .array(z.array(z.union([z.string(), z.number()])))
+    .optional(),
   connections: z
     .custom<Connections>()
     .pipe(z.record(z.string(), connectionTarget))

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-08-13T02:57:40.359Z
+> Generated at 2025-08-13T16:18:37.299Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -241,7 +241,7 @@ export interface ChipPropsSU<
   schWidth?: Distance
   schHeight?: Distance
   noSchematicRepresentation?: boolean
-  internallyConnectedPins?: string[][]
+  internallyConnectedPins?: (string | number)[][]
   externallyConnectedPins?: string[][]
   connections?: Connections<PinLabel>
 }
@@ -353,7 +353,7 @@ export interface ConnectorProps extends CommonComponentProps {
    * Groups of pins that are internally connected
    * e.g., [["1","2"], ["2","3"]]
    */
-  internallyConnectedPins?: string[][]
+  internallyConnectedPins?: (string | number)[][]
   /**
    * Connector standard, e.g. usb_c, m2
    */
@@ -530,7 +530,7 @@ export interface JumperProps extends CommonComponentProps {
    * Groups of pins that are internally connected
    * e.g., [["1","2"], ["2","3"]]
    */
-  internallyConnectedPins?: string[][]
+  internallyConnectedPins?: (string | number)[][]
   /**
    * Connections to other components
    */

--- a/lib/components/chip.ts
+++ b/lib/components/chip.ts
@@ -58,7 +58,7 @@ export interface ChipPropsSU<
   schWidth?: Distance
   schHeight?: Distance
   noSchematicRepresentation?: boolean
-  internallyConnectedPins?: string[][]
+  internallyConnectedPins?: (string | number)[][]
   externallyConnectedPins?: string[][]
   connections?: Connections<PinLabel>
 }
@@ -138,7 +138,9 @@ export const chipProps = commonComponentProps.extend({
   pinLabels: pinLabelsProp.optional(),
   showPinAliases: z.boolean().optional(),
   pcbPinLabels: z.record(z.string(), z.string()).optional(),
-  internallyConnectedPins: z.array(z.array(z.string())).optional(),
+  internallyConnectedPins: z
+    .array(z.array(z.union([z.string(), z.number()])))
+    .optional(),
   externallyConnectedPins: z.array(z.array(z.string())).optional(),
   schPinArrangement: schematicPinArrangement.optional(),
   schPortArrangement: schematicPinArrangement.optional(),

--- a/lib/components/connector.ts
+++ b/lib/components/connector.ts
@@ -34,7 +34,7 @@ export interface ConnectorProps extends CommonComponentProps {
    * Groups of pins that are internally connected
    * e.g., [["1","2"], ["2","3"]]
    */
-  internallyConnectedPins?: string[][]
+  internallyConnectedPins?: (string | number)[][]
   /**
    * Connector standard, e.g. usb_c, m2
    */
@@ -55,7 +55,9 @@ export const connectorProps = commonComponentProps.extend({
   schHeight: distance.optional(),
   schDirection: z.enum(["left", "right"]).optional(),
   schPortArrangement: schematicPortArrangement.optional(),
-  internallyConnectedPins: z.array(z.array(z.string())).optional(),
+  internallyConnectedPins: z
+    .array(z.array(z.union([z.string(), z.number()])))
+    .optional(),
   standard: z.enum(["usb_c", "m2"]).optional(),
 })
 

--- a/lib/components/jumper.ts
+++ b/lib/components/jumper.ts
@@ -49,7 +49,7 @@ export interface JumperProps extends CommonComponentProps {
    * Groups of pins that are internally connected
    * e.g., [["1","2"], ["2","3"]]
    */
-  internallyConnectedPins?: string[][]
+  internallyConnectedPins?: (string | number)[][]
   /**
    * Connections to other components
    */
@@ -73,7 +73,9 @@ export const jumperProps = commonComponentProps.extend({
   schPortArrangement: schematicPortArrangement.optional(),
   pcbPinLabels: z.record(z.string(), z.string()).optional(),
   pinCount: z.union([z.literal(2), z.literal(3)]).optional(),
-  internallyConnectedPins: z.array(z.array(z.string())).optional(),
+  internallyConnectedPins: z
+    .array(z.array(z.union([z.string(), z.number()])))
+    .optional(),
   connections: z
     .custom<Connections>()
     .pipe(z.record(z.string(), connectionTarget))

--- a/tests/jumper.test.ts
+++ b/tests/jumper.test.ts
@@ -19,6 +19,16 @@ test("should parse 2-pin jumper with pins 1-2 internally connected", () => {
   expect(parsed.internallyConnectedPins).toEqual([["1", "2"]])
 })
 
+test("should parse 2-pin jumper with numeric internallyConnectedPins", () => {
+  const rawProps: JumperProps = {
+    name: "jumper",
+    pinCount: 2,
+    internallyConnectedPins: [[1, 2]],
+  }
+  const parsed = jumperProps.parse(rawProps)
+  expect(parsed.internallyConnectedPins).toEqual([[1, 2]])
+})
+
 test("should parse 3-pin jumper with pins 1-2 internally connected", () => {
   const rawProps: JumperProps = {
     name: "jumper",


### PR DESCRIPTION
## Summary
- allow `internallyConnectedPins` to include numbers in jumper, connector, and chip props
- document number support in README and generated docs
- add test for numeric internally connected pins

## Testing
- `bun run format`
- `bun run typecheck`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689cba0c2508832cbfb77dd6df96868a