### PR TITLE
board color customization props, silkscreenColor etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,18 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   borderRadius?: Distance;
   boardAnchorPosition?: Point;
   boardAnchorAlignment?: z.infer<typeof ninePointAnchor>;
+  /** Color applied to both top and bottom solder masks */
+  solderMaskColor?: BoardColor;
+  /** Color of the top solder mask */
+  topSolderMaskColor?: BoardColor;
+  /** Color of the bottom solder mask */
+  bottomSolderMaskColor?: BoardColor;
+  /** Color applied to both top and bottom silkscreens */
+  silkscreenColor?: BoardColor;
+  /** Color of the top silkscreen */
+  topSilkscreenColor?: BoardColor;
+  /** Color of the bottom silkscreen */
+  bottomSilkscreenColor?: BoardColor;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -418,12 +418,30 @@ export const batteryProps = commonComponentProps.extend({
 ### board
 
 ```typescript
+import type { AutocompleteString } from "lib/common/autocomplete"
+export type BoardColorPreset =
+  | "not_specified"
+  | "green"
+  | "red"
+  | "blue"
+  | "purple"
+  | "black"
+  | "white"
+  | "yellow"
+export type BoardColor = AutocompleteString<BoardColorPreset>
+const boardColor = z.custom<BoardColor>((value) => typeof value === "string")
 export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   material?: "fr4" | "fr1"
   layers?: 2 | 4
   borderRadius?: Distance
   boardAnchorPosition?: Point
   boardAnchorAlignment?: z.infer<typeof ninePointAnchor>
+  solderMaskColor?: BoardColor
+  topSolderMaskColor?: BoardColor
+  bottomSolderMaskColor?: BoardColor
+  silkscreenColor?: BoardColor
+  topSilkscreenColor?: BoardColor
+  bottomSilkscreenColor?: BoardColor
 }
 /** Number of layers for the PCB */
 export const boardProps = subcircuitGroupProps.extend({
@@ -432,6 +450,12 @@ export const boardProps = subcircuitGroupProps.extend({
   borderRadius: distance.optional(),
   boardAnchorPosition: point.optional(),
   boardAnchorAlignment: ninePointAnchor.optional(),
+  solderMaskColor: boardColor.optional(),
+  topSolderMaskColor: boardColor.optional(),
+  bottomSolderMaskColor: boardColor.optional(),
+  silkscreenColor: boardColor.optional(),
+  topSilkscreenColor: boardColor.optional(),
+  bottomSilkscreenColor: boardColor.optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -161,6 +161,18 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   borderRadius?: Distance
   boardAnchorPosition?: Point
   boardAnchorAlignment?: z.infer<typeof ninePointAnchor>
+  /** Color applied to both top and bottom solder masks */
+  solderMaskColor?: BoardColor
+  /** Color of the top solder mask */
+  topSolderMaskColor?: BoardColor
+  /** Color of the bottom solder mask */
+  bottomSolderMaskColor?: BoardColor
+  /** Color applied to both top and bottom silkscreens */
+  silkscreenColor?: BoardColor
+  /** Color of the top silkscreen */
+  topSilkscreenColor?: BoardColor
+  /** Color of the bottom silkscreen */
+  bottomSilkscreenColor?: BoardColor
 }
 
 

--- a/lib/components/board.ts
+++ b/lib/components/board.ts
@@ -1,9 +1,27 @@
+import type { AutocompleteString } from "lib/common/autocomplete"
 import { distance, type Distance } from "lib/common/distance"
 import { ninePointAnchor } from "lib/common/ninePointAnchor"
 import { type Point, point } from "lib/common/point"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 import { subcircuitGroupProps, type SubcircuitGroupProps } from "./group"
+
+const boardColorPresets = [
+  "not_specified",
+  "green",
+  "red",
+  "blue",
+  "purple",
+  "black",
+  "white",
+  "yellow",
+] as const
+
+export type BoardColorPreset = (typeof boardColorPresets)[number]
+
+export type BoardColor = AutocompleteString<BoardColorPreset>
+
+const boardColor = z.custom<BoardColor>((value) => typeof value === "string")
 
 export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   material?: "fr4" | "fr1"
@@ -12,6 +30,18 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   borderRadius?: Distance
   boardAnchorPosition?: Point
   boardAnchorAlignment?: z.infer<typeof ninePointAnchor>
+  /** Color applied to both top and bottom solder masks */
+  solderMaskColor?: BoardColor
+  /** Color of the top solder mask */
+  topSolderMaskColor?: BoardColor
+  /** Color of the bottom solder mask */
+  bottomSolderMaskColor?: BoardColor
+  /** Color applied to both top and bottom silkscreens */
+  silkscreenColor?: BoardColor
+  /** Color of the top silkscreen */
+  topSilkscreenColor?: BoardColor
+  /** Color of the bottom silkscreen */
+  bottomSilkscreenColor?: BoardColor
 }
 
 export const boardProps = subcircuitGroupProps.extend({
@@ -20,6 +50,12 @@ export const boardProps = subcircuitGroupProps.extend({
   borderRadius: distance.optional(),
   boardAnchorPosition: point.optional(),
   boardAnchorAlignment: ninePointAnchor.optional(),
+  solderMaskColor: boardColor.optional(),
+  topSolderMaskColor: boardColor.optional(),
+  bottomSolderMaskColor: boardColor.optional(),
+  silkscreenColor: boardColor.optional(),
+  topSilkscreenColor: boardColor.optional(),
+  bottomSilkscreenColor: boardColor.optional(),
 })
 
 type InferredBoardProps = z.input<typeof boardProps>

--- a/tests/board.test.ts
+++ b/tests/board.test.ts
@@ -45,3 +45,22 @@ test("should parse boardAnchorAlignment prop", () => {
   const parsed = boardProps.parse(raw)
   expect(parsed.boardAnchorAlignment).toBe("bottom_right")
 })
+
+test("should parse board color customization props", () => {
+  const raw: BoardProps = {
+    name: "board",
+    solderMaskColor: "green",
+    topSolderMaskColor: "matte_black",
+    bottomSolderMaskColor: "kicad:custom_solder_mask",
+    silkscreenColor: "white",
+    topSilkscreenColor: "kicad:silkscreen_special",
+    bottomSilkscreenColor: "ghost_white",
+  }
+  const parsed = boardProps.parse(raw)
+  expect(parsed.solderMaskColor).toBe("green")
+  expect(parsed.topSolderMaskColor).toBe("matte_black")
+  expect(parsed.bottomSolderMaskColor).toBe("kicad:custom_solder_mask")
+  expect(parsed.silkscreenColor).toBe("white")
+  expect(parsed.topSilkscreenColor).toBe("kicad:silkscreen_special")
+  expect(parsed.bottomSilkscreenColor).toBe("ghost_white")
+})


### PR DESCRIPTION
## Summary
- simplify board color typing to use AutocompleteString presets
- add shared solder mask and silkscreen color props while removing dielectric core color
- document and test the revised board color configuration options

## Testing
- bunx tsc --noEmit
- bun test tests/board.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68df28be2024832e87e5d62b1f5c0643