### PR TITLE
Add boardOrigin anchor to board component props

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   /** Number of layers for the PCB */
   layers?: 2 | 4;
   borderRadius?: Distance;
+  boardOrigin?: z.infer<typeof ninePointAnchor>;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -422,12 +422,14 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   material?: "fr4" | "fr1"
   layers?: 2 | 4
   borderRadius?: Distance
+  boardOrigin?: z.infer<typeof ninePointAnchor>
 }
 /** Number of layers for the PCB */
 export const boardProps = subcircuitGroupProps.extend({
   material: z.enum(["fr4", "fr1"]).default("fr4"),
   layers: z.union([z.literal(2), z.literal(4)]).default(2),
   borderRadius: distance.optional(),
+  boardOrigin: ninePointAnchor.optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -159,6 +159,7 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   /** Number of layers for the PCB */
   layers?: 2 | 4
   borderRadius?: Distance
+  boardOrigin?: z.infer<typeof ninePointAnchor>
 }
 
 

--- a/lib/components/board.ts
+++ b/lib/components/board.ts
@@ -1,4 +1,5 @@
 import { distance, type Distance } from "lib/common/distance"
+import { ninePointAnchor } from "lib/common/ninePointAnchor"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 import { subcircuitGroupProps, type SubcircuitGroupProps } from "./group"
@@ -8,12 +9,14 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   /** Number of layers for the PCB */
   layers?: 2 | 4
   borderRadius?: Distance
+  boardOrigin?: z.infer<typeof ninePointAnchor>
 }
 
 export const boardProps = subcircuitGroupProps.extend({
   material: z.enum(["fr4", "fr1"]).default("fr4"),
   layers: z.union([z.literal(2), z.literal(4)]).default(2),
   borderRadius: distance.optional(),
+  boardOrigin: ninePointAnchor.optional(),
 })
 
 type InferredBoardProps = z.input<typeof boardProps>

--- a/tests/board.test.ts
+++ b/tests/board.test.ts
@@ -27,3 +27,9 @@ test("should parse borderRadius prop", () => {
   const parsed = boardProps.parse(raw)
   expect(parsed.borderRadius).toBe(2)
 })
+
+test("should parse boardOrigin prop", () => {
+  const raw: BoardProps = { name: "board", boardOrigin: "bottom_right" }
+  const parsed = boardProps.parse(raw)
+  expect(parsed.boardOrigin).toBe("bottom_right")
+})


### PR DESCRIPTION
## Summary
- add an optional boardOrigin nine-point anchor field to the board props schema
- document the new boardOrigin property in the README and generated references
- extend the board props unit test to cover parsing of the boardOrigin anchor

## Testing
- bunx tsc --noEmit
- bun test tests/board.test.ts
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68c9aadc3a54832eaf196b4b2b0016ad