### PR TITLE
feat: add inductor connections support

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ export interface InductorProps<PinLabel extends string = string>
   inductance: number | string;
   maxCurrentRating?: number | string;
   schOrientation?: SchematicOrientation;
+  connections?: Connections<InductorPinLabels>;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1263,11 +1263,13 @@ export interface InductorProps<PinLabel extends string = string>
   inductance: number | string
   maxCurrentRating?: number | string
   schOrientation?: SchematicOrientation
+  connections?: Connections<InductorPinLabels>
 }
 export const inductorProps = commonComponentProps.extend({
   inductance,
   maxCurrentRating: z.union([z.string(), z.number()]).optional(),
   schOrientation: schematicOrientation.optional(),
+  connections: createConnectionsProp(inductorPins).optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-09-04T23:27:14.482Z
+> Generated at 2025-09-05T04:02:14.227Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -502,6 +502,7 @@ export interface InductorProps<PinLabel extends string = string>
   inductance: number | string
   maxCurrentRating?: number | string
   schOrientation?: SchematicOrientation
+  connections?: Connections<InductorPinLabels>
 }
 
 

--- a/lib/components/inductor.ts
+++ b/lib/components/inductor.ts
@@ -4,28 +4,32 @@ import {
   commonComponentProps,
   lrPins,
 } from "lib/common/layout"
+import { createConnectionsProp } from "lib/common/connectionsProp"
 import {
   schematicOrientation,
   type SchematicOrientation,
 } from "lib/common/schematicOrientation"
+import type { Connections } from "lib/utility-types/connections-and-selectors"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
+
+export const inductorPins = lrPins
+export type InductorPinLabels = (typeof inductorPins)[number]
 
 export interface InductorProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   inductance: number | string
   maxCurrentRating?: number | string
   schOrientation?: SchematicOrientation
+  connections?: Connections<InductorPinLabels>
 }
 
 export const inductorProps = commonComponentProps.extend({
   inductance,
   maxCurrentRating: z.union([z.string(), z.number()]).optional(),
   schOrientation: schematicOrientation.optional(),
+  connections: createConnectionsProp(inductorPins).optional(),
 })
-
-export const inductorPins = lrPins
-export type InductorPinLabels = (typeof inductorPins)[number]
 
 type InferredInductorProps = z.input<typeof inductorProps>
 

--- a/tests/inductor.test.ts
+++ b/tests/inductor.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { inductorProps, type InductorProps } from "lib/components/inductor"
+import { z } from "zod"
+
+test("should parse inductor props with single string connections", () => {
+  const rawProps: InductorProps = {
+    name: "L1",
+    inductance: 10,
+    connections: {
+      pin1: "net.A",
+      pin2: "net.B",
+    },
+  }
+  const parsedProps = inductorProps.parse(rawProps)
+  expect(parsedProps.connections).toEqual({
+    pin1: "net.A",
+    pin2: "net.B",
+  })
+})
+
+test("should parse inductor props with array connections", () => {
+  const rawProps: InductorProps = {
+    name: "L1",
+    inductance: 10,
+    connections: {
+      pin1: ["net.A", "net.A2"],
+      pin2: ["net.B", "net.B2"],
+    },
+  }
+  const parsedProps = inductorProps.parse(rawProps)
+  expect(parsedProps.connections).toEqual({
+    pin1: ["net.A", "net.A2"],
+    pin2: ["net.B", "net.B2"],
+  })
+})
+
+test("should reject connections with invalid keys", () => {
+  expect(() => {
+    inductorProps.parse({
+      name: "L1",
+      inductance: 10,
+      connections: {
+        invalid: "net.INVALID",
+      } as any,
+    })
+  }).toThrow(z.ZodError)
+})
+
+test("should allow optional connections", () => {
+  const rawProps: InductorProps = {
+    name: "L1",
+    inductance: 10,
+  }
+  const parsedProps = inductorProps.parse(rawProps)
+  expect(parsedProps.connections).toBeUndefined()
+})


### PR DESCRIPTION
## Summary
- support `connections` prop for `<inductor />`
- document inductor connections
- add tests for inductor connections parsing

## Testing
- `bun test tests/inductor.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68ba605f28d0832e8d2e016a5f8932f3