### PR TITLE
Add includeBoards option to project configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1519,6 +1519,7 @@ export interface PlatformConfig {
   version?: string;
   url?: string;
   printBoardInformationToSilkscreen?: boolean;
+  includeBoards?: string[];
 
   pcbDisabled?: boolean;
   schematicDisabled?: boolean;
@@ -1564,6 +1565,7 @@ export interface ProjectConfig
     | "version"
     | "url"
     | "printBoardInformationToSilkscreen"
+    | "includeBoards"
   > {}
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1165,6 +1165,7 @@ export interface PlatformConfig {
   version?: string
   url?: string
   printBoardInformationToSilkscreen?: boolean
+  includeBoards?: string[]
 
   pcbDisabled?: boolean
   schematicDisabled?: boolean

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -62,6 +62,7 @@ export interface PlatformConfig {
   version?: string
   url?: string
   printBoardInformationToSilkscreen?: boolean
+  includeBoards?: string[]
 
   pcbDisabled?: boolean
   schematicDisabled?: boolean
@@ -155,6 +156,12 @@ export const platformConfig = z.object({
   version: z.string().optional(),
   url: z.string().optional(),
   printBoardInformationToSilkscreen: z.boolean().optional(),
+  includeBoards: z
+    .array(z.string())
+    .describe(
+      'The board files to automatically build with "tsci build", defaults to ["**/*.circuit.tsx"]. Can be an array of files or globs',
+    )
+    .optional(),
   localCacheEngine: z.any().optional(),
   pcbDisabled: z.boolean().optional(),
   schematicDisabled: z.boolean().optional(),

--- a/lib/projectConfig.ts
+++ b/lib/projectConfig.ts
@@ -10,6 +10,7 @@ export interface ProjectConfig
     | "version"
     | "url"
     | "printBoardInformationToSilkscreen"
+    | "includeBoards"
   > {}
 
 const platformConfigObject = platformConfig as z.ZodObject<any>
@@ -20,6 +21,7 @@ export const projectConfig = platformConfigObject.pick({
   version: true,
   url: true,
   printBoardInformationToSilkscreen: true,
+  includeBoards: true,
 }) as z.ZodType<ProjectConfig>
 
 expectTypesMatch<ProjectConfig, z.infer<typeof projectConfig>>(true)

--- a/tests/projectConfig.test.ts
+++ b/tests/projectConfig.test.ts
@@ -8,6 +8,7 @@ test("projectConfig only includes project-specific fields", () => {
     version: "1.2.3",
     url: "https://example.com/docs",
     printBoardInformationToSilkscreen: true,
+    includeBoards: ["boards/main.circuit.tsx"],
     pcbDisabled: true,
     schematicDisabled: true,
     partsEngineDisabled: true,
@@ -20,5 +21,6 @@ test("projectConfig only includes project-specific fields", () => {
     version: "1.2.3",
     url: "https://example.com/docs",
     printBoardInformationToSilkscreen: true,
+    includeBoards: ["boards/main.circuit.tsx"],
   })
 })


### PR DESCRIPTION
## Summary
- add an optional includeBoards field to the platform configuration schema with documentation
- expose the includeBoards option via projectConfig so project settings can whitelist boards
- update the project configuration test to cover includeBoards handling

## Testing
- bunx tsc --noEmit
- bun test tests/projectConfig.test.ts
- bun scripts/generate-component-types.ts
- bun scripts/generate-manual-edits-docs.ts
- bun scripts/generate-readme-docs.ts
- bun scripts/generate-props-overview.ts
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68eeb6145c04832e9a1d7ff26cd17719