### PR TITLE
chore: prefix kicad footprint paths

### DIFF
--- a/lib/generated/kicad-autocomplete.ts
+++ b/lib/generated/kicad-autocomplete.ts
@@ -1,6 +1,6 @@
 import type { AutocompleteString } from "../common/autocomplete"
 
-export type KicadAutocompleteStringPath = AutocompleteString<
+export type KicadFootprint =
   | "Audio_Module/Reverb_BTDR-1H"
   | "Audio_Module/Reverb_BTDR-1V"
   | "Battery/Battery_CR1225"
@@ -13806,4 +13806,6 @@ export type KicadAutocompleteStringPath = AutocompleteString<
   | "Varistor/RV_Disc_D9mm_W6.1mm_P5mm"
   | "Varistor/RV_Rect_V25S440P_L26.5mm_W8.2mm_P12.7mm"
   | "Varistor/Varistor_Panasonic_VF"
->
+
+export type KicadAutocompleteStringPath =
+  AutocompleteString<`kicad:${KicadFootprint}`>

--- a/scripts/generate-kicad-autocomplete.ts
+++ b/scripts/generate-kicad-autocomplete.ts
@@ -19,7 +19,10 @@ async function main() {
 
   const typeEntries = sanitizedFiles.map((p) => `  | "${p}"`).join("\n")
 
-  const content = `import type { AutocompleteString } from "../common/autocomplete"\n\nexport type KicadAutocompleteStringPath = AutocompleteString<\n${typeEntries}\n>\n`
+  const content =
+    `import type { AutocompleteString } from "../common/autocomplete"\n\n` +
+    `export type KicadFootprint =\n${typeEntries}\n\n` +
+    `export type KicadAutocompleteStringPath = AutocompleteString<\`kicad:\${KicadFootprint}\`>\n`
 
   const outDir = path.join(__dirname, "../lib/generated")
   fs.mkdirSync(outDir, { recursive: true })


### PR DESCRIPTION
## Summary
- prefix Kicad footprint strings with `kicad:` using template literal types
- update generator to emit prefixed autocomplete type

## Testing
- `bun run typecheck`
- `CI=1 bun test`


------
https://chatgpt.com/codex/tasks/task_b_68befc93d74483278c9dc2b1c4103d49