### PR TITLE
Add zOffsetFromSurface support to cadmodel component

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -21,12 +21,14 @@ export interface CadModelBase {
   }
   size?: { x: number | string; y: number | string; z: number | string }
   modelUnitToMmScale?: Distance
+  zOffsetFromSurface?: Distance
 }
 export const cadModelBase = z.object({
   rotationOffset: z.number().or(rotationPoint3).optional(),
   positionOffset: point3.optional(),
   size: point3.optional(),
   modelUnitToMmScale: distance.optional(),
+  zOffsetFromSurface: distance.optional(),
 })
 export interface CadModelStl extends CadModelBase {
   stlUrl: string
@@ -1827,8 +1829,7 @@ export const pcbNotePathProps = pcbLayoutProps
 ### pcb-note-rect
 
 ```typescript
-export interface PcbNoteRectProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
+export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   width: string | number
   height: string | number
   strokeWidth?: string | number
@@ -2208,7 +2209,7 @@ export const schematicArcProps = z.object({
     .enum(["clockwise", "counterclockwise"])
     .default("counterclockwise"),
   strokeWidth: distance.optional(),
-  color: z.string().optional().default("#000000"),
+  color: z.string().optional(),
   isDashed: z.boolean().optional().default(false),
 })
 ```
@@ -2271,7 +2272,7 @@ export const schematicCircleProps = z.object({
   center: point,
   radius: distance,
   strokeWidth: distance.optional(),
-  color: z.string().optional().default("#000000"),
+  color: z.string().optional(),
   isFilled: z.boolean().optional().default(false),
   fillColor: z.string().optional(),
   isDashed: z.boolean().optional().default(false),
@@ -2287,7 +2288,7 @@ export const schematicLineProps = z.object({
   x2: distance,
   y2: distance,
   strokeWidth: distance.optional(),
-  color: z.string().optional().default("#000000"),
+  color: z.string().optional(),
   isDashed: z.boolean().optional().default(false),
 })
 ```
@@ -2312,7 +2313,7 @@ export const schematicRectProps = z.object({
   height: distance,
   rotation: rotation.default(0),
   strokeWidth: distance.optional(),
-  color: z.string().optional().default("#000000"),
+  color: z.string().optional(),
   isFilled: z.boolean().optional().default(false),
   fillColor: z.string().optional(),
   isDashed: z.boolean().optional().default(false),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -280,6 +280,7 @@ export interface CadModelBase {
   }
   size?: { x: number | string; y: number | string; z: number | string }
   modelUnitToMmScale?: Distance
+  zOffsetFromSurface?: Distance
 }
 
 
@@ -930,8 +931,7 @@ export interface PcbNotePathProps
 }
 
 
-export interface PcbNoteRectProps
-  extends Omit<PcbLayoutProps, "pcbRotation"> {
+export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   width: string | number
   height: string | number
   strokeWidth?: string | number

--- a/lib/common/cadModel.ts
+++ b/lib/common/cadModel.ts
@@ -21,6 +21,7 @@ export interface CadModelBase {
   }
   size?: { x: number | string; y: number | string; z: number | string }
   modelUnitToMmScale?: Distance
+  zOffsetFromSurface?: Distance
 }
 
 export const cadModelBase = z.object({
@@ -28,6 +29,7 @@ export const cadModelBase = z.object({
   positionOffset: point3.optional(),
   size: point3.optional(),
   modelUnitToMmScale: distance.optional(),
+  zOffsetFromSurface: distance.optional(),
 })
 
 expectTypesMatch<CadModelBase, z.input<typeof cadModelBase>>(true)

--- a/tests/cadmodel.test.ts
+++ b/tests/cadmodel.test.ts
@@ -33,3 +33,17 @@ test("cadmodel accepts optional stepUrl", () => {
 
   expect(parsed.stepUrl).toBe("https://example.com/model.step")
 })
+
+test("cadmodel accepts zOffsetFromSurface", () => {
+  const raw: CadModelPropsInput = {
+    modelUrl: "https://example.com/model.stl",
+    zOffsetFromSurface: 0,
+  }
+
+  const parsed = cadmodelProps.parse(raw) as Exclude<
+    CadModelPropsInput,
+    null | string
+  >
+
+  expect(parsed.zOffsetFromSurface).toBe(0)
+})


### PR DESCRIPTION
## Summary
- allow cadmodel props to specify a zOffsetFromSurface distance
- regenerate component and props docs to include the new property
- add coverage for the new prop in cadmodel prop parsing tests

## Testing
- bun test tests/cadmodel.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68eea4833348832e9471eecc02a17191