### PR TITLE
feat: add pcb position anchor for components

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -118,6 +118,7 @@ export interface PcbLayoutProps {
   pcbX?: string | number
   pcbY?: string | number
   pcbRotation?: string | number
+  pcbPositionAnchor?: string
   layer?: LayerRefInput
   pcbRelative?: boolean
   relative?: boolean
@@ -129,6 +130,7 @@ export interface CommonLayoutProps {
   pcbX?: string | number
   pcbY?: string | number
   pcbRotation?: string | number
+  pcbPositionAnchor?: string
 
   schX?: string | number
   schY?: string | number
@@ -150,6 +152,7 @@ export const pcbLayoutProps = z.object({
   pcbX: distance.optional(),
   pcbY: distance.optional(),
   pcbRotation: rotation.optional(),
+  pcbPositionAnchor: z.string().optional(),
   layer: layer_ref.optional(),
   pcbRelative: z.boolean().optional(),
   relative: z.boolean().optional(),
@@ -158,6 +161,7 @@ export const commonLayoutProps = z.object({
   pcbX: distance.optional(),
   pcbY: distance.optional(),
   pcbRotation: rotation.optional(),
+  pcbPositionAnchor: z.string().optional(),
   schX: distance.optional(),
   schY: distance.optional(),
   schRotation: rotation.optional(),

--- a/lib/common/layout.ts
+++ b/lib/common/layout.ts
@@ -14,6 +14,7 @@ export interface PcbLayoutProps {
   pcbX?: string | number
   pcbY?: string | number
   pcbRotation?: string | number
+  pcbPositionAnchor?: string
   layer?: LayerRefInput
   /**
    * If true, pcbX/pcbY will be interpreted relative to the parent group
@@ -29,6 +30,7 @@ export interface CommonLayoutProps {
   pcbX?: string | number
   pcbY?: string | number
   pcbRotation?: string | number
+  pcbPositionAnchor?: string
 
   schX?: string | number
   schY?: string | number
@@ -57,6 +59,7 @@ export const pcbLayoutProps = z.object({
   pcbX: distance.optional(),
   pcbY: distance.optional(),
   pcbRotation: rotation.optional(),
+  pcbPositionAnchor: z.string().optional(),
   layer: layer_ref.optional(),
   pcbRelative: z.boolean().optional(),
   relative: z.boolean().optional(),
@@ -68,6 +71,7 @@ export const commonLayoutProps = z.object({
   pcbX: distance.optional(),
   pcbY: distance.optional(),
   pcbRotation: rotation.optional(),
+  pcbPositionAnchor: z.string().optional(),
   schX: distance.optional(),
   schY: distance.optional(),
   schRotation: rotation.optional(),

--- a/tests/pcbPositionAnchor.test.ts
+++ b/tests/pcbPositionAnchor.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test"
+import { resistorProps, type ResistorProps } from "lib/components/resistor"
+
+test("pcbPositionAnchor defaults allow padcenter", () => {
+  const raw: ResistorProps = {
+    name: "R1",
+    resistance: 1000,
+    pcbPositionAnchor: "padcenter",
+  }
+  const parsed = resistorProps.parse(raw)
+  expect(parsed.pcbPositionAnchor).toBe("padcenter")
+})
+
+test("pcbPositionAnchor accepts arbitrary strings", () => {
+  const raw: ResistorProps = {
+    name: "R1",
+    resistance: 1000,
+    pcbPositionAnchor: "pin1",
+  }
+  const parsed = resistorProps.parse(raw)
+  expect(parsed.pcbPositionAnchor).toBe("pin1")
+})


### PR DESCRIPTION
## Summary
- allow setting `pcbPositionAnchor` to customize PCB coordinate origin
- document `pcbPositionAnchor` in generated component docs
- test `pcbPositionAnchor` with resistor component

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/pcbPositionAnchor.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests`


------
https://chatgpt.com/codex/tasks/task_b_68bf0db24a4c832ebfa7645c79324dd4