### PR TITLE
feat: add model unit scale to cadmodel

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ export interface CadModelProps extends CadModelBase {
   pcbX?: Distance;
   pcbY?: Distance;
   pcbZ?: Distance;
+  modelUnitToMmScale?: Distance;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -547,6 +547,7 @@ export interface CadModelProps extends CadModelBase {
   pcbX?: Distance
   pcbY?: Distance
   pcbZ?: Distance
+  modelUnitToMmScale?: Distance
 }
 const cadModelBaseWithUrl = cadModelBase.extend({
   modelUrl: z.string(),
@@ -1827,8 +1828,7 @@ export const pcbNotePathProps = pcbLayoutProps
 ### pcb-note-rect
 
 ```typescript
-export interface PcbNoteRectProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
+export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   width: string | number
   height: string | number
   strokeWidth?: string | number

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -310,6 +310,7 @@ export interface CadModelProps extends CadModelBase {
   pcbX?: Distance
   pcbY?: Distance
   pcbZ?: Distance
+  modelUnitToMmScale?: Distance
 }
 
 
@@ -930,8 +931,7 @@ export interface PcbNotePathProps
 }
 
 
-export interface PcbNoteRectProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
+export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   width: string | number
   height: string | number
   strokeWidth?: string | number

--- a/lib/components/cadmodel.ts
+++ b/lib/components/cadmodel.ts
@@ -9,6 +9,7 @@ export interface CadModelProps extends CadModelBase {
   pcbX?: Distance
   pcbY?: Distance
   pcbZ?: Distance
+  modelUnitToMmScale?: Distance
 }
 
 const pcbPosition = z.object({

--- a/tests/cadmodel.test.ts
+++ b/tests/cadmodel.test.ts
@@ -33,3 +33,17 @@ test("cadmodel accepts optional stepUrl", () => {
 
   expect(parsed.stepUrl).toBe("https://example.com/model.step")
 })
+
+test("cadmodel accepts modelUnitToMmScale", () => {
+  const raw: CadModelPropsInput = {
+    modelUrl: "https://example.com/model.stl",
+    modelUnitToMmScale: 2,
+  }
+
+  const parsed = cadmodelProps.parse(raw) as Exclude<
+    CadModelPropsInput,
+    null | string
+  >
+
+  expect(parsed.modelUnitToMmScale).toBe(2)
+})


### PR DESCRIPTION
## Summary
- add the `modelUnitToMmScale` option to the `<cadmodel />` props interface and documentation
- extend cadmodel validation tests to cover parsing the new model scale property

## Testing
- `bun test tests/cadmodel.test.ts`
- `bunx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68edb723a804832e9bf9a9ab0313697b