### PR TITLE
Add optional board thickness prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,12 @@ export interface BatteryProps<PinLabel extends string = string>
 
 ```ts
 export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
+  title?: string;
   material?: "fr4" | "fr1";
   /** Number of layers for the PCB */
   layers?: 2 | 4;
   borderRadius?: Distance;
+  thickness?: Distance;
   boardAnchorPosition?: Point;
   boardAnchorAlignment?: z.infer<typeof ninePointAnchor>;
   /** Color applied to both top and bottom solder masks */

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -445,9 +445,11 @@ export const batteryProps = commonComponentProps.extend({
 
 ```typescript
 export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
+  title?: string
   material?: "fr4" | "fr1"
   layers?: 2 | 4
   borderRadius?: Distance
+  thickness?: Distance
   boardAnchorPosition?: Point
   boardAnchorAlignment?: z.infer<typeof ninePointAnchor>
   solderMaskColor?: BoardColor
@@ -462,8 +464,10 @@ export const boardProps = subcircuitGroupProps.extend({
   material: z.enum(["fr4", "fr1"]).default("fr4"),
   layers: z.union([z.literal(2), z.literal(4)]).default(2),
   borderRadius: distance.optional(),
+  thickness: distance.optional(),
   boardAnchorPosition: point.optional(),
   boardAnchorAlignment: ninePointAnchor.optional(),
+  title: z.string().optional(),
   solderMaskColor: boardColor.optional(),
   topSolderMaskColor: boardColor.optional(),
   bottomSolderMaskColor: boardColor.optional(),
@@ -2558,12 +2562,16 @@ export const viaProps = commonLayoutProps.extend({
 ### voltageprobe
 
 ```typescript
-export interface VoltageProbeProps extends CommonComponentProps {
+export interface VoltageProbeProps extends Omit<CommonComponentProps, "name"> {
+  name?: string
   connectsTo: string | string[]
 }
-export const voltageProbeProps = commonComponentProps.extend({
-  connectsTo: z.string().or(z.array(z.string())),
-})
+export const voltageProbeProps = commonComponentProps
+  .omit({ name: true })
+  .extend({
+    name: z.string().optional(),
+    connectsTo: z.string().or(z.array(z.string())),
+  })
 ```
 
 ### voltagesource

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -201,10 +201,12 @@ export interface BatteryProps<PinLabel extends string = string>
 
 
 export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
+  title?: string
   material?: "fr4" | "fr1"
   /** Number of layers for the PCB */
   layers?: 2 | 4
   borderRadius?: Distance
+  thickness?: Distance
   boardAnchorPosition?: Point
   boardAnchorAlignment?: z.infer<typeof ninePointAnchor>
   /** Color applied to both top and bottom solder masks */
@@ -1388,7 +1390,8 @@ export interface ViaProps extends CommonLayoutProps {
 }
 
 
-export interface VoltageProbeProps extends CommonComponentProps {
+export interface VoltageProbeProps extends Omit<CommonComponentProps, "name"> {
+  name?: string
   connectsTo: string | string[]
 }
 

--- a/lib/components/board.ts
+++ b/lib/components/board.ts
@@ -29,6 +29,7 @@ export interface BoardProps extends Omit<SubcircuitGroupProps, "subcircuit"> {
   /** Number of layers for the PCB */
   layers?: 2 | 4
   borderRadius?: Distance
+  thickness?: Distance
   boardAnchorPosition?: Point
   boardAnchorAlignment?: z.infer<typeof ninePointAnchor>
   /** Color applied to both top and bottom solder masks */
@@ -49,6 +50,7 @@ export const boardProps = subcircuitGroupProps.extend({
   material: z.enum(["fr4", "fr1"]).default("fr4"),
   layers: z.union([z.literal(2), z.literal(4)]).default(2),
   borderRadius: distance.optional(),
+  thickness: distance.optional(),
   boardAnchorPosition: point.optional(),
   boardAnchorAlignment: ninePointAnchor.optional(),
   title: z.string().optional(),


### PR DESCRIPTION
## Summary
- add an optional `thickness` distance property to the board component schema
- regenerate documentation to include the new board thickness prop

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68e82b0e3c78832e9f491f33e28b8ebb