### PR TITLE
feat: add schMaxTraceDistance subcircuit prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ export interface CommonComponentProps extends CommonLayoutProps {
 
 ```ts
 export interface SubcircuitGroupProps extends BaseGroupProps {
-  layout?: LayoutBuilder;
   manualEdits?: ManualEditsFileInput;
   routingDisabled?: boolean;
   defaultTraceWidth?: Distance;
@@ -129,6 +128,9 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
    * If true, net labels will automatically be created for complex traces
    */
   schTraceAutoLabelEnabled?: boolean;
+
+  /** Maximum length a trace can span on the schematic */
+  schMaxTraceDistance?: Distance;
 
   partsEngine?: PartsEngine;
 }

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1097,6 +1097,8 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
 
   schTraceAutoLabelEnabled?: boolean
 
+  schMaxTraceDistance?: Distance
+
   partsEngine?: PartsEngine
 
   square?: boolean
@@ -1207,6 +1209,7 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   manualEdits: manual_edits_file.optional(),
   schAutoLayoutEnabled: z.boolean().optional(),
   schTraceAutoLabelEnabled: z.boolean().optional(),
+  schMaxTraceDistance: distance.optional(),
   routingDisabled: z.boolean().optional(),
   defaultTraceWidth: length.optional(),
   minTraceWidth: length.optional(),
@@ -1897,6 +1900,7 @@ export const silkscreenTextProps = pcbLayoutProps.extend({
   anchorAlignment: ninePointAnchor.default("center"),
   font: z.enum(["tscircuit2024"]).optional(),
   fontSize: length.optional(),
+  layers: z.array(layer_ref).optional(),
 })
 ```
 
@@ -2195,6 +2199,27 @@ export const viaProps = commonLayoutProps.extend({
   holeDiameter: distance,
   outerDiameter: distance,
   connectsTo: z.string().or(z.array(z.string())).optional(),
+})
+```
+
+### voltagesource
+
+```typescript
+export interface VoltageSourceProps extends CommonComponentProps {
+  voltage?: number | string
+  frequency?: number | string
+  peakToPeakVoltage?: number | string
+  waveShape?: WaveShape
+  phase?: number | string
+  dutyCycle?: number | string
+}
+export const voltageSourceProps = commonComponentProps.extend({
+  voltage: voltage.optional(),
+  frequency: frequency.optional(),
+  peakToPeakVoltage: voltage.optional(),
+  waveShape: z.enum(["sinewave", "square", "triangle", "sawtooth"]).optional(),
+  phase: rotation.optional(),
+  dutyCycle: percentage.optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-08-13T23:26:56.160Z
+> Generated at 2025-08-27T22:41:04.139Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -1072,6 +1072,9 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
    */
   schTraceAutoLabelEnabled?: boolean
 
+  /** Maximum length a trace can span on the schematic */
+  schMaxTraceDistance?: Distance
+
   partsEngine?: PartsEngine
 
   /** When autosizing, the board will be made square */
@@ -1151,6 +1154,16 @@ export interface ViaProps extends CommonLayoutProps {
   holeDiameter: number | string
   outerDiameter: number | string
   connectsTo?: string | string[]
+}
+
+
+export interface VoltageSourceProps extends CommonComponentProps {
+  voltage?: number | string
+  frequency?: number | string
+  peakToPeakVoltage?: number | string
+  waveShape?: WaveShape
+  phase?: number | string
+  dutyCycle?: number | string
 }
 
 ```

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -329,6 +329,9 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
    */
   schTraceAutoLabelEnabled?: boolean
 
+  /** Maximum length a trace can span on the schematic */
+  schMaxTraceDistance?: Distance
+
   partsEngine?: PartsEngine
 
   /** When autosizing, the board will be made square */
@@ -449,6 +452,7 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   manualEdits: manual_edits_file.optional(),
   schAutoLayoutEnabled: z.boolean().optional(),
   schTraceAutoLabelEnabled: z.boolean().optional(),
+  schMaxTraceDistance: distance.optional(),
   routingDisabled: z.boolean().optional(),
   defaultTraceWidth: length.optional(),
   minTraceWidth: length.optional(),

--- a/scripts/generate-readme-docs.ts
+++ b/scripts/generate-readme-docs.ts
@@ -147,7 +147,6 @@ function generateInterfaceDefinitions(
       name: "Group",
       props: "SubcircuitGroupProps",
       interfaceDefinition: `export interface SubcircuitGroupProps extends BaseGroupProps {
-  layout?: LayoutBuilder
   manualEdits?: ManualEditsFileInput
   routingDisabled?: boolean
   defaultTraceWidth?: Distance
@@ -167,6 +166,9 @@ function generateInterfaceDefinitions(
    * If true, net labels will automatically be created for complex traces
    */
   schTraceAutoLabelEnabled?: boolean
+
+  /** Maximum length a trace can span on the schematic */
+  schMaxTraceDistance?: Distance
 
   partsEngine?: PartsEngine
 }`,

--- a/tests/group.test.ts
+++ b/tests/group.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "bun:test"
-import { baseGroupProps, type BaseGroupProps } from "../lib/components/group"
+import {
+  baseGroupProps,
+  subcircuitGroupProps,
+  type BaseGroupProps,
+  type SubcircuitGroupProps,
+} from "../lib/components/group"
 
 test("should parse cellBorder", () => {
   const raw: BaseGroupProps = {
@@ -190,4 +195,13 @@ test("should parse schematic layout props", () => {
   expect(parsed.schFlexGap).toBe("0.2mm")
   expect(parsed.schPack).toBe(true)
   expect(parsed.schMatchAdapt).toBe(true)
+})
+
+test("should parse schMaxTraceDistance", () => {
+  const raw: SubcircuitGroupProps = {
+    name: "g",
+    schMaxTraceDistance: "10mm",
+  }
+  const parsed = subcircuitGroupProps.parse(raw)
+  expect(parsed.schMaxTraceDistance).toBe(10)
 })


### PR DESCRIPTION
## Summary
- add optional `schMaxTraceDistance` to `SubcircuitGroupProps`
- document new property and regenerate props references
- test parsing `schMaxTraceDistance`

## Testing
- `bun test tests/group.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68af88ecff30832e9aeefd46599c853c