### PR TITLE
feat(pin-header): allow record pin labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ export interface PinHeaderProps extends CommonComponentProps {
   /**
    * Labels for each pin
    */
-  pinLabels?: SchematicPinLabel[];
+  pinLabels?: Record<string, SchematicPinLabel> | SchematicPinLabel[];
 
   /**
    * Connections to other components

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1458,7 +1458,7 @@ export interface PinHeaderProps extends CommonComponentProps {
 
   platedDiameter?: number | string
 
-  pinLabels?: SchematicPinLabel[]
+  pinLabels?: Record<string, SchematicPinLabel> | SchematicPinLabel[]
 
   connections?: Connections<string>
 
@@ -1488,7 +1488,10 @@ export const pinHeaderProps = commonComponentProps.extend({
   rightAngle: z.boolean().optional(),
   holeDiameter: distance.optional(),
   platedDiameter: distance.optional(),
-  pinLabels: z.array(schematicPinLabel).optional(),
+  pinLabels: z
+    .record(z.string(), schematicPinLabel)
+    .or(z.array(schematicPinLabel))
+    .optional(),
   connections: z
     .custom<Connections>()
     .pipe(z.record(z.string(), connectionTarget))

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-08-27T22:41:04.139Z
+> Generated at 2025-08-29T05:11:45.645Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -810,7 +810,7 @@ export interface PinHeaderProps extends CommonComponentProps {
   /**
    * Labels for each pin
    */
-  pinLabels?: SchematicPinLabel[]
+  pinLabels?: Record<string, SchematicPinLabel> | SchematicPinLabel[]
 
   /**
    * Connections to other components

--- a/lib/components/pin-header.ts
+++ b/lib/components/pin-header.ts
@@ -74,7 +74,7 @@ export interface PinHeaderProps extends CommonComponentProps {
   /**
    * Labels for each pin
    */
-  pinLabels?: SchematicPinLabel[]
+  pinLabels?: Record<string, SchematicPinLabel> | SchematicPinLabel[]
 
   /**
    * Connections to other components
@@ -123,7 +123,10 @@ export const pinHeaderProps = commonComponentProps.extend({
   rightAngle: z.boolean().optional(),
   holeDiameter: distance.optional(),
   platedDiameter: distance.optional(),
-  pinLabels: z.array(schematicPinLabel).optional(),
+  pinLabels: z
+    .record(z.string(), schematicPinLabel)
+    .or(z.array(schematicPinLabel))
+    .optional(),
   connections: z
     .custom<Connections>()
     .pipe(z.record(z.string(), connectionTarget))

--- a/tests/pin-header.test.ts
+++ b/tests/pin-header.test.ts
@@ -58,6 +58,26 @@ test("should parse rightAngle property", () => {
   expect(parsed.rightAngle).toBe(true)
 })
 
+test("should parse pinLabels as array", () => {
+  const rawProps: PinHeaderProps = {
+    name: "header",
+    pinCount: 2,
+    pinLabels: ["A", "B"],
+  }
+  const parsed = pinHeaderProps.parse(rawProps)
+  expect(parsed.pinLabels).toEqual(["A", "B"])
+})
+
+test("should parse pinLabels as record", () => {
+  const rawProps: PinHeaderProps = {
+    name: "header",
+    pinCount: 2,
+    pinLabels: { 1: "A", 2: "B" },
+  }
+  const parsed = pinHeaderProps.parse(rawProps)
+  expect(parsed.pinLabels).toEqual({ 1: "A", 2: "B" })
+})
+
 test("should snapshot schematic props for pin header", () => {
   const rawProps: PinHeaderProps = {
     name: "header",

--- a/tests/schematicPinLabels.test.ts
+++ b/tests/schematicPinLabels.test.ts
@@ -23,10 +23,17 @@ test("Schematic pinLabels should reject labels with invalid characters", () => {
   }
   expect(jumperProps.safeParse(invalidJumper).success).toBe(false)
 
-  const invalidHeader = {
+  const invalidHeaderArray = {
     name: "hdr",
     pinCount: 2,
     pinLabels: ["A-B"],
   }
-  expect(pinHeaderProps.safeParse(invalidHeader).success).toBe(false)
+  expect(pinHeaderProps.safeParse(invalidHeaderArray).success).toBe(false)
+
+  const invalidHeaderRecord = {
+    name: "hdr",
+    pinCount: 2,
+    pinLabels: { 1: "A-B" },
+  }
+  expect(pinHeaderProps.safeParse(invalidHeaderRecord).success).toBe(false)
 })


### PR DESCRIPTION
## Summary
- allow `pinLabels` on PinHeader to accept a record of labels or an array
- add tests for pinLabels record and array support
- update generated docs and README

## Testing
- `bun test tests/pin-header.test.ts`
- `bun test tests/schematicPinLabels.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68b135f0025c832ebd41dc11e0abd88c