### PR TITLE
Add obstructsWithinBounds common component property

### DIFF
--- a/lib/common/layout.ts
+++ b/lib/common/layout.ts
@@ -179,6 +179,12 @@ export interface CommonComponentProps<PinLabel extends string = string>
   children?: any
   symbolName?: string
   doNotPlace?: boolean
+  /**
+   * Does this component take up all the space within its bounds on a layer. This is generally true
+   * except for when separated pin headers are being represented by a single component (in which case,
+   * chips can be placed between the pin headers) or for tall modules where chips fit underneath.
+   */
+  obstructsWithinBounds?: boolean
 }
 
 export const commonComponentProps = commonLayoutProps
@@ -190,6 +196,12 @@ export const commonComponentProps = commonLayoutProps
     children: z.any().optional(),
     symbolName: z.string().optional(),
     doNotPlace: z.boolean().optional(),
+    obstructsWithinBounds: z
+      .boolean()
+      .optional()
+      .describe(
+        "Does this component take up all the space within its bounds on a layer. This is generally true except for when separated pin headers are being represented by a single component (in which case, chips can be placed between the pin headers) or for tall modules where chips fit underneath",
+      ),
     pinAttributes: z.record(z.string(), pinAttributeMap).optional(),
   })
 


### PR DESCRIPTION
## Summary
- add the obstructsWithinBounds flag to common component props with documentation
- expose the property through the shared Zod schema so runtime validation knows about it

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68d82b7a2c3c832e9f426d5db89b5bfa