### PR TITLE
Improve autorouter prop autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1126,6 +1126,8 @@ export interface PlatformConfig {
 
   autorouter?: AutorouterProp;
 
+  autorouterMap?: Record<string, AutorouterDefinition>;
+
   // TODO this follows a subset of the localStorage interface
   localCacheEngine?: any;
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -410,11 +410,15 @@ export const schematicPinStyle = z.record(
 ```typescript
 export interface AnalogSimulationProps {
   simulationType?: "spice_transient_analysis"
+  duration?: number | string
+  timePerStep?: number | string
 }
 export const analogSimulationProps = z.object({
   simulationType: z
     .literal("spice_transient_analysis")
     .default("spice_transient_analysis"),
+  duration: ms.optional(),
+  timePerStep: ms.optional(),
 })
 ```
 
@@ -2081,7 +2085,8 @@ export const schematicPathProps = z.object({
 
 ```typescript
 export const schematicRectProps = z.object({
-  center: point,
+  schX: distance.optional(),
+  schY: distance.optional(),
   width: distance,
   height: distance,
   rotation: rotation.default(0),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -20,6 +20,8 @@ const validatedProps = chipProps.parse(unknownProps)
 ```ts
 export interface AnalogSimulationProps {
   simulationType?: "spice_transient_analysis"
+  duration?: number | string
+  timePerStep?: number | string
 }
 
 
@@ -46,6 +48,20 @@ export interface AutorouterConfig {
     | /** @deprecated Use "sequential_trace" */ "sequential-trace"
     | /** @deprecated Use "auto_local" */ "auto-local"
     | /** @deprecated Use "auto_cloud" */ "auto-cloud"
+}
+
+
+export interface AutorouterDefinition {
+  createAutorouter: (
+    simpleRouteJson: SimpleRouteJson,
+    opts?: Record<string, unknown>,
+  ) => AutorouterInstance | Promise<AutorouterInstance>
+}
+
+
+export interface AutorouterInstance {
+  run: () => Promise<void>
+  getOutputSimpleRouteJson: () => Promise<SimpleRouteJson>
 }
 
 
@@ -1040,6 +1056,8 @@ export interface PlatformConfig {
   partsEngine?: PartsEngine
 
   autorouter?: AutorouterProp
+
+  autorouterMap?: Record<string, AutorouterDefinition>
 
   // TODO this follows a subset of the localStorage interface
   localCacheEngine?: any

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -1,4 +1,5 @@
 import { layer_ref, length, distance } from "circuit-json"
+import type { AutocompleteString } from "lib/common/autocomplete"
 import type { Distance } from "lib/common/distance"
 import {
   type CommonLayoutProps,
@@ -309,8 +310,7 @@ export interface AutorouterConfig {
     | /** @deprecated Use "auto_cloud" */ "auto-cloud"
 }
 
-export type AutorouterProp =
-  | AutorouterConfig
+export type AutorouterPreset =
   | "sequential_trace"
   | "subcircuit"
   | "auto"
@@ -320,6 +320,10 @@ export type AutorouterProp =
   | "sequential-trace"
   | "auto-local"
   | "auto-cloud"
+
+export type AutorouterProp =
+  | AutorouterConfig
+  | AutocompleteString<AutorouterPreset>
 
 export const autorouterConfig = z.object({
   serverUrl: z.string().optional(),
@@ -352,8 +356,7 @@ export const autorouterConfig = z.object({
   local: z.boolean().optional(),
 })
 
-export const autorouterProp = z.union([
-  autorouterConfig,
+export const autorouterPreset = z.union([
   z.literal("sequential_trace"),
   z.literal("subcircuit"),
   z.literal("auto"),
@@ -363,6 +366,16 @@ export const autorouterProp = z.union([
   z.literal("sequential-trace"),
   z.literal("auto-local"),
   z.literal("auto-cloud"),
+])
+
+const autorouterString = z.string() as z.ZodType<
+  AutocompleteString<AutorouterPreset>
+>
+
+export const autorouterProp: z.ZodType<AutorouterProp> = z.union([
+  autorouterConfig,
+  autorouterPreset,
+  autorouterString,
 ])
 
 export interface SubcircuitGroupProps extends BaseGroupProps {
@@ -545,6 +558,8 @@ type InferredBaseGroupProps = z.input<typeof baseGroupProps>
 type InferredSubcircuitGroupPropsWithBool = z.input<
   typeof subcircuitGroupPropsWithBool
 >
+
+expectTypesMatch<AutorouterProp, z.input<typeof autorouterProp>>(true)
 
 expectTypesMatch<BaseGroupProps, InferredBaseGroupProps>(true)
 expectTypesMatch<


### PR DESCRIPTION
## Summary
- wrap the autorouter string prop in the AutocompleteString helper to retain preset suggestions while permitting custom autorouter identifiers
- align the autorouter zod schema with the updated type alias and assert the inferred type matches the exported AutorouterProp

## Testing
- bun scripts/generate-component-types.ts
- bun scripts/generate-manual-edits-docs.ts
- bun scripts/generate-readme-docs.ts
- bun scripts/generate-props-overview.ts
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68e2ede9fd84832eb4aeff3d9adc3661