### PR TITLE
feat: add projectBaseUrl to platformConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -1026,6 +1026,7 @@ export interface PlatformConfig {
   cloudAutorouterUrl?: string;
 
   projectName?: string;
+  projectBaseUrl?: string;
   version?: string;
   url?: string;
   printBoardInformationToSilkscreen?: boolean;

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -26,6 +26,7 @@ export interface PlatformConfig {
   cloudAutorouterUrl?: string
 
   projectName?: string
+  projectBaseUrl?: string
   version?: string
   url?: string
   printBoardInformationToSilkscreen?: boolean
@@ -61,6 +62,7 @@ export const platformConfig = z.object({
   registryApiUrl: z.string().optional(),
   cloudAutorouterUrl: z.string().optional(),
   projectName: z.string().optional(),
+  projectBaseUrl: z.string().optional(),
   version: z.string().optional(),
   url: z.string().optional(),
   printBoardInformationToSilkscreen: z.boolean().optional(),

--- a/tests/projectBaseUrl.test.ts
+++ b/tests/projectBaseUrl.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test"
+import { platformConfig } from "lib/platformConfig"
+
+test("projectBaseUrl can be set", () => {
+  const config = platformConfig.parse({
+    projectBaseUrl: "https://example.com/",
+  })
+  expect(config.projectBaseUrl).toBe("https://example.com/")
+})


### PR DESCRIPTION
## Summary
- add optional `projectBaseUrl` to `PlatformConfig`
- document `projectBaseUrl` in README
- test `projectBaseUrl` parsing

## Testing
- `bun test tests`


------
https://chatgpt.com/codex/tasks/task_b_68c2fec318dc832e8b98c1a7cf2317f8