### PR TITLE
feat(pin-header): add pcb orientation prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,11 @@ export interface PinHeaderProps extends CommonComponentProps {
   rightAngle?: boolean;
 
   /**
+   * Orientation of the header on the PCB
+   */
+  pcbOrientation?: PcbOrientation;
+
+  /**
    * Diameter of the through-hole for each pin
    */
   holeDiameter?: number | string;

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1540,6 +1540,8 @@ export interface PinHeaderProps extends CommonComponentProps {
 
   rightAngle?: boolean
 
+  pcbOrientation?: PcbOrientation
+
   holeDiameter?: number | string
 
   platedDiameter?: number | string
@@ -1572,6 +1574,7 @@ export const pinHeaderProps = commonComponentProps.extend({
   pcbPinLabels: z.record(z.string(), z.string()).optional(),
   doubleRow: z.boolean().optional(),
   rightAngle: z.boolean().optional(),
+  pcbOrientation: pcbOrientationProp.optional(),
   holeDiameter: distance.optional(),
   platedDiameter: distance.optional(),
   pinLabels: z

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-09-08T13:45:01.668Z
+> Generated at 2025-09-08T17:03:36.951Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -829,6 +829,11 @@ export interface PinHeaderProps extends CommonComponentProps {
    * If true, the header is a right-angle style connector
    */
   rightAngle?: boolean
+
+  /**
+   * Orientation of the header on the PCB
+   */
+  pcbOrientation?: PcbOrientation
 
   /**
    * Diameter of the through-hole for each pin

--- a/lib/common/pcbOrientation.ts
+++ b/lib/common/pcbOrientation.ts
@@ -1,0 +1,12 @@
+import { expectTypesMatch } from "lib/typecheck"
+import { z } from "zod"
+
+export const pcbOrientation = z
+  .enum(["vertical", "horizontal"])
+  .describe(
+    "vertical means pins go 1->2 downward and horizontal means pins go 1->2 rightward",
+  )
+
+export type PcbOrientation = "vertical" | "horizontal"
+
+expectTypesMatch<PcbOrientation, z.infer<typeof pcbOrientation>>(true)

--- a/lib/components/pin-header.ts
+++ b/lib/components/pin-header.ts
@@ -16,6 +16,10 @@ import {
   schematicPinLabel,
   type SchematicPinLabel,
 } from "lib/common/schematicPinLabel"
+import {
+  pcbOrientation as pcbOrientationProp,
+  type PcbOrientation,
+} from "lib/common/pcbOrientation"
 import type { Connections } from "lib/utility-types/connections-and-selectors"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
@@ -60,6 +64,11 @@ export interface PinHeaderProps extends CommonComponentProps {
    * If true, the header is a right-angle style connector
    */
   rightAngle?: boolean
+
+  /**
+   * Orientation of the header on the PCB
+   */
+  pcbOrientation?: PcbOrientation
 
   /**
    * Diameter of the through-hole for each pin
@@ -121,6 +130,7 @@ export const pinHeaderProps = commonComponentProps.extend({
   pcbPinLabels: z.record(z.string(), z.string()).optional(),
   doubleRow: z.boolean().optional(),
   rightAngle: z.boolean().optional(),
+  pcbOrientation: pcbOrientationProp.optional(),
   holeDiameter: distance.optional(),
   platedDiameter: distance.optional(),
   pinLabels: z

--- a/tests/pin-header.test.ts
+++ b/tests/pin-header.test.ts
@@ -58,6 +58,16 @@ test("should parse rightAngle property", () => {
   expect(parsed.rightAngle).toBe(true)
 })
 
+test("should parse pcbOrientation property", () => {
+  const rawProps: PinHeaderProps = {
+    name: "header",
+    pinCount: 2,
+    pcbOrientation: "horizontal",
+  }
+  const parsed = pinHeaderProps.parse(rawProps)
+  expect(parsed.pcbOrientation).toBe("horizontal")
+})
+
 test("should parse pinLabels as array", () => {
   const rawProps: PinHeaderProps = {
     name: "header",


### PR DESCRIPTION
## Summary
- add PcbOrientation type and pcbOrientation prop for pin headers
- document pcbOrientation usage in README and generated docs
- test pin header pcbOrientation parsing

## Testing
- `bun run format`
- `bun test tests/pin-header.test.ts tests/pcbPinLabels.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68bf0ba44adc832e861cf1de1bd57fd6