### PR TITLE
feat(voltageprobe): Make an optional name prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1088,7 +1088,8 @@ export interface ViaProps extends CommonLayoutProps {
 ### VoltageProbeProps `<voltageprobe />`
 
 ```ts
-export interface VoltageProbeProps extends CommonComponentProps {
+export interface VoltageProbeProps extends Omit<CommonComponentProps, "name"> {
+  name?: string;
   connectsTo: string | string[];
 }
 ```

--- a/lib/components/voltageprobe.ts
+++ b/lib/components/voltageprobe.ts
@@ -5,12 +5,16 @@ import {
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
-export interface VoltageProbeProps extends CommonComponentProps {
+export interface VoltageProbeProps extends Omit<CommonComponentProps, "name"> {
+  name?: string
   connectsTo: string | string[]
 }
 
-export const voltageProbeProps = commonComponentProps.extend({
-  connectsTo: z.string().or(z.array(z.string())),
-})
+export const voltageProbeProps = commonComponentProps
+  .omit({ name: true })
+  .extend({
+    name: z.string().optional(),
+    connectsTo: z.string().or(z.array(z.string())),
+  })
 
 expectTypesMatch<VoltageProbeProps, z.input<typeof voltageProbeProps>>(true)

--- a/tests/voltageprobe.test.ts
+++ b/tests/voltageprobe.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test"
+import {
+  voltageProbeProps,
+  type VoltageProbeProps,
+} from "lib/components/voltageprobe"
+
+test("should parse voltageprobe with name", () => {
+  const raw: VoltageProbeProps = {
+    connectsTo: "C1.pin1",
+    name: "C1_pos",
+  }
+  const parsed = voltageProbeProps.parse(raw)
+  expect(parsed.name).toBe("C1_pos")
+  expect(parsed.connectsTo).toBe("C1.pin1")
+})
+
+test("should parse voltageprobe without name", () => {
+  const raw: VoltageProbeProps = {
+    connectsTo: "net.VOUT",
+  }
+  const parsed = voltageProbeProps.parse(raw)
+  expect(parsed.name).toBeUndefined()
+  expect(parsed.connectsTo).toBe("net.VOUT")
+})


### PR DESCRIPTION
This change makes the name prop optional for the <voltageprobe /> component. This allows for usage like <voltageprobe
connectsTo="net.VOUT" /> in addition to the previous requirement of always supplying a name.                               

A test has been added to verify that the component can be parsed both with and without the name prop. 