### PR TITLE
feat: support stepUrl for cadmodel component

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ export interface CadAssemblyProps {
 ```ts
 export interface CadModelProps extends CadModelBase {
   modelUrl: string;
+  stepUrl?: string;
   pcbX?: Distance;
   pcbY?: Distance;
   pcbZ?: Distance;

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -540,12 +540,14 @@ export const cadassemblyProps = z.object({
 ```typescript
 export interface CadModelProps extends CadModelBase {
   modelUrl: string
+  stepUrl?: string
   pcbX?: Distance
   pcbY?: Distance
   pcbZ?: Distance
 }
 const cadModelBaseWithUrl = cadModelBase.extend({
   modelUrl: z.string(),
+  stepUrl: z.string().optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -301,6 +301,7 @@ export interface CadModelObj extends CadModelBase {
 
 export interface CadModelProps extends CadModelBase {
   modelUrl: string
+  stepUrl?: string
   pcbX?: Distance
   pcbY?: Distance
   pcbZ?: Distance

--- a/lib/components/cadmodel.ts
+++ b/lib/components/cadmodel.ts
@@ -5,6 +5,7 @@ import { z } from "zod"
 
 export interface CadModelProps extends CadModelBase {
   modelUrl: string
+  stepUrl?: string
   pcbX?: Distance
   pcbY?: Distance
   pcbZ?: Distance
@@ -18,6 +19,7 @@ const pcbPosition = z.object({
 
 const cadModelBaseWithUrl = cadModelBase.extend({
   modelUrl: z.string(),
+  stepUrl: z.string().optional(),
 })
 
 const cadModelObject = cadModelBaseWithUrl.merge(pcbPosition)

--- a/tests/cadmodel.test.ts
+++ b/tests/cadmodel.test.ts
@@ -19,3 +19,17 @@ test("cadmodel accepts pcb coordinates", () => {
   expect(parsed.pcbY).toBe(2)
   expect(parsed.pcbZ).toBe(3)
 })
+
+test("cadmodel accepts optional stepUrl", () => {
+  const raw: CadModelPropsInput = {
+    modelUrl: "https://example.com/model.stl",
+    stepUrl: "https://example.com/model.step",
+  }
+
+  const parsed = cadmodelProps.parse(raw) as Exclude<
+    CadModelPropsInput,
+    null | string
+  >
+
+  expect(parsed.stepUrl).toBe("https://example.com/model.step")
+})


### PR DESCRIPTION
## Summary
- allow `<cadmodel />` props to accept an optional `stepUrl`
- regenerate documentation to surface the new property
- extend the cadmodel unit test coverage for the new field

## Testing
- bun test tests/cadmodel.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68e8902878b4832e946efa7b4f0d677b