### PR TITLE
feat: Add duration and timePerStep to analog simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
 ```ts
 export interface AnalogSimulationProps {
   simulationType?: "spice_transient_analysis";
+  duration?: number | string;
+  timePerStep?: number | string;
 }
 ```
 

--- a/lib/common/time.ts
+++ b/lib/common/time.ts
@@ -1,0 +1,20 @@
+import { z } from "zod"
+import { expectTypesMatch } from "lib/typecheck"
+
+export type Time = number | string
+
+export const time = z
+  .union([z.string(), z.number()])
+  .transform((v) => {
+    if (typeof v === "number") return v
+    if (v.endsWith("ms")) return parseFloat(v) / 1000
+    if (v.endsWith("us")) return parseFloat(v) / 1_000_000
+    if (v.endsWith("ns")) return parseFloat(v) / 1_000_000_000
+    if (v.endsWith("ps")) return parseFloat(v) / 1_000_000_000_000
+    if (v.endsWith("fs")) return parseFloat(v) / 1_000_000_000_000_000
+    if (v.endsWith("s")) return parseFloat(v)
+    return parseFloat(v)
+  })
+  .describe("A time value, e.g. '1ms' or 0.001")
+
+expectTypesMatch<Time, z.input<typeof time>>(true)

--- a/lib/components/analogsimulation.ts
+++ b/lib/components/analogsimulation.ts
@@ -1,14 +1,19 @@
+import { time } from "../common/time"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
 export interface AnalogSimulationProps {
   simulationType?: "spice_transient_analysis"
+  duration?: number | string
+  timePerStep?: number | string
 }
 
 export const analogSimulationProps = z.object({
   simulationType: z
     .literal("spice_transient_analysis")
     .default("spice_transient_analysis"),
+  duration: time.optional(),
+  timePerStep: time.optional(),
 })
 
 expectTypesMatch<AnalogSimulationProps, z.input<typeof analogSimulationProps>>(

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,6 +12,7 @@ export * from "./common/schematicPinDefinitions"
 export * from "./common/schematicPinStyle"
 export * from "./common/cadModel"
 export * from "./common/schematicPinLabel"
+export * from "./common/time"
 
 export * from "./components/board"
 export * from "./components/breakout"

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -7,7 +7,8 @@ import {
 import { expectTypesMatch } from "./typecheck"
 import { z } from "zod"
 import { type CadModelProp, cadModelProp } from "./common/cadModel"
-import { frequency, time } from "circuit-json"
+import { frequency } from "circuit-json"
+import { time } from "./common/time"
 
 export interface FootprintLibraryResult {
   footprintCircuitJson: any[]

--- a/tests/analogsimulation.test.ts
+++ b/tests/analogsimulation.test.ts
@@ -14,3 +14,16 @@ test("analog simulation defaults to spice transient analysis", () => {
   const parsed = analogSimulationProps.parse(raw)
   expect(parsed.simulationType).toBe("spice_transient_analysis")
 })
+
+test("analog simulation accepts time parameters", () => {
+  const raw: AnalogSimulationProps = {
+    duration: "1ms",
+    timePerStep: "1us",
+  }
+
+  expectTypeOf(raw).toMatchTypeOf<z.input<typeof analogSimulationProps>>()
+
+  const parsed = analogSimulationProps.parse(raw)
+  expect(parsed.duration).toBe(0.001)
+  expect(parsed.timePerStep).toBe(0.000001)
+})


### PR DESCRIPTION
This PR adds duration and timePerStep props to the <analogsimulation> component, allowing for more control over spice      
transient analysis simulations.                                                                                            