### PR TITLE
feat: add battery voltage property and standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
 export interface BatteryProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   capacity?: number | string;
+  voltage?: number | string;
+  standard?: "AA" | "AAA" | "9V" | "CR2032" | "18650" | "C";
   schOrientation?: SchematicOrientation;
 }
 ```

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -323,10 +323,16 @@ export const schematicPinStyle = z.record(
 export interface BatteryProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   capacity?: number | string
+  voltage?: number | string
+  standard?: "AA" | "AAA" | "9V" | "CR2032" | "18650" | "C"
   schOrientation?: SchematicOrientation
 }
 export const batteryProps = commonComponentProps.extend({
   capacity: capacity.optional(),
+  voltage: voltage.optional(),
+  standard: z
+    .enum(["AA", "AAA", "9V", "CR2032", "18650", "C"])
+    .optional(),
   schOrientation: schematicOrientation.optional(),
 })
 ```

--- a/lib/components/battery.ts
+++ b/lib/components/battery.ts
@@ -1,3 +1,4 @@
+import { voltage } from "circuit-json"
 import { z } from "zod"
 import {
   commonComponentProps,
@@ -31,11 +32,15 @@ const capacity = z
 export interface BatteryProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   capacity?: number | string
+  voltage?: number | string
+  standard?: "AA" | "AAA" | "9V" | "CR2032" | "18650" | "C"
   schOrientation?: SchematicOrientation
 }
 
 export const batteryProps = commonComponentProps.extend({
   capacity: capacity.optional(),
+  voltage: voltage.optional(),
+  standard: z.enum(["AA", "AAA", "9V", "CR2032", "18650", "C"]).optional(),
   schOrientation: schematicOrientation.optional(),
 })
 export const batteryPins = lrPolarPins

--- a/tests/battery.test.ts
+++ b/tests/battery.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { batteryProps, type BatteryProps } from "lib/components/battery"
+
+test("should parse voltage and standard for battery", () => {
+  const raw: BatteryProps = {
+    name: "bat1",
+    voltage: "9V",
+    standard: "9V",
+  }
+  const parsed = batteryProps.parse(raw)
+  expect(parsed.voltage).toBe(9)
+  expect(parsed.standard).toBe("9V")
+})
+
+test("should fail with invalid standard", () => {
+  const raw = { name: "bat2", standard: "invalid" } as any
+  expect(() => batteryProps.parse(raw)).toThrow()
+})


### PR DESCRIPTION
## Summary
- add voltage and standard properties to battery component
- document new battery properties
- test battery voltage and standard parsing

## Testing
- `bun test tests/battery.test.ts`
- `bun run generate:component-types`
- `bun run generate:readme-docs`


------
https://chatgpt.com/codex/tasks/task_b_68b2288fa960832ebf22605babdf772f