### PR TITLE
feat: support cadModel in footprint library map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1036,16 +1036,10 @@ export interface PlatformConfig {
 
   footprintLibraryMap?: Record<
     string,
-    | ((
-        path: string,
-      ) => Promise<{ footprintCircuitJson: any[]; cadModel?: CadModelProp }>)
+    | ((path: string) => Promise<FootprintLibraryResult>)
     | Record<
         string,
-        | any[]
-        | ((path: string) => Promise<{
-            footprintCircuitJson: any[];
-            cadModel?: CadModelProp;
-          }>)
+        any[] | ((path: string) => Promise<FootprintLibraryResult>)
       >
   >;
 }

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-09-08T21:44:45.218Z
+> Generated at 2025-09-09T00:49:12.874Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -493,6 +493,12 @@ export interface EditTraceHintEvent extends BaseManualEditEvent {
 }
 
 
+export interface FootprintLibraryResult {
+  footprintCircuitJson: any[]
+  cadModel?: CadModelProp
+}
+
+
 export interface FootprintProps {
   /**
    * The layer that the footprint is designed for. If you set this to "top"
@@ -943,17 +949,8 @@ export interface PlatformConfig {
 
   footprintLibraryMap?: Record<
     string,
-    | ((
-        path: string,
-      ) => Promise<{ footprintCircuitJson: any[]; cadModel?: CadModelProp }>)
-    | Record<
-        string,
-        | any[]
-        | ((path: string) => Promise<{
-            footprintCircuitJson: any[]
-            cadModel?: CadModelProp
-          }>)
-      >
+    | ((path: string) => Promise<FootprintLibraryResult>)
+    | Record<string, any[] | ((path: string) => Promise<FootprintLibraryResult>)>
   >
 }
 

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -8,6 +8,11 @@ import { expectTypesMatch } from "./typecheck"
 import { z } from "zod"
 import { type CadModelProp, cadModelProp } from "./common/cadModel"
 
+export interface FootprintLibraryResult {
+  footprintCircuitJson: any[]
+  cadModel?: CadModelProp
+}
+
 export interface PlatformConfig {
   partsEngine?: PartsEngine
 
@@ -31,32 +36,23 @@ export interface PlatformConfig {
 
   footprintLibraryMap?: Record<
     string,
-    | ((
-        path: string,
-      ) => Promise<{ footprintCircuitJson: any[]; cadModel?: CadModelProp }>)
+    | ((path: string) => Promise<FootprintLibraryResult>)
     | Record<
         string,
-        | any[]
-        | ((path: string) => Promise<{
-            footprintCircuitJson: any[]
-            cadModel?: CadModelProp
-          }>)
+        any[] | ((path: string) => Promise<FootprintLibraryResult>)
       >
   >
 }
 
 const unvalidatedCircuitJson = z.array(z.any()).describe("Circuit JSON")
+const footprintLibraryResult = z.object({
+  footprintCircuitJson: z.array(z.any()),
+  cadModel: cadModelProp.optional(),
+})
 const pathToCircuitJsonFn = z
   .function()
   .args(z.string())
-  .returns(
-    z.promise(
-      z.object({
-        footprintCircuitJson: z.array(z.any()),
-        cadModel: cadModelProp.optional(),
-      }),
-    ),
-  )
+  .returns(z.promise(footprintLibraryResult))
   .describe("A function that takes a path and returns Circuit JSON")
 
 export const platformConfig = z.object({

--- a/tests/footprintLibraryMap-cadModel.test.ts
+++ b/tests/footprintLibraryMap-cadModel.test.ts
@@ -8,7 +8,13 @@ test("footprintLibraryMap function may return cadModel", async () => {
     footprintLibraryMap: {
       lib: async (_path: string) => ({
         footprintCircuitJson: [],
-        cadModel: { stlUrl: "model.stl" },
+        cadModel: {
+          objUrl: "model.obj",
+          mtlUrl: "model.mtl",
+          rotationOffset: { x: 1, y: 2, z: 3 },
+          positionOffset: { x: 4, y: 5, z: 6 },
+          size: { x: 7, y: 8, z: 9 },
+        },
       }),
     },
   })
@@ -17,6 +23,12 @@ test("footprintLibraryMap function may return cadModel", async () => {
     throw new Error("footprintLibraryMap.lib is not a function")
   }
   const result = await entry("myfootprint")
-  expect(result.cadModel).toEqual({ stlUrl: "model.stl" })
+  expect(result.cadModel).toEqual({
+    objUrl: "model.obj",
+    mtlUrl: "model.mtl",
+    rotationOffset: { x: 1, y: 2, z: 3 },
+    positionOffset: { x: 4, y: 5, z: 6 },
+    size: { x: 7, y: 8, z: 9 },
+  })
   expect(Array.isArray(result.footprintCircuitJson)).toBe(true)
 })


### PR DESCRIPTION
## Summary
- define `FootprintLibraryResult` and allow `footprintLibraryMap` functions to return optional `cadModel`
- document `FootprintLibraryResult` in generated docs
- test returning `cadModel` data from `footprintLibraryMap`

## Testing
- `bun test tests/footprintLibraryMap-cadModel.test.ts`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68bf78e68e84832e8e178c349d0c4a8d