### PR TITLE
feat: add coveredWithSolderMask to smtpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,6 +879,7 @@ export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   width: Distance;
   height: Distance;
   portHints?: PortHints;
+  coveredWithSolderMask?: boolean;
 }
 ```
 

--- a/docs/CIRCUIT_JSON_PCB_OVERVIEW.md
+++ b/docs/CIRCUIT_JSON_PCB_OVERVIEW.md
@@ -245,6 +245,7 @@ export interface PcbSmtPadCircle {
   radius: number
   layer: LayerRef
   port_hints?: string[]
+  covered_with_solder_mask?: boolean
   pcb_component_id?: string
   pcb_port_id?: string
 }
@@ -260,6 +261,7 @@ export interface PcbSmtPadRect {
   height: number
   layer: LayerRef
   port_hints?: string[]
+  covered_with_solder_mask?: boolean
   pcb_component_id?: string
   pcb_port_id?: string
 }

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2093,6 +2093,7 @@ export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   width: Distance
   height: Distance
   portHints?: PortHints
+  coveredWithSolderMask?: boolean
 }
 export interface RotatedRectSmtPadProps
   extends Omit<PcbLayoutProps, "pcbRotation"> {
@@ -2102,12 +2103,14 @@ export interface RotatedRectSmtPadProps
   height: Distance
   ccwRotation: number
   portHints?: PortHints
+  coveredWithSolderMask?: boolean
 }
 export interface CircleSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   name?: string
   shape: "circle"
   radius: Distance
   portHints?: PortHints
+  coveredWithSolderMask?: boolean
 }
 export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   name?: string
@@ -2116,6 +2119,7 @@ export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   height: Distance
   radius: Distance
   portHints?: PortHints
+  coveredWithSolderMask?: boolean
 }
 export interface PolygonSmtPadProps
   extends Omit<PcbLayoutProps, "pcbRotation"> {
@@ -2123,6 +2127,7 @@ export interface PolygonSmtPadProps
   shape: "polygon"
   points: Point[]
   portHints?: PortHints
+  coveredWithSolderMask?: boolean
 }
 export const rectSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
@@ -2132,6 +2137,7 @@ export const rectSmtPadProps = pcbLayoutProps
     width: distance,
     height: distance,
     portHints: portHints.optional(),
+    coveredWithSolderMask: z.boolean().optional(),
   })
 export const rotatedRectSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
@@ -2142,6 +2148,7 @@ export const rotatedRectSmtPadProps = pcbLayoutProps
     height: distance,
     ccwRotation: z.number(),
     portHints: portHints.optional(),
+    coveredWithSolderMask: z.boolean().optional(),
   })
 export const circleSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
@@ -2150,6 +2157,7 @@ export const circleSmtPadProps = pcbLayoutProps
     shape: z.literal("circle"),
     radius: distance,
     portHints: portHints.optional(),
+    coveredWithSolderMask: z.boolean().optional(),
   })
 export const pillSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
@@ -2160,6 +2168,7 @@ export const pillSmtPadProps = pcbLayoutProps
     height: distance,
     radius: distance,
     portHints: portHints.optional(),
+    coveredWithSolderMask: z.boolean().optional(),
   })
 export const polygonSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
@@ -2168,6 +2177,7 @@ export const polygonSmtPadProps = pcbLayoutProps
     shape: z.literal("polygon"),
     points: z.array(point),
     portHints: portHints.optional(),
+    coveredWithSolderMask: z.boolean().optional(),
   })
 ```
 

--- a/lib/components/smtpad.ts
+++ b/lib/components/smtpad.ts
@@ -15,6 +15,7 @@ export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   width: Distance
   height: Distance
   portHints?: PortHints
+  coveredWithSolderMask?: boolean
 }
 
 export interface RotatedRectSmtPadProps
@@ -25,6 +26,7 @@ export interface RotatedRectSmtPadProps
   height: Distance
   ccwRotation: number
   portHints?: PortHints
+  coveredWithSolderMask?: boolean
 }
 
 export interface CircleSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
@@ -32,6 +34,7 @@ export interface CircleSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   shape: "circle"
   radius: Distance
   portHints?: PortHints
+  coveredWithSolderMask?: boolean
 }
 
 export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
@@ -41,6 +44,7 @@ export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   height: Distance
   radius: Distance
   portHints?: PortHints
+  coveredWithSolderMask?: boolean
 }
 
 export interface PolygonSmtPadProps
@@ -49,6 +53,7 @@ export interface PolygonSmtPadProps
   shape: "polygon"
   points: Point[]
   portHints?: PortHints
+  coveredWithSolderMask?: boolean
 }
 
 export type SmtPadProps =
@@ -70,6 +75,7 @@ export const rectSmtPadProps = pcbLayoutProps
     width: distance,
     height: distance,
     portHints: portHints.optional(),
+    coveredWithSolderMask: z.boolean().optional(),
   })
 type InferredRectSmtPadProps = z.input<typeof rectSmtPadProps>
 expectTypesMatch<InferredRectSmtPadProps, RectSmtPadProps>(true)
@@ -83,6 +89,7 @@ export const rotatedRectSmtPadProps = pcbLayoutProps
     height: distance,
     ccwRotation: z.number(),
     portHints: portHints.optional(),
+    coveredWithSolderMask: z.boolean().optional(),
   })
 type InferredRotatedRectSmtPadProps = z.input<typeof rotatedRectSmtPadProps>
 expectTypesMatch<InferredRotatedRectSmtPadProps, RotatedRectSmtPadProps>(true)
@@ -94,6 +101,7 @@ export const circleSmtPadProps = pcbLayoutProps
     shape: z.literal("circle"),
     radius: distance,
     portHints: portHints.optional(),
+    coveredWithSolderMask: z.boolean().optional(),
   })
 type InferredCircleSmtPadProps = z.input<typeof circleSmtPadProps>
 expectTypesMatch<InferredCircleSmtPadProps, CircleSmtPadProps>(true)
@@ -107,6 +115,7 @@ export const pillSmtPadProps = pcbLayoutProps
     height: distance,
     radius: distance,
     portHints: portHints.optional(),
+    coveredWithSolderMask: z.boolean().optional(),
   })
 type InferredPillSmtPadProps = z.input<typeof pillSmtPadProps>
 expectTypesMatch<InferredPillSmtPadProps, PillSmtPadProps>(true)
@@ -118,6 +127,7 @@ export const polygonSmtPadProps = pcbLayoutProps
     shape: z.literal("polygon"),
     points: z.array(point),
     portHints: portHints.optional(),
+    coveredWithSolderMask: z.boolean().optional(),
   })
 type InferredPolygonSmtPadProps = z.input<typeof polygonSmtPadProps>
 expectTypesMatch<InferredPolygonSmtPadProps, PolygonSmtPadProps>(true)

--- a/tests/smtpad.test.ts
+++ b/tests/smtpad.test.ts
@@ -19,6 +19,7 @@ test("should parse PolygonSmtPadProps", () => {
     ],
     pcbX: 0,
     pcbY: "1mm",
+    coveredWithSolderMask: true,
   }
 
   expectTypeOf(rawProps).toMatchTypeOf<z.input<typeof polygonSmtPadProps>>()
@@ -27,11 +28,13 @@ test("should parse PolygonSmtPadProps", () => {
   expect(parsed.name).toBe("pad1")
   expect(parsed.points.length).toBe(3)
   expect(parsed.pcbY).toBe(1)
+  expect(parsed.coveredWithSolderMask).toBe(true)
 
   const parsedUnion = smtPadProps.parse(rawProps)
   if (parsedUnion.shape === "polygon") {
     expect(parsedUnion.name).toBe("pad1")
     expect(parsedUnion.points.length).toBe(3)
+    expect(parsedUnion.coveredWithSolderMask).toBe(true)
   } else {
     throw new Error("Expected PolygonSmtPadProps")
   }


### PR DESCRIPTION
## Summary
- add optional `coveredWithSolderMask` to `<smtpad />`
- document `covered_with_solder_mask` in PCB JSON docs
- cover new property in tests and generated docs

## Testing
- `bunx tsc --noEmit`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/smtpad.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68c703536618832e905ff36362c079ce