### PR TITLE
Remove simulation config fields from platformConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -1536,12 +1536,6 @@ export interface PlatformConfig {
   >;
 
   footprintFileParserMap?: Record<string, FootprintFileParserEntry>;
-
-  simSwitchFrequency?: number | string;
-  simCloseAt?: number | string;
-  simOpenAt?: number | string;
-  simStartClosed?: boolean;
-  simStartOpen?: boolean;
 }
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1183,11 +1183,6 @@ export interface PlatformConfig {
 
   footprintFileParserMap?: Record<string, FootprintFileParserEntry>
 
-  simSwitchFrequency?: number | string
-  simCloseAt?: number | string
-  simOpenAt?: number | string
-  simStartClosed?: boolean
-  simStartOpen?: boolean
 }
 
 

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -7,7 +7,6 @@ import {
 import { expectTypesMatch } from "./typecheck"
 import { z } from "zod"
 import { type CadModelProp, cadModelProp } from "./common/cadModel"
-import { frequency, ms } from "circuit-json"
 
 export interface FootprintLibraryResult {
   footprintCircuitJson: any[]
@@ -79,12 +78,6 @@ export interface PlatformConfig {
   >
 
   footprintFileParserMap?: Record<string, FootprintFileParserEntry>
-
-  simSwitchFrequency?: number | string
-  simCloseAt?: number | string
-  simOpenAt?: number | string
-  simStartClosed?: boolean
-  simStartOpen?: boolean
 }
 
 const unvalidatedCircuitJson = z.array(z.any()).describe("Circuit JSON")
@@ -175,11 +168,6 @@ export const platformConfig = z.object({
   footprintFileParserMap: z
     .record(z.string(), footprintFileParserEntry)
     .optional(),
-  simSwitchFrequency: frequency.optional(),
-  simCloseAt: ms.optional(),
-  simOpenAt: ms.optional(),
-  simStartClosed: z.boolean().optional(),
-  simStartOpen: z.boolean().optional(),
 }) as z.ZodType<PlatformConfig>
 
 expectTypesMatch<PlatformConfig, z.infer<typeof platformConfig>>(true)


### PR DESCRIPTION
## Summary
- remove simulation timing fields from the PlatformConfig interface and schema
- regenerate README and props overview docs to reflect the updated configuration options

## Testing
- bun test
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68eeb48da8cc832e8917753ca835f087