### PR TITLE
feat: add doNotConnect pin attribute

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -156,6 +156,7 @@ export interface PinAttributeMap {
   requiresGround?: boolean
   providesVoltage?: string | number
   requiresVoltage?: string | number
+  doNotConnect?: boolean
 }
 export const pinAttributeMap = z.object({
   providesPower: z.boolean().optional(),
@@ -164,6 +165,7 @@ export const pinAttributeMap = z.object({
   requiresGround: z.boolean().optional(),
   providesVoltage: z.union([z.string(), z.number()]).optional(),
   requiresVoltage: z.union([z.string(), z.number()]).optional(),
+  doNotConnect: z.boolean().optional(),
 })
 export interface CommonComponentProps<PinLabel extends string = string>
   extends CommonLayoutProps {
@@ -330,9 +332,7 @@ export interface BatteryProps<PinLabel extends string = string>
 export const batteryProps = commonComponentProps.extend({
   capacity: capacity.optional(),
   voltage: voltage.optional(),
-  standard: z
-    .enum(["AA", "AAA", "9V", "CR2032", "18650", "C"])
-    .optional(),
+  standard: z.enum(["AA", "AAA", "9V", "CR2032", "18650", "C"]).optional(),
   schOrientation: schematicOrientation.optional(),
 })
 ```

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-08-29T05:11:45.645Z
+> Generated at 2025-09-02T02:59:55.968Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -140,6 +140,8 @@ export interface BaseManualEditEvent {
 export interface BatteryProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   capacity?: number | string
+  voltage?: number | string
+  standard?: "AA" | "AAA" | "9V" | "CR2032" | "18650" | "C"
   schOrientation?: SchematicOrientation
 }
 
@@ -747,6 +749,7 @@ export interface PinAttributeMap {
   requiresGround?: boolean
   providesVoltage?: string | number
   requiresVoltage?: string | number
+  doNotConnect?: boolean
 }
 
 

--- a/lib/common/layout.ts
+++ b/lib/common/layout.ts
@@ -105,6 +105,7 @@ export interface PinAttributeMap {
   requiresGround?: boolean
   providesVoltage?: string | number
   requiresVoltage?: string | number
+  doNotConnect?: boolean
 }
 
 export const pinAttributeMap = z.object({
@@ -114,6 +115,7 @@ export const pinAttributeMap = z.object({
   requiresGround: z.boolean().optional(),
   providesVoltage: z.union([z.string(), z.number()]).optional(),
   requiresVoltage: z.union([z.string(), z.number()]).optional(),
+  doNotConnect: z.boolean().optional(),
 })
 
 expectTypesMatch<PinAttributeMap, z.input<typeof pinAttributeMap>>(true)

--- a/tests/chip3-type-tests.test.tsx
+++ b/tests/chip3-type-tests.test.tsx
@@ -147,7 +147,7 @@ test("[typetest] pinAttributes type matches pin labels", () => {
       pinLabels={pinLabels1}
       pinAttributes={{
         VCC: { providesPower: true },
-        GND: { requiresPower: true },
+        GND: { requiresPower: true, doNotConnect: true },
         // @ts-expect-error
         INVALID: { foo: true },
       }}

--- a/tests/pinAttributes.test.ts
+++ b/tests/pinAttributes.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { chipProps } from "lib/components/chip"
+
+test("pinAttributes allows doNotConnect", () => {
+  const rawProps = {
+    name: "chip",
+    pinAttributes: {
+      pin1: { doNotConnect: true },
+    },
+  }
+
+  const parsed = chipProps.parse(rawProps)
+  expect(parsed.pinAttributes?.pin1?.doNotConnect).toBe(true)
+})


### PR DESCRIPTION
## Summary
- allow marking pins as do not connect
- document new `doNotConnect` pin attribute
- test `doNotConnect` handling in pin attributes

## Testing
- `bun test tests/pinAttributes.test.ts tests/chip3-type-tests.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68b65d0debe0832e92d00a6950bc3d37