### PR TITLE
Add pill hole shape support

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,10 +550,32 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
 ### HoleProps `<hole />`
 
 ```ts
-export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+export type HoleProps = CircleHoleProps | PillHoleProps;
+```
+
+[Source](https://github.com/tscircuit/props/blob/main/lib/components/hole.ts)
+
+### CircleHoleProps `<hole />`
+
+```ts
+export interface CircleHoleProps extends PcbLayoutProps {
   name?: string;
+  shape?: "circle";
   diameter?: Distance;
   radius?: Distance;
+}
+```
+
+[Source](https://github.com/tscircuit/props/blob/main/lib/components/hole.ts)
+
+### PillHoleProps `<hole />`
+
+```ts
+export interface PillHoleProps extends PcbLayoutProps {
+  name?: string;
+  shape: "pill";
+  width: Distance;
+  height: Distance;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1391,18 +1391,38 @@ export const subcircuitGroupPropsWithBool = subcircuitGroupProps.extend({
 ### hole
 
 ```typescript
-export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+export interface CircleHoleProps extends PcbLayoutProps {
   name?: string
+  shape?: "circle"
   diameter?: Distance
   radius?: Distance
 }
-export const holeProps = pcbLayoutProps
-  .omit({ pcbRotation: true })
+export interface PillHoleProps extends PcbLayoutProps {
+  name?: string
+  shape: "pill"
+  width: Distance
+  height: Distance
+}
+export type HoleProps = CircleHoleProps | PillHoleProps
+const circleHoleProps = pcbLayoutProps
   .extend({
     name: z.string().optional(),
+    shape: z.literal("circle").optional(),
     diameter: distance.optional(),
     radius: distance.optional(),
   })
+  .transform((d) => ({
+    ...d,
+    diameter: d.diameter ?? 2 * d.radius!,
+    radius: d.radius ?? d.diameter! / 2,
+  }))
+const pillHoleProps = pcbLayoutProps.extend({
+  name: z.string().optional(),
+  shape: z.literal("pill"),
+  width: distance,
+  height: distance,
+})
+export const holeProps = z.union([circleHoleProps, pillHoleProps])
 ```
 
 ### inductor

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -323,6 +323,14 @@ export interface CirclePlatedHoleProps
 }
 
 
+export interface CircleHoleProps extends PcbLayoutProps {
+  name?: string
+  shape?: "circle"
+  diameter?: Distance
+  radius?: Distance
+}
+
+
 export interface CircleSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   name?: string
   shape: "circle"
@@ -577,11 +585,7 @@ export interface FuseProps<PinLabel extends string = string>
 }
 
 
-export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
-  name?: string
-  diameter?: Distance
-  radius?: Distance
-}
+export type HoleProps = CircleHoleProps | PillHoleProps
 
 
 export interface InductorProps<PinLabel extends string = string>
@@ -791,6 +795,14 @@ export interface PcbLayoutProps {
 export interface PcbRouteCache {
   pcbTraces: PcbTrace[]
   cacheKey: string
+}
+
+
+export interface PillHoleProps extends PcbLayoutProps {
+  name?: string
+  shape: "pill"
+  width: Distance
+  height: Distance
 }
 
 

--- a/lib/components/hole.ts
+++ b/lib/components/hole.ts
@@ -3,16 +3,26 @@ import { distance, type Distance } from "lib/common/distance"
 import { pcbLayoutProps, type PcbLayoutProps } from "lib/common/layout"
 import { expectTypesMatch } from "lib/typecheck"
 
-export interface HoleProps extends Omit<PcbLayoutProps, "pcbRotation"> {
+export interface CircleHoleProps extends PcbLayoutProps {
   name?: string
+  shape?: "circle"
   diameter?: Distance
   radius?: Distance
 }
 
-export const holeProps = pcbLayoutProps
-  .omit({ pcbRotation: true })
+export interface PillHoleProps extends PcbLayoutProps {
+  name?: string
+  shape: "pill"
+  width: Distance
+  height: Distance
+}
+
+export type HoleProps = CircleHoleProps | PillHoleProps
+
+const circleHoleProps = pcbLayoutProps
   .extend({
     name: z.string().optional(),
+    shape: z.literal("circle").optional(),
     diameter: distance.optional(),
     radius: distance.optional(),
   })
@@ -21,6 +31,15 @@ export const holeProps = pcbLayoutProps
     diameter: d.diameter ?? 2 * d.radius!,
     radius: d.radius ?? d.diameter! / 2,
   }))
+
+const pillHoleProps = pcbLayoutProps.extend({
+  name: z.string().optional(),
+  shape: z.literal("pill"),
+  width: distance,
+  height: distance,
+})
+
+export const holeProps = z.union([circleHoleProps, pillHoleProps])
 
 export type InferredHoleProps = z.input<typeof holeProps>
 

--- a/tests/hole.test.ts
+++ b/tests/hole.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import { expectTypeOf } from "expect-type"
+import { holeProps, type HoleProps } from "../lib/components/hole"
+import type { z } from "zod"
+
+test("circle holes compute missing diameter and accept pcbRotation", () => {
+  const raw: HoleProps = {
+    radius: 2,
+    pcbRotation: 90,
+  }
+
+  expectTypeOf(raw).toMatchTypeOf<z.input<typeof holeProps>>()
+
+  const parsed = holeProps.parse(raw)
+
+  if (parsed.shape === undefined || parsed.shape === "circle") {
+    expect(parsed.radius).toBe(2)
+    expect(parsed.diameter).toBe(4)
+    expect(parsed.pcbRotation).toBe(90)
+  } else {
+    throw new Error("Expected circle hole props")
+  }
+})
+
+test("pill holes require width and height", () => {
+  const raw: HoleProps = {
+    shape: "pill",
+    width: "4mm",
+    height: "1.5mm",
+    name: "slot",
+  }
+
+  expectTypeOf(raw).toMatchTypeOf<z.input<typeof holeProps>>()
+
+  const parsed = holeProps.parse(raw)
+
+  if (parsed.shape === "pill") {
+    expect(parsed.width).toBe(4)
+    expect(parsed.height).toBe(1.5)
+    expect(parsed.name).toBe("slot")
+  } else {
+    throw new Error("Expected pill hole props")
+  }
+})
+
+test("pill holes without required dimensions throw", () => {
+  const raw = {
+    shape: "pill",
+    width: "4mm",
+  }
+
+  expect(() => holeProps.parse(raw)).toThrow()
+})


### PR DESCRIPTION
## Summary
- add support for circle and pill hole prop variants that allow pcbRotation and width/height for pill slots
- add targeted tests covering circle defaults and pill validation
- document the new hole prop variants in the README and generated reference files

## Testing
- bun test tests/hole.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68c8921839ac832e98fc3550dfc62709