### PR TITLE
feat(board): add border radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   material?: "fr4" | "fr1";
   /** Number of layers for the PCB */
   layers?: 2 | 4;
+  borderRadius?: Distance;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -343,11 +343,13 @@ export const batteryProps = commonComponentProps.extend({
 export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   material?: "fr4" | "fr1"
   layers?: 2 | 4
+  borderRadius?: Distance
 }
 /** Number of layers for the PCB */
 export const boardProps = subcircuitGroupProps.extend({
   material: z.enum(["fr4", "fr1"]).default("fr4"),
   layers: z.union([z.literal(2), z.literal(4)]).default(2),
+  borderRadius: distance.optional(),
 })
 ```
 
@@ -2116,7 +2118,10 @@ export interface SymbolProps {
    * because you have a complex symbol. Default is "right" and this is most intuitive.
    */
 export const symbolProps = z.object({
-  originalFacingDirection: z.enum(["up", "down", "left", "right"]).default("right").optional(),
+  originalFacingDirection: z
+    .enum(["up", "down", "left", "right"])
+    .default("right")
+    .optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-09-02T02:59:55.968Z
+> Generated at 2025-09-04T23:27:14.482Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -150,6 +150,7 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   material?: "fr4" | "fr1"
   /** Number of layers for the PCB */
   layers?: 2 | 4
+  borderRadius?: Distance
 }
 
 
@@ -1112,6 +1113,17 @@ export interface SwitchProps extends CommonComponentProps {
   spst?: boolean
   dpst?: boolean
   dpdt?: boolean
+}
+
+
+export interface SymbolProps {
+  /**
+   * The facing direction that the symbol is designed for. If you set this to "right",
+   * then it means the children were intended to represent the symbol facing right.
+   * Generally, you shouldn't set this except where it can help prevent confusion
+   * because you have a complex symbol. Default is "right" and this is most intuitive.
+   */
+  originalFacingDirection?: "up" | "down" | "left" | "right"
 }
 
 

--- a/lib/components/board.ts
+++ b/lib/components/board.ts
@@ -1,3 +1,4 @@
+import { distance, type Distance } from "lib/common/distance"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 import { subcircuitGroupProps, type SubcircuitGroupProps } from "./group"
@@ -6,11 +7,13 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   material?: "fr4" | "fr1"
   /** Number of layers for the PCB */
   layers?: 2 | 4
+  borderRadius?: Distance
 }
 
 export const boardProps = subcircuitGroupProps.extend({
   material: z.enum(["fr4", "fr1"]).default("fr4"),
   layers: z.union([z.literal(2), z.literal(4)]).default(2),
+  borderRadius: distance.optional(),
 })
 
 type InferredBoardProps = z.input<typeof boardProps>

--- a/tests/board.test.ts
+++ b/tests/board.test.ts
@@ -21,3 +21,9 @@ test("should parse layers prop", () => {
   const parsed = boardProps.parse(raw)
   expect(parsed.layers).toBe(4)
 })
+
+test("should parse borderRadius prop", () => {
+  const raw: BoardProps = { name: "board", borderRadius: 2 }
+  const parsed = boardProps.parse(raw)
+  expect(parsed.borderRadius).toBe(2)
+})


### PR DESCRIPTION
## Summary
- allow specifying optional borderRadius for board components
- document borderRadius in README and generated files
- test borderRadius parsing

## Testing
- `bun test tests`


------
https://chatgpt.com/codex/tasks/task_b_68ba1fe04e18832ea1315aef6da16066