### PR TITLE
feat: support cad model in footprint lib map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1031,10 +1031,18 @@ export interface PlatformConfig {
 
   footprintLibraryMap?: Record<
     string,
-    | ((path: string) => Promise<{ footprintCircuitJson: any[] }>)
+    | ((
+        path: string,
+      ) => Promise<{ footprintCircuitJson: any[]; cadModel?: CadModelProp }>)
     | Record<
         string,
-        any[] | ((path: string) => Promise<{ footprintCircuitJson: any[] }>)
+        | any[]
+        | ((
+            path: string,
+          ) => Promise<{
+            footprintCircuitJson: any[];
+            cadModel?: CadModelProp;
+          }>)
       >
   >;
 }

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-09-05T06:06:52.079Z
+> Generated at 2025-09-07T21:39:56.694Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -252,6 +252,14 @@ export interface ChipPropsSU<
   internallyConnectedPins?: (string | number)[][]
   externallyConnectedPins?: string[][]
   connections?: Connections<PinLabel>
+}
+
+
+export interface CircleCopperPourProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "circle"
+  radius: Distance
+  connectsTo?: string | string[]
 }
 
 
@@ -892,14 +900,25 @@ export interface PlatformConfig {
 
   footprintLibraryMap?: Record<
     string,
-    Record<
-      string,
-      | any[]
-      | ((path: string) => Promise<{
-          footprintCircuitJson: any[]
-        }>)
-    >
+    | ((
+        path: string,
+      ) => Promise<{ footprintCircuitJson: any[]; cadModel?: CadModelProp }>)
+    | Record<
+        string,
+        | any[]
+        | ((
+            path: string,
+          ) => Promise<{ footprintCircuitJson: any[]; cadModel?: CadModelProp }>)
+      >
   >
+}
+
+
+export interface PolygonCopperPourProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "polygon"
+  points: Point[]
+  connectsTo?: string | string[]
 }
 
 
@@ -923,6 +942,15 @@ export interface PolygonSmtPadProps
 export interface PotentiometerProps extends CommonComponentProps {
   maxResistance: number | string
   pinVariant?: PotentiometerPinVariant
+}
+
+
+export interface RectCopperPourProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  shape: "rect"
+  width: Distance
+  height: Distance
+  connectsTo?: string | string[]
 }
 
 

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -6,6 +6,7 @@ import {
 } from "./components/group"
 import { expectTypesMatch } from "./typecheck"
 import { z } from "zod"
+import { type CadModelProp, cadModelProp } from "./common/cadModel"
 
 export interface PlatformConfig {
   partsEngine?: PartsEngine
@@ -30,10 +31,18 @@ export interface PlatformConfig {
 
   footprintLibraryMap?: Record<
     string,
-    | ((path: string) => Promise<{ footprintCircuitJson: any[] }>)
+    | ((
+        path: string,
+      ) => Promise<{ footprintCircuitJson: any[]; cadModel?: CadModelProp }>)
     | Record<
         string,
-        any[] | ((path: string) => Promise<{ footprintCircuitJson: any[] }>)
+        | any[]
+        | ((
+            path: string,
+          ) => Promise<{
+            footprintCircuitJson: any[]
+            cadModel?: CadModelProp
+          }>)
       >
   >
 }
@@ -42,7 +51,14 @@ const unvalidatedCircuitJson = z.array(z.any()).describe("Circuit JSON")
 const pathToCircuitJsonFn = z
   .function()
   .args(z.string())
-  .returns(z.promise(z.object({ footprintCircuitJson: z.array(z.any()) })))
+  .returns(
+    z.promise(
+      z.object({
+        footprintCircuitJson: z.array(z.any()),
+        cadModel: cadModelProp.optional(),
+      }),
+    ),
+  )
   .describe("A function that takes a path and returns Circuit JSON")
 
 export const platformConfig = z.object({

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -37,9 +37,7 @@ export interface PlatformConfig {
     | Record<
         string,
         | any[]
-        | ((
-            path: string,
-          ) => Promise<{
+        | ((path: string) => Promise<{
             footprintCircuitJson: any[]
             cadModel?: CadModelProp
           }>)

--- a/tests/footprintLibraryMap-cadModel.test.ts
+++ b/tests/footprintLibraryMap-cadModel.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { platformConfig } from "lib/platformConfig"
+
+// ensure footprintLibraryMap functions can return cadModel in addition to footprintCircuitJson
+
+test("footprintLibraryMap function may return cadModel", async () => {
+  const config = platformConfig.parse({
+    footprintLibraryMap: {
+      lib: async (_path: string) => ({
+        footprintCircuitJson: [],
+        cadModel: { stlUrl: "model.stl" },
+      }),
+    },
+  })
+  const result = await config.footprintLibraryMap!.lib("myfootprint")
+  expect(result.cadModel).toEqual({ stlUrl: "model.stl" })
+  expect(Array.isArray(result.footprintCircuitJson)).toBe(true)
+})


### PR DESCRIPTION
## Summary
- allow footprint library functions to return `cadModel`
- document footprint library map cad model support
- test footprint library functions returning `cadModel`

## Testing
- `bun test tests/footprintLibraryMap-cadModel.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68bdfadf4f50832e8ae83b5a126df305