### PR TITLE
Add spice engine to platform config

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ export interface MosfetProps<PinLabel extends string = string>
 export interface NetProps {
   name: string;
   connectsTo?: string | string[];
+  highlightColor?: string;
 }
 ```
 
@@ -1104,6 +1105,8 @@ export interface PlatformConfig {
   pcbDisabled?: boolean;
   schematicDisabled?: boolean;
   partsEngineDisabled?: boolean;
+
+  spiceEngine?: SpiceEngine;
 
   footprintLibraryMap?: Record<
     string,

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -17,6 +17,17 @@ export interface FootprintFileParserEntry {
   loadFromUrl: (url: string) => Promise<FootprintLibraryResult>
 }
 
+export type CircuitJson = any[]
+
+export interface SpiceEngineSimulationResult {
+  engineVersionString?: string
+  simulationResultCircuitJson: CircuitJson
+}
+
+export interface SpiceEngine {
+  simulate: (spiceString: string) => Promise<SpiceEngineSimulationResult>
+}
+
 export interface PlatformConfig {
   partsEngine?: PartsEngine
 
@@ -38,6 +49,8 @@ export interface PlatformConfig {
   pcbDisabled?: boolean
   schematicDisabled?: boolean
   partsEngineDisabled?: boolean
+
+  spiceEngine?: SpiceEngine
 
   footprintLibraryMap?: Record<
     string,
@@ -72,6 +85,21 @@ const footprintFileParserEntry = z.object({
     ),
 })
 
+const spiceEngineSimulationResult = z.object({
+  engineVersionString: z.string().optional(),
+  simulationResultCircuitJson: unvalidatedCircuitJson,
+})
+
+const spiceEngineZod = z.object({
+  simulate: z
+    .function()
+    .args(z.string())
+    .returns(z.promise(spiceEngineSimulationResult))
+    .describe(
+      "A function that takes a SPICE string and returns a simulation result",
+    ),
+})
+
 export const platformConfig = z.object({
   partsEngine: partsEngine.optional(),
   autorouter: autorouterProp.optional(),
@@ -86,6 +114,7 @@ export const platformConfig = z.object({
   pcbDisabled: z.boolean().optional(),
   schematicDisabled: z.boolean().optional(),
   partsEngineDisabled: z.boolean().optional(),
+  spiceEngine: spiceEngineZod.optional(),
   footprintLibraryMap: z
     .record(
       z.string(),

--- a/tests/spiceEngine.test.ts
+++ b/tests/spiceEngine.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import { platformConfig } from "lib/platformConfig"
+
+test("spiceEngine simulate returns simulation result", async () => {
+  const config = platformConfig.parse({
+    spiceEngine: {
+      async simulate(spiceString: string) {
+        expect(spiceString).toBe("R1 1 0 1k")
+
+        return {
+          engineVersionString: "1.0.0",
+          simulationResultCircuitJson: [],
+        }
+      },
+    },
+  })
+
+  const result = await config.spiceEngine?.simulate("R1 1 0 1k")
+  expect(result?.engineVersionString).toBe("1.0.0")
+  expect(Array.isArray(result?.simulationResultCircuitJson)).toBe(true)
+})


### PR DESCRIPTION
## Summary
- extend the platform config types and schema to include a spice simulation engine
- document the new spiceEngine option in the autogenerated README docs
- add a regression test covering spiceEngine parsing and execution

## Testing
- bun test tests/spiceEngine.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68d9c0ef2ffc832ea9630d2c3df907df