### PR TITLE
feat: add schematic margin props

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -145,6 +145,13 @@ export interface CommonLayoutProps {
   pcbMarginX?: string | number
   pcbMarginY?: string | number
 
+  schMarginTop?: string | number
+  schMarginRight?: string | number
+  schMarginBottom?: string | number
+  schMarginLeft?: string | number
+  schMarginX?: string | number
+  schMarginY?: string | number
+
   schX?: string | number
   schY?: string | number
   schRotation?: string | number
@@ -187,6 +194,12 @@ export const commonLayoutProps = z.object({
   pcbMarginLeft: distance.optional(),
   pcbMarginX: distance.optional(),
   pcbMarginY: distance.optional(),
+  schMarginTop: distance.optional(),
+  schMarginRight: distance.optional(),
+  schMarginBottom: distance.optional(),
+  schMarginLeft: distance.optional(),
+  schMarginX: distance.optional(),
+  schMarginY: distance.optional(),
   schX: distance.optional(),
   schY: distance.optional(),
   schRotation: rotation.optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-09-08T17:03:36.951Z
+> Generated at 2025-09-08T20:09:16.903Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -343,6 +343,21 @@ export interface CommonLayoutProps {
   pcbX?: string | number
   pcbY?: string | number
   pcbRotation?: string | number
+  pcbPositionAnchor?: string
+
+  pcbMarginTop?: string | number
+  pcbMarginRight?: string | number
+  pcbMarginBottom?: string | number
+  pcbMarginLeft?: string | number
+  pcbMarginX?: string | number
+  pcbMarginY?: string | number
+
+  schMarginTop?: string | number
+  schMarginRight?: string | number
+  schMarginBottom?: string | number
+  schMarginLeft?: string | number
+  schMarginX?: string | number
+  schMarginY?: string | number
 
   schX?: string | number
   schY?: string | number
@@ -710,7 +725,14 @@ export interface PcbLayoutProps {
   pcbX?: string | number
   pcbY?: string | number
   pcbRotation?: string | number
+  pcbPositionAnchor?: string
   layer?: LayerRefInput
+  pcbMarginTop?: string | number
+  pcbMarginRight?: string | number
+  pcbMarginBottom?: string | number
+  pcbMarginLeft?: string | number
+  pcbMarginX?: string | number
+  pcbMarginY?: string | number
   /**
    * If true, pcbX/pcbY will be interpreted relative to the parent group
    */

--- a/lib/common/layout.ts
+++ b/lib/common/layout.ts
@@ -45,6 +45,13 @@ export interface CommonLayoutProps {
   pcbMarginX?: string | number
   pcbMarginY?: string | number
 
+  schMarginTop?: string | number
+  schMarginRight?: string | number
+  schMarginBottom?: string | number
+  schMarginLeft?: string | number
+  schMarginX?: string | number
+  schMarginY?: string | number
+
   schX?: string | number
   schY?: string | number
   schRotation?: string | number
@@ -97,6 +104,12 @@ export const commonLayoutProps = z.object({
   pcbMarginLeft: distance.optional(),
   pcbMarginX: distance.optional(),
   pcbMarginY: distance.optional(),
+  schMarginTop: distance.optional(),
+  schMarginRight: distance.optional(),
+  schMarginBottom: distance.optional(),
+  schMarginLeft: distance.optional(),
+  schMarginX: distance.optional(),
+  schMarginY: distance.optional(),
   schX: distance.optional(),
   schY: distance.optional(),
   schRotation: rotation.optional(),

--- a/tests/schMargin.test.ts
+++ b/tests/schMargin.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import { batteryProps, type BatteryProps } from "lib/components/battery"
+
+test("should parse schMargin props", () => {
+  const raw: BatteryProps = {
+    name: "bat1",
+    schMarginTop: "1mm",
+    schMarginRight: "2mm",
+    schMarginBottom: 3,
+    schMarginLeft: "4mm",
+    schMarginX: "5mm",
+    schMarginY: 6,
+  }
+  const parsed = batteryProps.parse(raw)
+  expect(parsed.schMarginTop).toBe(1)
+  expect(parsed.schMarginRight).toBe(2)
+  expect(parsed.schMarginBottom).toBe(3)
+  expect(parsed.schMarginLeft).toBe(4)
+  expect(parsed.schMarginX).toBe(5)
+  expect(parsed.schMarginY).toBe(6)
+})


### PR DESCRIPTION
## Summary
- add schematic margin props to common layout
- document schematic margin props in generated docs
- test schematic margin prop parsing

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68bf3772e114832eb10c4bb7c3ff237b