### PR TITLE
feat: add pcb margin props for components

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -120,6 +120,12 @@ export interface PcbLayoutProps {
   pcbRotation?: string | number
   pcbPositionAnchor?: string
   layer?: LayerRefInput
+  pcbMarginTop?: string | number
+  pcbMarginRight?: string | number
+  pcbMarginBottom?: string | number
+  pcbMarginLeft?: string | number
+  pcbMarginX?: string | number
+  pcbMarginY?: string | number
   pcbRelative?: boolean
   relative?: boolean
 }
@@ -131,6 +137,13 @@ export interface CommonLayoutProps {
   pcbY?: string | number
   pcbRotation?: string | number
   pcbPositionAnchor?: string
+
+  pcbMarginTop?: string | number
+  pcbMarginRight?: string | number
+  pcbMarginBottom?: string | number
+  pcbMarginLeft?: string | number
+  pcbMarginX?: string | number
+  pcbMarginY?: string | number
 
   schX?: string | number
   schY?: string | number
@@ -154,6 +167,12 @@ export const pcbLayoutProps = z.object({
   pcbRotation: rotation.optional(),
   pcbPositionAnchor: z.string().optional(),
   layer: layer_ref.optional(),
+  pcbMarginTop: distance.optional(),
+  pcbMarginRight: distance.optional(),
+  pcbMarginBottom: distance.optional(),
+  pcbMarginLeft: distance.optional(),
+  pcbMarginX: distance.optional(),
+  pcbMarginY: distance.optional(),
   pcbRelative: z.boolean().optional(),
   relative: z.boolean().optional(),
 })
@@ -162,6 +181,12 @@ export const commonLayoutProps = z.object({
   pcbY: distance.optional(),
   pcbRotation: rotation.optional(),
   pcbPositionAnchor: z.string().optional(),
+  pcbMarginTop: distance.optional(),
+  pcbMarginRight: distance.optional(),
+  pcbMarginBottom: distance.optional(),
+  pcbMarginLeft: distance.optional(),
+  pcbMarginX: distance.optional(),
+  pcbMarginY: distance.optional(),
   schX: distance.optional(),
   schY: distance.optional(),
   schRotation: rotation.optional(),

--- a/lib/common/layout.ts
+++ b/lib/common/layout.ts
@@ -16,6 +16,12 @@ export interface PcbLayoutProps {
   pcbRotation?: string | number
   pcbPositionAnchor?: string
   layer?: LayerRefInput
+  pcbMarginTop?: string | number
+  pcbMarginRight?: string | number
+  pcbMarginBottom?: string | number
+  pcbMarginLeft?: string | number
+  pcbMarginX?: string | number
+  pcbMarginY?: string | number
   /**
    * If true, pcbX/pcbY will be interpreted relative to the parent group
    */
@@ -31,6 +37,13 @@ export interface CommonLayoutProps {
   pcbY?: string | number
   pcbRotation?: string | number
   pcbPositionAnchor?: string
+
+  pcbMarginTop?: string | number
+  pcbMarginRight?: string | number
+  pcbMarginBottom?: string | number
+  pcbMarginLeft?: string | number
+  pcbMarginX?: string | number
+  pcbMarginY?: string | number
 
   schX?: string | number
   schY?: string | number
@@ -61,6 +74,12 @@ export const pcbLayoutProps = z.object({
   pcbRotation: rotation.optional(),
   pcbPositionAnchor: z.string().optional(),
   layer: layer_ref.optional(),
+  pcbMarginTop: distance.optional(),
+  pcbMarginRight: distance.optional(),
+  pcbMarginBottom: distance.optional(),
+  pcbMarginLeft: distance.optional(),
+  pcbMarginX: distance.optional(),
+  pcbMarginY: distance.optional(),
   pcbRelative: z.boolean().optional(),
   relative: z.boolean().optional(),
 })
@@ -72,6 +91,12 @@ export const commonLayoutProps = z.object({
   pcbY: distance.optional(),
   pcbRotation: rotation.optional(),
   pcbPositionAnchor: z.string().optional(),
+  pcbMarginTop: distance.optional(),
+  pcbMarginRight: distance.optional(),
+  pcbMarginBottom: distance.optional(),
+  pcbMarginLeft: distance.optional(),
+  pcbMarginX: distance.optional(),
+  pcbMarginY: distance.optional(),
   schX: distance.optional(),
   schY: distance.optional(),
   schRotation: rotation.optional(),

--- a/tests/pcbMargin.test.ts
+++ b/tests/pcbMargin.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import { batteryProps, type BatteryProps } from "lib/components/battery"
+
+test("should parse pcbMargin props", () => {
+  const raw: BatteryProps = {
+    name: "bat1",
+    pcbMarginTop: "1mm",
+    pcbMarginRight: "2mm",
+    pcbMarginBottom: 3,
+    pcbMarginLeft: "4mm",
+    pcbMarginX: "5mm",
+    pcbMarginY: 6,
+  }
+  const parsed = batteryProps.parse(raw)
+  expect(parsed.pcbMarginTop).toBe(1)
+  expect(parsed.pcbMarginRight).toBe(2)
+  expect(parsed.pcbMarginBottom).toBe(3)
+  expect(parsed.pcbMarginLeft).toBe(4)
+  expect(parsed.pcbMarginX).toBe(5)
+  expect(parsed.pcbMarginY).toBe(6)
+})


### PR DESCRIPTION
## Summary
- add pcb margin layout fields to component schemas
- document pcb margin props in generated docs
- test pcb margin parsing for components

## Testing
- `bun test tests/pcbMargin.test.ts`
- `bun test tests/battery.test.ts`
- `bun test tests/platedhole.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68bf258a4e28832eb2e220f8c2aafb1a