### PR TITLE
feat: add freerouting autorouter preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
 
 [Source](https://github.com/tscircuit/props/blob/main/lib/components/group.ts)
 
+> **Note:** Autorouter preset strings now use `snake_case` (e.g., `auto_cloud`).
+> Kebab-case forms like `auto-cloud` are deprecated but remain supported for
+> backward compatibility.
+
 ### BatteryProps `<battery />`
 
 ```ts
@@ -211,6 +215,8 @@ export interface CadAssemblyProps {
    * "top" and this is most intuitive.
    */
   originalLayer?: LayerRef;
+
+  children?: any;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -72,6 +72,12 @@ export interface CadModelJscad extends CadModelBase {
 export const cadModelJscad = cadModelBase.extend({
   jscad: z.record(z.any()),
 })
+export const cadModelProp = z.union([
+  z.null(),
+  z.string(),
+  z.custom<ReactElement>((v) => {
+    return v && typeof v === "object" && "type" in v && "props" in v
+  }),
 ```
 
 ### connectionsProp
@@ -462,6 +468,8 @@ export const breakoutPointProps = pcbLayoutProps
 ```typescript
 export interface CadAssemblyProps {
   originalLayer?: LayerRef
+
+  children?: any
 }
 /**
    * The layer that the CAD assembly is designed for. If you set this to "top"
@@ -475,6 +483,7 @@ export interface CadAssemblyProps {
    */
 export const cadassemblyProps = z.object({
   originalLayer: layer_ref.default("top").optional(),
+  children: z.any().optional(),
 })
 ```
 
@@ -1182,15 +1191,22 @@ export interface AutorouterConfig {
   serverCacheEnabled?: boolean
   cache?: PcbRouteCache
   traceClearance?: Distance
-  groupMode?: "sequential-trace" | "subcircuit"
+  groupMode?:
+    | "sequential_trace"
+    | "subcircuit"
+    | /** @deprecated Use "sequential_trace" */ "sequential-trace"
   local?: boolean
   algorithmFn?: (simpleRouteJson: any) => Promise<any>
   preset?:
-    | "sequential-trace"
+    | "sequential_trace"
     | "subcircuit"
     | "auto"
-    | "auto-local"
-    | "auto-cloud"
+    | "auto_local"
+    | "auto_cloud"
+    | "freerouting"
+    | /** @deprecated Use "sequential_trace" */ "sequential-trace"
+    | /** @deprecated Use "auto_local" */ "auto-local"
+    | /** @deprecated Use "auto_cloud" */ "auto-cloud"
 }
 export const autorouterConfig = z.object({
   serverUrl: z.string().optional(),
@@ -1199,7 +1215,9 @@ export const autorouterConfig = z.object({
   serverCacheEnabled: z.boolean().optional(),
   cache: z.custom<PcbRouteCache>((v) => true).optional(),
   traceClearance: length.optional(),
-  groupMode: z.enum(["sequential-trace", "subcircuit"]).optional(),
+  groupMode: z
+    .enum(["sequential_trace", "subcircuit", "sequential-trace"])
+    .optional(),
   algorithmFn: z
     .custom<(simpleRouteJson: any) => Promise<any>>(
       (v) => typeof v === "function" || v === undefined,
@@ -1207,9 +1225,13 @@ export const autorouterConfig = z.object({
     .optional(),
   preset: z
     .enum([
-      "sequential-trace",
+      "sequential_trace",
       "subcircuit",
       "auto",
+      "auto_local",
+      "auto_cloud",
+      "freerouting",
+      "sequential-trace",
       "auto-local",
       "auto-cloud",
     ])

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -255,22 +255,33 @@ export interface AutorouterConfig {
   serverCacheEnabled?: boolean
   cache?: PcbRouteCache
   traceClearance?: Distance
-  groupMode?: "sequential-trace" | "subcircuit"
+  groupMode?:
+    | "sequential_trace"
+    | "subcircuit"
+    | /** @deprecated Use "sequential_trace" */ "sequential-trace"
   local?: boolean
   algorithmFn?: (simpleRouteJson: any) => Promise<any>
   preset?:
-    | "sequential-trace"
+    | "sequential_trace"
     | "subcircuit"
     | "auto"
-    | "auto-local"
-    | "auto-cloud"
+    | "auto_local"
+    | "auto_cloud"
+    | "freerouting"
+    | /** @deprecated Use "sequential_trace" */ "sequential-trace"
+    | /** @deprecated Use "auto_local" */ "auto-local"
+    | /** @deprecated Use "auto_cloud" */ "auto-cloud"
 }
 
 export type AutorouterProp =
   | AutorouterConfig
-  | "sequential-trace"
+  | "sequential_trace"
   | "subcircuit"
   | "auto"
+  | "auto_local"
+  | "auto_cloud"
+  | "freerouting"
+  | "sequential-trace"
   | "auto-local"
   | "auto-cloud"
 
@@ -281,7 +292,9 @@ export const autorouterConfig = z.object({
   serverCacheEnabled: z.boolean().optional(),
   cache: z.custom<PcbRouteCache>((v) => true).optional(),
   traceClearance: length.optional(),
-  groupMode: z.enum(["sequential-trace", "subcircuit"]).optional(),
+  groupMode: z
+    .enum(["sequential_trace", "subcircuit", "sequential-trace"])
+    .optional(),
   algorithmFn: z
     .custom<(simpleRouteJson: any) => Promise<any>>(
       (v) => typeof v === "function" || v === undefined,
@@ -289,9 +302,13 @@ export const autorouterConfig = z.object({
     .optional(),
   preset: z
     .enum([
-      "sequential-trace",
+      "sequential_trace",
       "subcircuit",
       "auto",
+      "auto_local",
+      "auto_cloud",
+      "freerouting",
+      "sequential-trace",
       "auto-local",
       "auto-cloud",
     ])
@@ -301,9 +318,13 @@ export const autorouterConfig = z.object({
 
 export const autorouterProp = z.union([
   autorouterConfig,
-  z.literal("sequential-trace"),
+  z.literal("sequential_trace"),
   z.literal("subcircuit"),
   z.literal("auto"),
+  z.literal("auto_local"),
+  z.literal("auto_cloud"),
+  z.literal("freerouting"),
+  z.literal("sequential-trace"),
   z.literal("auto-local"),
   z.literal("auto-cloud"),
 ])

--- a/tests/autorouter.test.ts
+++ b/tests/autorouter.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test"
+import { autorouterProp } from "../lib/components/group"
+
+test("supports freerouting preset", () => {
+  const result = autorouterProp.parse("freerouting")
+  expect(result).toBe("freerouting")
+})
+
+test("supports snake_case presets", () => {
+  const result = autorouterProp.parse("auto_cloud")
+  expect(result).toBe("auto_cloud")
+})
+
+test("still supports deprecated kebab-case presets", () => {
+  const result = autorouterProp.parse("auto-cloud")
+  expect(result).toBe("auto-cloud")
+})


### PR DESCRIPTION
## Summary
- support `freerouting` in autorouter presets
- switch autorouter presets to snake_case
- document deprecation of kebab-case presets

## Testing
- `bun test tests/autorouter.test.ts`
- `bun test tests/group.test.ts`
- `bunx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68c4d8a4d410832e88b906c6644a88b5