### PR TITLE
feat(board): add anchor position and alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   /** Number of layers for the PCB */
   layers?: 2 | 4;
   borderRadius?: Distance;
-  boardOrigin?: z.infer<typeof ninePointAnchor>;
+  boardAnchorPosition?: Point;
+  boardAnchorAlignment?: z.infer<typeof ninePointAnchor>;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -422,14 +422,16 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   material?: "fr4" | "fr1"
   layers?: 2 | 4
   borderRadius?: Distance
-  boardOrigin?: z.infer<typeof ninePointAnchor>
+  boardAnchorPosition?: Point
+  boardAnchorAlignment?: z.infer<typeof ninePointAnchor>
 }
 /** Number of layers for the PCB */
 export const boardProps = subcircuitGroupProps.extend({
   material: z.enum(["fr4", "fr1"]).default("fr4"),
   layers: z.union([z.literal(2), z.literal(4)]).default(2),
   borderRadius: distance.optional(),
-  boardOrigin: ninePointAnchor.optional(),
+  boardAnchorPosition: point.optional(),
+  boardAnchorAlignment: ninePointAnchor.optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -159,7 +159,8 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   /** Number of layers for the PCB */
   layers?: 2 | 4
   borderRadius?: Distance
-  boardOrigin?: z.infer<typeof ninePointAnchor>
+  boardAnchorPosition?: Point
+  boardAnchorAlignment?: z.infer<typeof ninePointAnchor>
 }
 
 

--- a/lib/components/board.ts
+++ b/lib/components/board.ts
@@ -1,5 +1,6 @@
 import { distance, type Distance } from "lib/common/distance"
 import { ninePointAnchor } from "lib/common/ninePointAnchor"
+import { type Point, point } from "lib/common/point"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 import { subcircuitGroupProps, type SubcircuitGroupProps } from "./group"
@@ -9,14 +10,16 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   /** Number of layers for the PCB */
   layers?: 2 | 4
   borderRadius?: Distance
-  boardOrigin?: z.infer<typeof ninePointAnchor>
+  boardAnchorPosition?: Point
+  boardAnchorAlignment?: z.infer<typeof ninePointAnchor>
 }
 
 export const boardProps = subcircuitGroupProps.extend({
   material: z.enum(["fr4", "fr1"]).default("fr4"),
   layers: z.union([z.literal(2), z.literal(4)]).default(2),
   borderRadius: distance.optional(),
-  boardOrigin: ninePointAnchor.optional(),
+  boardAnchorPosition: point.optional(),
+  boardAnchorAlignment: ninePointAnchor.optional(),
 })
 
 type InferredBoardProps = z.input<typeof boardProps>

--- a/tests/board.test.ts
+++ b/tests/board.test.ts
@@ -28,8 +28,20 @@ test("should parse borderRadius prop", () => {
   expect(parsed.borderRadius).toBe(2)
 })
 
-test("should parse boardOrigin prop", () => {
-  const raw: BoardProps = { name: "board", boardOrigin: "bottom_right" }
+test("should parse boardAnchorPosition prop", () => {
+  const raw: BoardProps = {
+    name: "board",
+    boardAnchorPosition: { x: 1, y: 2 },
+  }
   const parsed = boardProps.parse(raw)
-  expect(parsed.boardOrigin).toBe("bottom_right")
+  expect(parsed.boardAnchorPosition).toEqual({ x: 1, y: 2 })
+})
+
+test("should parse boardAnchorAlignment prop", () => {
+  const raw: BoardProps = {
+    name: "board",
+    boardAnchorAlignment: "bottom_right",
+  }
+  const parsed = boardProps.parse(raw)
+  expect(parsed.boardAnchorAlignment).toBe("bottom_right")
 })


### PR DESCRIPTION
## Summary
- replace the deprecated `boardOrigin` prop with `boardAnchorPosition` and `boardAnchorAlignment`
- allow the board anchor position to be specified with a point schema and document the new props
- update board prop tests to cover parsing of the new fields

## Testing
- bun test tests/board.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68c9b4bfef3c832e8ce6c8dd4951a1e8