### PR TITLE
feat: add pcb position anchor to group

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,10 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbPaddingRight?: Distance;
   pcbPaddingTop?: Distance;
   pcbPaddingBottom?: Distance;
+  /**
+   * Anchor to use when interpreting pcbX/pcbY relative to pcbPosition
+   */
+  pcbPositionAnchor?: AutocompleteString<z.infer<typeof ninePointAnchor>>;
 
   /** @deprecated Use `pcbGrid` */
   grid?: boolean;

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1223,6 +1223,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbPaddingRight?: Distance
   pcbPaddingTop?: Distance
   pcbPaddingBottom?: Distance
+  pcbPositionAnchor?: AutocompleteString<z.infer<typeof ninePointAnchor>>
 
   grid?: boolean
   flex?: boolean | string
@@ -1474,6 +1475,7 @@ export const baseGroupProps = commonLayoutProps.extend({
   pcbPaddingRight: length.optional(),
   pcbPaddingTop: length.optional(),
   pcbPaddingBottom: length.optional(),
+  pcbPositionAnchor: pcbPositionAnchorAutocomplete.optional(),
 })
 export const subcircuitGroupProps = baseGroupProps.extend({
   manualEdits: manual_edits_file.optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -120,6 +120,10 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbPaddingRight?: Distance
   pcbPaddingTop?: Distance
   pcbPaddingBottom?: Distance
+  /**
+   * Anchor to use when interpreting pcbX/pcbY relative to pcbPosition
+   */
+  pcbPositionAnchor?: AutocompleteString<z.infer<typeof ninePointAnchor>>
 
   /** @deprecated Use `pcbGrid` */
   grid?: boolean

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -6,6 +6,7 @@ import {
   commonLayoutProps,
   type SupplierPartNumbers,
 } from "lib/common/layout"
+import { ninePointAnchor } from "lib/common/ninePointAnchor"
 import { type Point, point } from "lib/common/point"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
@@ -210,6 +211,10 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbPaddingRight?: Distance
   pcbPaddingTop?: Distance
   pcbPaddingBottom?: Distance
+  /**
+   * Anchor to use when interpreting pcbX/pcbY relative to pcbPosition
+   */
+  pcbPositionAnchor?: AutocompleteString<z.infer<typeof ninePointAnchor>>
 
   /** @deprecated Use `pcbGrid` */
   grid?: boolean
@@ -324,6 +329,10 @@ export type AutorouterPreset =
 export type AutorouterProp =
   | AutorouterConfig
   | AutocompleteString<AutorouterPreset>
+
+const pcbPositionAnchorAutocomplete = z.custom<
+  AutocompleteString<z.infer<typeof ninePointAnchor>>
+>((value) => typeof value === "string")
 
 export const autorouterConfig = z.object({
   serverUrl: z.string().optional(),
@@ -520,6 +529,7 @@ export const baseGroupProps = commonLayoutProps.extend({
   pcbPaddingRight: length.optional(),
   pcbPaddingTop: length.optional(),
   pcbPaddingBottom: length.optional(),
+  pcbPositionAnchor: pcbPositionAnchorAutocomplete.optional(),
 })
 
 export const partsEngine = z.custom<PartsEngine>((v) => "findPart" in v)


### PR DESCRIPTION
## Summary
- add a pcbPositionAnchor prop to group props with nine-point anchor autocomplete support
- regenerate docs to document the new group prop

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68eaa6b421a0832eaabc8c7f7a29ef14