### PR TITLE
feat: add knockout silkscreen text properties

### DIFF
--- a/lib/components/silkscreen-text.ts
+++ b/lib/components/silkscreen-text.ts
@@ -8,15 +8,15 @@ export const silkscreenTextProps = pcbLayoutProps.extend({
   anchorAlignment: ninePointAnchor.default("center"),
   font: z.enum(["tscircuit2024"]).optional(),
   fontSize: length.optional(),
-  /**
-   * If true, text will knock out underlying silkscreen
-   */
   isKnockout: z.boolean().optional(),
   knockoutPadding: length.optional(),
   knockoutPaddingLeft: length.optional(),
   knockoutPaddingRight: length.optional(),
   knockoutPaddingTop: length.optional(),
   knockoutPaddingBottom: length.optional(),
+  knockoutCornerRadius: length.optional(),
+  knockoutBorderWidth: length.optional(),
+  knockoutColor: z.string().optional(),
   layers: z.array(layer_ref).optional(),
 })
 export type SilkscreenTextProps = z.input<typeof silkscreenTextProps>


### PR DESCRIPTION
Adds knockout text support to SilkscreenText component.

New props:
- isKnockout
- knockoutPadding
- knockoutCornerRadius
- knockoutBorderWidth
- knockoutColor

/claim #770