### PR TITLE
feat: add cadModel unit scale

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -20,11 +20,13 @@ export interface CadModelBase {
     z: number | string
   }
   size?: { x: number | string; y: number | string; z: number | string }
+  modelUnitToMmScale?: Distance
 }
 export const cadModelBase = z.object({
   rotationOffset: z.number().or(rotationPoint3).optional(),
   positionOffset: point3.optional(),
   size: point3.optional(),
+  modelUnitToMmScale: distance.optional(),
 })
 export interface CadModelStl extends CadModelBase {
   stlUrl: string

--- a/lib/common/cadModel.ts
+++ b/lib/common/cadModel.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
-import { point3 } from "./point3"
 import { expectTypesMatch } from "lib/typecheck"
+import { distance, type Distance } from "./distance"
+import { point3 } from "./point3"
 
 export const rotationPoint3 = z.object({
   x: z.union([z.number(), z.string()]),
@@ -18,12 +19,14 @@ export interface CadModelBase {
     z: number | string
   }
   size?: { x: number | string; y: number | string; z: number | string }
+  modelUnitToMmScale?: Distance
 }
 
 export const cadModelBase = z.object({
   rotationOffset: z.number().or(rotationPoint3).optional(),
   positionOffset: point3.optional(),
   size: point3.optional(),
+  modelUnitToMmScale: distance.optional(),
 })
 
 expectTypesMatch<CadModelBase, z.input<typeof cadModelBase>>(true)

--- a/tests/footprintLibraryMap-cadModel.test.ts
+++ b/tests/footprintLibraryMap-cadModel.test.ts
@@ -14,6 +14,7 @@ test("footprintLibraryMap function may return cadModel", async () => {
           rotationOffset: { x: 1, y: 2, z: 3 },
           positionOffset: { x: 4, y: 5, z: 6 },
           size: { x: 7, y: 8, z: 9 },
+          modelUnitToMmScale: 2,
         },
       }),
     },
@@ -29,6 +30,7 @@ test("footprintLibraryMap function may return cadModel", async () => {
     rotationOffset: { x: 1, y: 2, z: 3 },
     positionOffset: { x: 4, y: 5, z: 6 },
     size: { x: 7, y: 8, z: 9 },
+    modelUnitToMmScale: 2,
   })
   expect(Array.isArray(result.footprintCircuitJson)).toBe(true)
 })


### PR DESCRIPTION
## Summary
- allow specifying CAD model unit scale via optional `modelUnitToMmScale`
- cover new CAD model property in tests
- regenerate component type docs

## Testing
- `bun test tests/footprintLibraryMap-cadModel.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68c1032db2b0832e8eecc13b8d2b1e70