### PR TITLE
chore: add generation guidance and verification workflow

### DIFF
--- a/.github/workflows/verify-generated.yml
+++ b/.github/workflows/verify-generated.yml
@@ -1,0 +1,36 @@
+name: Verify Generated Artifacts
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  verify-generated-content:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run generation scripts
+        run: |
+          bun scripts/generate-component-types.ts
+          bun scripts/generate-manual-edits-docs.ts
+          bun scripts/generate-readme-docs.ts
+          bun scripts/generate-props-overview.ts
+
+      - name: Ensure working tree is clean
+        run: |
+          if ! git diff --quiet; then
+            echo "Generated files are out of date. Please run the generation scripts and commit the results." >&2
+            git status --short
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Repository Guidance
+
+This repository contains the generated props documentation and supporting scripts for the `@tscircuit/props` package. Many files—especially under `docs/` and `generated/`—are produced by scripts inside the `scripts/` directory. Keeping these generated artifacts in sync is critical for ensuring the package consumers receive up-to-date information.
+
+## Required Workflow Before Committing
+- Always run the generation scripts and include their results in your commit before opening a pull request or merging changes. Run the scripts with:
+  ```sh
+  bun scripts/generate-component-types.ts
+  bun scripts/generate-manual-edits-docs.ts
+  bun scripts/generate-readme-docs.ts
+  bun scripts/generate-props-overview.ts
+  ```
+- After running the scripts, confirm that `git status` reports a clean working tree (or that you have staged all generated changes) before committing.
+
+Following these steps helps prevent CI failures and ensures generated content stays in sync with the source definitions.

--- a/README.md
+++ b/README.md
@@ -1142,6 +1142,12 @@ export interface PlatformConfig {
   >;
 
   footprintFileParserMap?: Record<string, FootprintFileParserEntry>;
+
+  simSwitchFrequency?: number | string;
+  simCloseAt?: number | string;
+  simOpenAt?: number | string;
+  simStartClosed?: boolean;
+  simStartOpen?: boolean;
 }
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1,6 +1,6 @@
 # @tscircuit/props Overview
 
-> Generated at 2025-10-03T23:04:08.599Z
+> Generated at 2025-10-04T18:42:43.137Z
 > Latest version: https://github.com/tscircuit/props/blob/main/generated/PROPS_OVERVIEW.md
 
 This document provides an overview of all the prop types available in @tscircuit/props.
@@ -1070,6 +1070,12 @@ export interface PlatformConfig {
   >
 
   footprintFileParserMap?: Record<string, FootprintFileParserEntry>
+
+  simSwitchFrequency?: number | string
+  simCloseAt?: number | string
+  simOpenAt?: number | string
+  simStartClosed?: boolean
+  simStartOpen?: boolean
 }
 
 


### PR DESCRIPTION
## Summary
- add repository guidance in AGENTS.md with required generation workflow
- create a GitHub Action that runs required generation scripts (excluding the KiCad autocomplete generator) and fails on dirty diffs
- refresh generated documentation to reflect current PlatformConfig fields

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68e168266048832eab3e6d5a4e2f13d1