### PR TITLE
Add double sided assembly option to board component

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ export interface BoardProps
   topSilkscreenColor?: BoardColor;
   /** Color of the bottom silkscreen */
   bottomSilkscreenColor?: BoardColor;
+  /** Whether the board should be assembled on both sides */
+  doubleSidedAssembly?: boolean;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -461,8 +461,9 @@ export interface BoardProps
   silkscreenColor?: BoardColor
   topSilkscreenColor?: BoardColor
   bottomSilkscreenColor?: BoardColor
+  doubleSidedAssembly?: boolean
 }
-/** Color of the bottom silkscreen */
+/** Whether the board should be assembled on both sides */
 export const boardProps = subcircuitGroupProps
   .omit({ connections: true })
   .extend({
@@ -479,6 +480,7 @@ export const boardProps = subcircuitGroupProps
     silkscreenColor: boardColor.optional(),
     topSilkscreenColor: boardColor.optional(),
     bottomSilkscreenColor: boardColor.optional(),
+    doubleSidedAssembly: z.boolean().optional().default(false),
   })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -226,6 +226,8 @@ export interface BoardProps
   topSilkscreenColor?: BoardColor
   /** Color of the bottom silkscreen */
   bottomSilkscreenColor?: BoardColor
+  /** Whether the board should be assembled on both sides */
+  doubleSidedAssembly?: boolean
 }
 
 
@@ -1183,7 +1185,6 @@ export interface PlatformConfig {
   >
 
   footprintFileParserMap?: Record<string, FootprintFileParserEntry>
-
 }
 
 

--- a/lib/components/board.ts
+++ b/lib/components/board.ts
@@ -45,6 +45,8 @@ export interface BoardProps
   topSilkscreenColor?: BoardColor
   /** Color of the bottom silkscreen */
   bottomSilkscreenColor?: BoardColor
+  /** Whether the board should be assembled on both sides */
+  doubleSidedAssembly?: boolean
 }
 
 export const boardProps = subcircuitGroupProps
@@ -63,6 +65,7 @@ export const boardProps = subcircuitGroupProps
     silkscreenColor: boardColor.optional(),
     topSilkscreenColor: boardColor.optional(),
     bottomSilkscreenColor: boardColor.optional(),
+    doubleSidedAssembly: z.boolean().optional().default(false),
   })
 
 type InferredBoardProps = z.input<typeof boardProps>


### PR DESCRIPTION
## Summary
- add a `doubleSidedAssembly` option to the `<board />` component props and schema
a- regenerate the documentation and component type outputs to include the new property

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68f0265fc4e4832eb30046bf4f88283c