### PR TITLE
feat: add connections to voltagesource

### DIFF
--- a/README.md
+++ b/README.md
@@ -970,13 +970,15 @@ export interface ViaProps extends CommonLayoutProps {
 ### VoltageSourceProps `<voltagesource />`
 
 ```ts
-export interface VoltageSourceProps extends CommonComponentProps {
+export interface VoltageSourceProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   voltage?: number | string;
   frequency?: number | string;
   peakToPeakVoltage?: number | string;
   waveShape?: WaveShape;
   phase?: number | string;
   dutyCycle?: number | string;
+  connections?: Connections<VoltageSourcePinLabels>;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2246,13 +2246,15 @@ export const viaProps = commonLayoutProps.extend({
 ### voltagesource
 
 ```typescript
-export interface VoltageSourceProps extends CommonComponentProps {
+export interface VoltageSourceProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   voltage?: number | string
   frequency?: number | string
   peakToPeakVoltage?: number | string
   waveShape?: WaveShape
   phase?: number | string
   dutyCycle?: number | string
+  connections?: Connections<VoltageSourcePinLabels>
 }
 export const voltageSourceProps = commonComponentProps.extend({
   voltage: voltage.optional(),
@@ -2261,6 +2263,7 @@ export const voltageSourceProps = commonComponentProps.extend({
   waveShape: z.enum(["sinewave", "square", "triangle", "sawtooth"]).optional(),
   phase: rotation.optional(),
   dutyCycle: percentage.optional(),
+  connections: createConnectionsProp(voltageSourcePinLabels).optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-09-05T04:02:14.227Z
+> Generated at 2025-09-05T06:06:52.079Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -1173,13 +1173,15 @@ export interface ViaProps extends CommonLayoutProps {
 }
 
 
-export interface VoltageSourceProps extends CommonComponentProps {
+export interface VoltageSourceProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   voltage?: number | string
   frequency?: number | string
   peakToPeakVoltage?: number | string
   waveShape?: WaveShape
   phase?: number | string
   dutyCycle?: number | string
+  connections?: Connections<VoltageSourcePinLabels>
 }
 
 ```

--- a/lib/components/voltagesource.ts
+++ b/lib/components/voltagesource.ts
@@ -2,19 +2,27 @@ import { frequency, rotation, voltage } from "circuit-json"
 import {
   type CommonComponentProps,
   commonComponentProps,
+  lrPolarPins,
 } from "lib/common/layout"
+import { createConnectionsProp } from "lib/common/connectionsProp"
+import type { Connections } from "lib/utility-types/connections-and-selectors"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
 export type WaveShape = "sinewave" | "square" | "triangle" | "sawtooth"
 
-export interface VoltageSourceProps extends CommonComponentProps {
+export const voltageSourcePinLabels = ["pin1", "pin2", "pos", "neg"] as const
+export type VoltageSourcePinLabels = (typeof voltageSourcePinLabels)[number]
+
+export interface VoltageSourceProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   voltage?: number | string
   frequency?: number | string
   peakToPeakVoltage?: number | string
   waveShape?: WaveShape
   phase?: number | string
   dutyCycle?: number | string
+  connections?: Connections<VoltageSourcePinLabels>
 }
 
 const percentage = z
@@ -42,7 +50,10 @@ export const voltageSourceProps = commonComponentProps.extend({
   waveShape: z.enum(["sinewave", "square", "triangle", "sawtooth"]).optional(),
   phase: rotation.optional(),
   dutyCycle: percentage.optional(),
+  connections: createConnectionsProp(voltageSourcePinLabels).optional(),
 })
+
+export const voltageSourcePins = lrPolarPins
 
 type InferredVoltageSourceProps = z.input<typeof voltageSourceProps>
 expectTypesMatch<VoltageSourceProps, InferredVoltageSourceProps>(true)

--- a/tests/voltagesource.test.ts
+++ b/tests/voltagesource.test.ts
@@ -3,6 +3,7 @@ import {
   voltageSourceProps,
   type VoltageSourceProps,
 } from "lib/components/voltagesource"
+import { z } from "zod"
 
 test("should parse voltage source props", () => {
   const rawProps: VoltageSourceProps = {
@@ -115,4 +116,53 @@ test("should parse duty cycle", () => {
   expect(() =>
     voltageSourceProps.parse({ name: "vs_duty", dutyCycle: 2 }),
   ).toThrow()
+})
+
+test("should parse voltage source props with single string connections", () => {
+  const rawProps: VoltageSourceProps = {
+    name: "vs_conn",
+    connections: {
+      pos: "net.VCC",
+      neg: "net.GND",
+    },
+  }
+  const parsed = voltageSourceProps.parse(rawProps)
+  expect(parsed.connections).toEqual({
+    pos: "net.VCC",
+    neg: "net.GND",
+  })
+})
+
+test("should parse voltage source props with array connections", () => {
+  const rawProps: VoltageSourceProps = {
+    name: "vs_conn_arr",
+    connections: {
+      pos: ["net.VCC", "net.5V"],
+      neg: ["net.GND"],
+    },
+  }
+  const parsed = voltageSourceProps.parse(rawProps)
+  expect(parsed.connections).toEqual({
+    pos: ["net.VCC", "net.5V"],
+    neg: ["net.GND"],
+  })
+})
+
+test("should reject connections with invalid keys", () => {
+  expect(() => {
+    voltageSourceProps.parse({
+      name: "vs_invalid_conn",
+      connections: {
+        invalid: "net.X",
+      } as any,
+    })
+  }).toThrow(z.ZodError)
+})
+
+test("should allow optional connections", () => {
+  const rawProps: VoltageSourceProps = {
+    name: "vs_no_conn",
+  }
+  const parsed = voltageSourceProps.parse(rawProps)
+  expect(parsed.connections).toBeUndefined()
 })


### PR DESCRIPTION
## Summary
- add optional `connections` to `VoltageSourceProps`
- test voltage source connection parsing
- update generated docs

## Testing
- `bun test tests/voltagesource.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68ba7d6d34a4832ea908157532f2483a