### PR TITLE
Add includeInBoardPinout pin attribute support

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -233,6 +233,7 @@ export interface PinAttributeMap {
   providesVoltage?: string | number
   requiresVoltage?: string | number
   doNotConnect?: boolean
+  includeInBoardPinout?: boolean
 }
 export const pinAttributeMap = z.object({
   providesPower: z.boolean().optional(),
@@ -242,6 +243,7 @@ export const pinAttributeMap = z.object({
   providesVoltage: z.union([z.string(), z.number()]).optional(),
   requiresVoltage: z.union([z.string(), z.number()]).optional(),
   doNotConnect: z.boolean().optional(),
+  includeInBoardPinout: z.boolean().optional(),
 })
 export interface CommonComponentProps<PinLabel extends string = string>
   extends CommonLayoutProps {

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -846,6 +846,7 @@ export interface PinAttributeMap {
   providesVoltage?: string | number
   requiresVoltage?: string | number
   doNotConnect?: boolean
+  includeInBoardPinout?: boolean
 }
 
 

--- a/lib/common/layout.ts
+++ b/lib/common/layout.ts
@@ -151,6 +151,7 @@ export interface PinAttributeMap {
   providesVoltage?: string | number
   requiresVoltage?: string | number
   doNotConnect?: boolean
+  includeInBoardPinout?: boolean
 }
 
 export const pinAttributeMap = z.object({
@@ -161,6 +162,7 @@ export const pinAttributeMap = z.object({
   providesVoltage: z.union([z.string(), z.number()]).optional(),
   requiresVoltage: z.union([z.string(), z.number()]).optional(),
   doNotConnect: z.boolean().optional(),
+  includeInBoardPinout: z.boolean().optional(),
 })
 
 expectTypesMatch<PinAttributeMap, z.input<typeof pinAttributeMap>>(true)

--- a/tests/chip3-type-tests.test.tsx
+++ b/tests/chip3-type-tests.test.tsx
@@ -147,7 +147,11 @@ test("[typetest] pinAttributes type matches pin labels", () => {
       pinLabels={pinLabels1}
       pinAttributes={{
         VCC: { providesPower: true },
-        GND: { requiresPower: true, doNotConnect: true },
+        GND: {
+          requiresPower: true,
+          doNotConnect: true,
+          includeInBoardPinout: true,
+        },
         // @ts-expect-error
         INVALID: { foo: true },
       }}

--- a/tests/pinAttributes.test.ts
+++ b/tests/pinAttributes.test.ts
@@ -5,10 +5,11 @@ test("pinAttributes allows doNotConnect", () => {
   const rawProps = {
     name: "chip",
     pinAttributes: {
-      pin1: { doNotConnect: true },
+      pin1: { doNotConnect: true, includeInBoardPinout: false },
     },
   }
 
   const parsed = chipProps.parse(rawProps)
   expect(parsed.pinAttributes?.pin1?.doNotConnect).toBe(true)
+  expect(parsed.pinAttributes?.pin1?.includeInBoardPinout).toBe(false)
 })


### PR DESCRIPTION
## Summary
- allow pin attributes to specify `includeInBoardPinout` and validate it in the shared schema
- cover the new attribute with parsing/type tests
- document the new attribute in the generated component type references

## Testing
- bun test tests/pinAttributes.test.ts
- bun test tests/chip3-type-tests.test.tsx
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68c84f974a94832e92508322a73ed8ca