### PR TITLE
Add connections support to switch component

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ resistorProps.parse({ resistance: "10k" } as ResistorPropsInput);
 
 | Component               | Props Interface                                                       |
 | ----------------------- | --------------------------------------------------------------------- |
+| `<analogsimulation />`  | [`AnalogSimulationProps`](#analogsimulationprops-analogsimulation)    |
 | `<battery />`           | [`BatteryProps`](#batteryprops-battery)                               |
 | `<board />`             | [`BoardProps`](#boardprops-board)                                     |
 | `<breakout />`          | [`BreakoutProps`](#breakoutprops-breakout)                            |
@@ -144,6 +145,16 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
 ```
 
 [Source](https://github.com/tscircuit/props/blob/main/lib/components/group.ts)
+
+### AnalogSimulationProps `<analogsimulation />`
+
+```ts
+export interface AnalogSimulationProps {
+  simulationType?: "spice_transient_analysis";
+}
+```
+
+[Source](https://github.com/tscircuit/props/blob/main/lib/components/analogsimulation.ts)
 
 ### BatteryProps `<battery />`
 
@@ -989,6 +1000,7 @@ export interface SwitchProps extends CommonComponentProps {
   spst?: boolean;
   dpst?: boolean;
   dpdt?: boolean;
+  connections?: Connections<string>;
 }
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-09-14T18:16:33.787Z
+> Generated at 2025-10-03T23:04:08.599Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -18,6 +18,11 @@ const validatedProps = chipProps.parse(unknownProps)
 ## Available Props
 
 ```ts
+export interface AnalogSimulationProps {
+  simulationType?: "spice_transient_analysis"
+}
+
+
 export interface AutorouterConfig {
   serverUrl?: string
   inputFormat?: "simplified" | "circuit-json"
@@ -53,6 +58,31 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
    * Title to display above this group in the schematic view
    */
   schTitle?: string
+
+  /**
+   * If true, render this group as a single schematic box
+   */
+  showAsSchematicBox?: boolean
+
+  /**
+   * Mapping of external pin names to internal connection targets
+   */
+  connections?: Connections
+
+  /**
+   * Arrangement for pins when rendered as a schematic box
+   */
+  schPinArrangement?: SchematicPinArrangement
+
+  /**
+   * Spacing between pins when rendered as a schematic box
+   */
+  schPinSpacing?: Distance
+
+  /**
+   * Styles to apply to individual pins in the schematic box representation
+   */
+  schPinStyle?: SchematicPinStyle
 
   pcbWidth?: Distance
   pcbHeight?: Distance
@@ -326,6 +356,14 @@ export interface CircleCutoutProps
 }
 
 
+export interface CircleHoleProps extends PcbLayoutProps {
+  name?: string
+  shape?: "circle"
+  diameter?: Distance
+  radius?: Distance
+}
+
+
 export interface CirclePlatedHoleProps
   extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string
@@ -337,19 +375,12 @@ export interface CirclePlatedHoleProps
 }
 
 
-export interface CircleHoleProps extends PcbLayoutProps {
-  name?: string
-  shape?: "circle"
-  diameter?: Distance
-  radius?: Distance
-}
-
-
 export interface CircleSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   name?: string
   shape: "circle"
   radius: Distance
   portHints?: PortHints
+  coveredWithSolderMask?: boolean
 }
 
 
@@ -368,11 +399,12 @@ export interface CircularHoleWithRectPlatedProps
   holeDiameter: number | string
   rectPadWidth: number | string
   rectPadHeight: number | string
+  rectBorderRadius?: number | string
   holeShape?: "circle"
   padShape?: "rect"
   portHints?: PortHints
-  pcbHoleOffsetX?: number | string
-  pcbHoleOffsetY?: number | string
+  holeOffsetX?: number | string
+  holeOffsetY?: number | string
 }
 
 
@@ -386,6 +418,12 @@ export interface CommonComponentProps<PinLabel extends string = string>
   children?: any
   symbolName?: string
   doNotPlace?: boolean
+  /**
+   * Does this component take up all the space within its bounds on a layer. This is generally true
+   * except for when separated pin headers are being represented by a single component (in which case,
+   * chips can be placed between the pin headers) or for tall modules where chips fit underneath.
+   */
+  obstructsWithinBounds?: boolean
 }
 
 
@@ -552,14 +590,14 @@ export interface EditTraceHintEvent extends BaseManualEditEvent {
 }
 
 
-export interface FootprintLibraryResult {
-  footprintCircuitJson: any[]
-  cadModel?: CadModelProp
+export interface FootprintFileParserEntry {
+  loadFromUrl: (url: string) => Promise<FootprintLibraryResult>
 }
 
 
-export interface FootprintFileParserEntry {
-  loadFromUrl: (url: string) => Promise<FootprintLibraryResult>
+export interface FootprintLibraryResult {
+  footprintCircuitJson: any[]
+  cadModel?: CadModelProp
 }
 
 
@@ -602,9 +640,6 @@ export interface FuseProps<PinLabel extends string = string>
    */
   connections?: Connections<PinLabel>
 }
-
-
-export type HoleProps = CircleHoleProps | PillHoleProps
 
 
 export interface InductorProps<PinLabel extends string = string>
@@ -762,6 +797,7 @@ export interface NetLabelProps {
 export interface NetProps {
   name: string
   connectsTo?: string | string[]
+  highlightColor?: string
 }
 
 
@@ -770,8 +806,7 @@ export interface NonSubcircuitGroupProps extends BaseGroupProps {
 }
 
 
-export interface OvalPlatedHoleProps
-  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
+export interface OvalPlatedHoleProps extends Omit<PcbLayoutProps, "layer"> {
   name?: string
   connectsTo?: string | string[]
   shape: "oval"
@@ -834,6 +869,8 @@ export interface PillPlatedHoleProps extends Omit<PcbLayoutProps, "layer"> {
   outerHeight: number | string
   holeWidth: number | string
   holeHeight: number | string
+  holeOffsetX?: number | string
+  holeOffsetY?: number | string
 
   /** @deprecated use holeWidth */
   innerWidth?: number | string
@@ -851,6 +888,7 @@ export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   height: Distance
   radius: Distance
   portHints?: PortHints
+  coveredWithSolderMask?: boolean
 }
 
 
@@ -866,6 +904,8 @@ export interface PillWithRectPadPlatedHoleProps
   rectPadWidth: number | string
   rectPadHeight: number | string
   portHints?: PortHints
+  holeOffsetX?: number | string
+  holeOffsetY?: number | string
 }
 
 
@@ -878,6 +918,7 @@ export interface PinAttributeMap {
   requiresVoltage?: string | number
   doNotConnect?: boolean
   includeInBoardPinout?: boolean
+  highlightColor?: string
 }
 
 
@@ -1017,6 +1058,8 @@ export interface PlatformConfig {
   schematicDisabled?: boolean
   partsEngineDisabled?: boolean
 
+  spiceEngineMap?: Record<string, SpiceEngine>
+
   footprintLibraryMap?: Record<
     string,
     | ((path: string) => Promise<FootprintLibraryResult>)
@@ -1044,6 +1087,7 @@ export interface PolygonSmtPadProps
   shape: "polygon"
   points: Point[]
   portHints?: PortHints
+  coveredWithSolderMask?: boolean
 }
 
 
@@ -1067,7 +1111,9 @@ export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   shape: "rect"
   width: Distance
   height: Distance
+  rectBorderRadius?: Distance
   portHints?: PortHints
+  coveredWithSolderMask?: boolean
 }
 
 
@@ -1106,6 +1152,7 @@ export interface RotatedRectSmtPadProps
   height: Distance
   ccwRotation: number
   portHints?: PortHints
+  coveredWithSolderMask?: boolean
 }
 
 
@@ -1171,6 +1218,17 @@ export interface SolderJumperProps extends JumperProps {
    * If true, all pins are connected with cuttable traces
    */
   bridged?: boolean
+}
+
+
+export interface SpiceEngine {
+  simulate: (spiceString: string) => Promise<SpiceEngineSimulationResult>
+}
+
+
+export interface SpiceEngineSimulationResult {
+  engineVersionString?: string
+  simulationResultCircuitJson: CircuitJson
 }
 
 
@@ -1246,6 +1304,7 @@ export interface SwitchProps extends CommonComponentProps {
   spst?: boolean
   dpst?: boolean
   dpdt?: boolean
+  connections?: Connections<string>
 }
 
 

--- a/lib/components/switch.ts
+++ b/lib/components/switch.ts
@@ -2,6 +2,8 @@ import {
   type CommonComponentProps,
   commonComponentProps,
 } from "lib/common/layout"
+import { connectionTarget } from "lib/common/connectionsProp"
+import type { Connections } from "lib/utility-types/connections-and-selectors"
 import { expectTypesMatch } from "lib/typecheck"
 
 import { z } from "zod"
@@ -13,6 +15,7 @@ export interface SwitchProps extends CommonComponentProps {
   spst?: boolean
   dpst?: boolean
   dpdt?: boolean
+  connections?: Connections<string>
 }
 
 export const switchProps = commonComponentProps
@@ -23,6 +26,10 @@ export const switchProps = commonComponentProps
     spdt: z.boolean().optional(),
     dpst: z.boolean().optional(),
     dpdt: z.boolean().optional(),
+    connections: z
+      .custom<Connections<string>>()
+      .pipe(z.record(z.string(), connectionTarget))
+      .optional(),
   })
   .transform((props) => {
     const updatedProps: SwitchProps = { ...props }

--- a/tests/switch.test.ts
+++ b/tests/switch.test.ts
@@ -30,3 +30,15 @@ test("should fail to parse switch props with invalid switch type", () => {
   const parsedProps = switchProps.parse(rawProps)
   expect(parsedProps.dpst).toBe(false)
 })
+
+test("should parse switch props with connections", () => {
+  const rawProps: SwitchProps = {
+    name: "switch",
+    connections: {
+      pin1: ".U1 > .pin1",
+    },
+  }
+
+  const parsedProps = switchProps.parse(rawProps)
+  expect(parsedProps.connections?.pin1).toBe(".U1 > .pin1")
+})


### PR DESCRIPTION
## Summary
- allow switch props to accept connections and validate their shape
- document the new connections field in generated references
- add a regression test covering connections parsing

## Testing
- bun test tests/switch.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68e055d1e1b0832ebaa37356813b90a0