### PR TITLE
Add rats nest color customization to nets, traces, and pin attributes

### DIFF
--- a/lib/common/layout.ts
+++ b/lib/common/layout.ts
@@ -152,6 +152,7 @@ export interface PinAttributeMap {
   requiresVoltage?: string | number
   doNotConnect?: boolean
   includeInBoardPinout?: boolean
+  ratsNestColor?: string
 }
 
 export const pinAttributeMap = z.object({
@@ -163,6 +164,7 @@ export const pinAttributeMap = z.object({
   requiresVoltage: z.union([z.string(), z.number()]).optional(),
   doNotConnect: z.boolean().optional(),
   includeInBoardPinout: z.boolean().optional(),
+  ratsNestColor: z.string().optional(),
 })
 
 expectTypesMatch<PinAttributeMap, z.input<typeof pinAttributeMap>>(true)

--- a/lib/components/net.ts
+++ b/lib/components/net.ts
@@ -4,11 +4,13 @@ import { expectTypesMatch } from "lib/typecheck"
 export interface NetProps {
   name: string
   connectsTo?: string | string[]
+  ratsNestColor?: string
 }
 
 export const netProps = z.object({
   name: z.string(),
   connectsTo: z.string().or(z.array(z.string())).optional(),
+  ratsNestColor: z.string().optional(),
 })
 
 type InferredNetProps = z.input<typeof netProps>

--- a/lib/components/trace.ts
+++ b/lib/components/trace.ts
@@ -18,6 +18,7 @@ const baseTraceProps = z.object({
   pcbPath: z.array(point).optional(),
   schDisplayLabel: z.string().optional(),
   schStroke: z.string().optional(),
+  ratsNestColor: z.string().optional(),
   maxLength: distance.optional(),
 })
 

--- a/tests/chip3-type-tests.test.tsx
+++ b/tests/chip3-type-tests.test.tsx
@@ -151,6 +151,7 @@ test("[typetest] pinAttributes type matches pin labels", () => {
           requiresPower: true,
           doNotConnect: true,
           includeInBoardPinout: true,
+          ratsNestColor: "#00ff00",
         },
         // @ts-expect-error
         INVALID: { foo: true },

--- a/tests/net.test.ts
+++ b/tests/net.test.ts
@@ -7,6 +7,7 @@ test("should parse NetProps with connectsTo", () => {
   const raw: NetProps = {
     name: "N1",
     connectsTo: ["U1.1", "U2.2"],
+    ratsNestColor: "blue",
   }
 
   expectTypeOf(raw).toMatchTypeOf<z.input<typeof netProps>>()
@@ -14,4 +15,5 @@ test("should parse NetProps with connectsTo", () => {
   const parsed = netProps.parse(raw)
   expect(parsed.name).toBe("N1")
   expect(parsed.connectsTo).toEqual(["U1.1", "U2.2"])
+  expect(parsed.ratsNestColor).toBe("blue")
 })

--- a/tests/pinAttributes.test.ts
+++ b/tests/pinAttributes.test.ts
@@ -5,11 +5,16 @@ test("pinAttributes allows doNotConnect", () => {
   const rawProps = {
     name: "chip",
     pinAttributes: {
-      pin1: { doNotConnect: true, includeInBoardPinout: false },
+      pin1: {
+        doNotConnect: true,
+        includeInBoardPinout: false,
+        ratsNestColor: "#ff0000",
+      },
     },
   }
 
   const parsed = chipProps.parse(rawProps)
   expect(parsed.pinAttributes?.pin1?.doNotConnect).toBe(true)
   expect(parsed.pinAttributes?.pin1?.includeInBoardPinout).toBe(false)
+  expect(parsed.pinAttributes?.pin1?.ratsNestColor).toBe("#ff0000")
 })

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -3,8 +3,14 @@ import { traceProps, type TraceProps } from "lib/components/trace"
 
 // Ensure traceProps allows arbitrary schStroke values
 
-test("parses arbitrary schStroke on trace", () => {
-  const raw: TraceProps = { from: "A", to: "B", schStroke: "green" }
+test("parses arbitrary schStroke and ratsNestColor on trace", () => {
+  const raw: TraceProps = {
+    from: "A",
+    to: "B",
+    schStroke: "green",
+    ratsNestColor: "#123456",
+  }
   const parsed = traceProps.parse(raw)
   expect(parsed.schStroke).toBe("green")
+  expect(parsed.ratsNestColor).toBe("#123456")
 })


### PR DESCRIPTION
## Summary
- allow traces and nets to specify an optional ratsNestColor
- extend pinAttributes to support ratsNestColor metadata
- add coverage ensuring the new properties parse and type-check correctly

## Testing
- bun test tests/net.test.ts tests/trace.test.ts tests/pinAttributes.test.ts tests/chip3-type-tests.test.tsx
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68ca35e20ba4832eaac2dc54eb56cf51