### PR TITLE
feat: add panel component props

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ resistorProps.parse({ resistance: "10k" } as ResistorPropsInput);
 | `<net />`                      | [`NetProps`](#netprops-net)                                                                |
 | `<netalias />`                 | [`NetAliasProps`](#netaliasprops-netalias)                                                 |
 | `<netlabel />`                 | [`NetLabelProps`](#netlabelprops-netlabel)                                                 |
+| `<panel />`                    | [`PanelProps`](#panelprops-panel)                                                          |
 | `<pcbkeepout />`               | [`PcbKeepoutProps`](#pcbkeepoutprops-pcbkeepout)                                           |
 | `<pcbnotedimension />`         | [`PcbNoteDimensionProps`](#pcbnotedimensionprops-pcbnotedimension)                         |
 | `<pcbnoteline />`              | [`PcbNoteLineProps`](#pcbnotelineprops-pcbnoteline)                                        |
@@ -860,6 +861,22 @@ export interface NetLabelProps {
 ```
 
 [Source](https://github.com/tscircuit/props/blob/main/lib/components/netlabel.ts)
+
+### PanelProps `<panel />`
+
+```ts
+export interface PanelProps extends BaseGroupProps {
+  width: Distance;
+  height: Distance;
+  children?: BaseGroupProps["children"];
+  /**
+   * If true, prevent a solder mask from being applied to this panel.
+   */
+  noSolderMask?: boolean;
+}
+```
+
+[Source](https://github.com/tscircuit/props/blob/main/lib/components/panel.ts)
 
 ### PcbKeepoutProps `<pcbkeepout />`
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1742,6 +1742,32 @@ export const netLabelProps = z.object({
 })
 ```
 
+### panel
+
+```typescript
+export interface PanelProps extends BaseGroupProps {
+  width: Distance
+  height: Distance
+  children?: BaseGroupProps["children"]
+  noSolderMask?: boolean
+}
+/**
+   * If true, prevent a solder mask from being applied to this panel.
+   */
+export const panelProps = baseGroupProps
+  .omit({
+    width: true,
+    height: true,
+    children: true,
+  })
+  .extend({
+    width: distance,
+    height: distance,
+    children: z.any().optional(),
+    noSolderMask: z.boolean().optional(),
+  })
+```
+
 ### pcb-keepout
 
 ```typescript

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -877,6 +877,17 @@ export interface OvalPlatedHoleProps extends Omit<PcbLayoutProps, "layer"> {
 }
 
 
+export interface PanelProps extends BaseGroupProps {
+  width: Distance
+  height: Distance
+  children?: BaseGroupProps["children"]
+  /**
+   * If true, prevent a solder mask from being applied to this panel.
+   */
+  noSolderMask?: boolean
+}
+
+
 export interface PcbLayoutProps {
   pcbX?: string | number
   pcbY?: string | number

--- a/lib/components/panel.ts
+++ b/lib/components/panel.ts
@@ -1,0 +1,30 @@
+import { distance, type Distance } from "lib/common/distance"
+import { expectTypesMatch } from "lib/typecheck"
+import { z } from "zod"
+import { baseGroupProps, type BaseGroupProps } from "./group"
+
+export interface PanelProps extends BaseGroupProps {
+  width: Distance
+  height: Distance
+  children?: BaseGroupProps["children"]
+  /**
+   * If true, prevent a solder mask from being applied to this panel.
+   */
+  noSolderMask?: boolean
+}
+
+export const panelProps = baseGroupProps
+  .omit({
+    width: true,
+    height: true,
+    children: true,
+  })
+  .extend({
+    width: distance,
+    height: distance,
+    children: z.any().optional(),
+    noSolderMask: z.boolean().optional(),
+  })
+
+type InferredPanelProps = z.input<typeof panelProps>
+expectTypesMatch<PanelProps, InferredPanelProps>(true)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,6 +14,7 @@ export * from "./common/cadModel"
 export * from "./common/schematicPinLabel"
 
 export * from "./components/board"
+export * from "./components/panel"
 export * from "./components/breakout"
 export * from "./components/chip"
 export * from "./components/pinout"


### PR DESCRIPTION
## Summary
- add a panel component definition with required width and height along with an optional noSolderMask flag
- export the panel component and regenerate the documentation listings to include it

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68f13fef0b60832e821a0e25493ecca2