### PR TITLE
feat: add footprint file parser map to platform config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,6 +1069,15 @@ export interface VoltageSourceProps<PinLabel extends string = string>
 ### PlatformConfig
 
 ```ts
+export interface FootprintLibraryResult {
+  footprintCircuitJson: any[];
+  cadModel?: CadModelProp;
+}
+
+export interface FootprintFileParserEntry {
+  loadFromUrl: (url: string) => Promise<FootprintLibraryResult>;
+}
+
 export interface PlatformConfig {
   partsEngine?: PartsEngine;
 
@@ -1099,6 +1108,8 @@ export interface PlatformConfig {
         any[] | ((path: string) => Promise<FootprintLibraryResult>)
       >
   >;
+
+  footprintFileParserMap?: Record<string, FootprintFileParserEntry>;
 }
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -544,6 +544,11 @@ export interface FootprintLibraryResult {
 }
 
 
+export interface FootprintFileParserEntry {
+  loadFromUrl: (url: string) => Promise<FootprintLibraryResult>
+}
+
+
 export interface FootprintProps {
   /**
    * The layer that the footprint is designed for. If you set this to "top"
@@ -1006,6 +1011,8 @@ export interface PlatformConfig {
         any[] | ((path: string) => Promise<FootprintLibraryResult>)
       >
   >
+
+  footprintFileParserMap?: Record<string, FootprintFileParserEntry>
 }
 
 

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -13,6 +13,10 @@ export interface FootprintLibraryResult {
   cadModel?: CadModelProp
 }
 
+export interface FootprintFileParserEntry {
+  loadFromUrl: (url: string) => Promise<FootprintLibraryResult>
+}
+
 export interface PlatformConfig {
   partsEngine?: PartsEngine
 
@@ -43,6 +47,8 @@ export interface PlatformConfig {
         any[] | ((path: string) => Promise<FootprintLibraryResult>)
       >
   >
+
+  footprintFileParserMap?: Record<string, FootprintFileParserEntry>
 }
 
 const unvalidatedCircuitJson = z.array(z.any()).describe("Circuit JSON")
@@ -55,6 +61,16 @@ const pathToCircuitJsonFn = z
   .args(z.string())
   .returns(z.promise(footprintLibraryResult))
   .describe("A function that takes a path and returns Circuit JSON")
+
+const footprintFileParserEntry = z.object({
+  loadFromUrl: z
+    .function()
+    .args(z.string())
+    .returns(z.promise(footprintLibraryResult))
+    .describe(
+      "A function that takes a footprint file URL and returns Circuit JSON",
+    ),
+})
 
 export const platformConfig = z.object({
   partsEngine: partsEngine.optional(),
@@ -81,6 +97,9 @@ export const platformConfig = z.object({
         ),
       ]),
     )
+    .optional(),
+  footprintFileParserMap: z
+    .record(z.string(), footprintFileParserEntry)
     .optional(),
 }) as z.ZodType<PlatformConfig>
 

--- a/tests/footprintFileParserMap.test.ts
+++ b/tests/footprintFileParserMap.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import { platformConfig } from "lib/platformConfig"
+
+test("footprintFileParserMap loadFromUrl returns footprint data", async () => {
+  const config = platformConfig.parse({
+    footprintFileParserMap: {
+      kicad_mod: {
+        loadFromUrl: async (url: string) => {
+          expect(url).toBe("https://example.com/resistor.kicad_mod")
+          return {
+            footprintCircuitJson: [],
+            cadModel: {
+              objUrl: "model.obj",
+              mtlUrl: "model.mtl",
+              rotationOffset: { x: 1, y: 2, z: 3 },
+              positionOffset: { x: 4, y: 5, z: 6 },
+              size: { x: 7, y: 8, z: 9 },
+              modelUnitToMmScale: 2,
+            },
+          }
+        },
+      },
+    },
+  })
+
+  const loader = config.footprintFileParserMap?.kicad_mod?.loadFromUrl
+  if (typeof loader !== "function") {
+    throw new Error(
+      "footprintFileParserMap.kicad_mod.loadFromUrl is not a function",
+    )
+  }
+
+  const result = await loader("https://example.com/resistor.kicad_mod")
+  expect(result.cadModel).toEqual({
+    objUrl: "model.obj",
+    mtlUrl: "model.mtl",
+    rotationOffset: { x: 1, y: 2, z: 3 },
+    positionOffset: { x: 4, y: 5, z: 6 },
+    size: { x: 7, y: 8, z: 9 },
+    modelUnitToMmScale: 2,
+  })
+  expect(Array.isArray(result.footprintCircuitJson)).toBe(true)
+})


### PR DESCRIPTION
## Summary
- add a footprintFileParserMap definition to the platform configuration schema
- document the new parser entry type in the generated and README docs with a loadFromUrl hook
- add coverage ensuring loadFromUrl functions can return footprint data

## Testing
- bun test tests/footprintFileParserMap.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68c98dd471c0832ea81c9907d6545892