### PR TITLE
Allow trace pcbPath to include selector references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1310,6 +1310,7 @@ export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   width: Distance;
   height: Distance;
   rectBorderRadius?: Distance;
+  cornerRadius?: Distance;
   portHints?: PortHints;
   coveredWithSolderMask?: boolean;
 }

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2479,6 +2479,7 @@ export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   width: Distance
   height: Distance
   rectBorderRadius?: Distance
+  cornerRadius?: Distance
   portHints?: PortHints
   coveredWithSolderMask?: boolean
 }
@@ -2488,6 +2489,7 @@ export interface RotatedRectSmtPadProps
   shape: "rotated_rect"
   width: Distance
   height: Distance
+  cornerRadius?: Distance
   ccwRotation: number
   portHints?: PortHints
   coveredWithSolderMask?: boolean
@@ -2524,6 +2526,7 @@ export const rectSmtPadProps = pcbLayoutProps
     width: distance,
     height: distance,
     rectBorderRadius: distance.optional(),
+    cornerRadius: distance.optional(),
     portHints: portHints.optional(),
     coveredWithSolderMask: z.boolean().optional(),
   })
@@ -2535,6 +2538,7 @@ export const rotatedRectSmtPadProps = pcbLayoutProps
     width: distance,
     height: distance,
     ccwRotation: z.number(),
+    cornerRadius: distance.optional(),
     portHints: portHints.optional(),
     coveredWithSolderMask: z.boolean().optional(),
   })

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1238,6 +1238,7 @@ export interface RectSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   width: Distance
   height: Distance
   rectBorderRadius?: Distance
+  cornerRadius?: Distance
   portHints?: PortHints
   coveredWithSolderMask?: boolean
 }
@@ -1276,6 +1277,7 @@ export interface RotatedRectSmtPadProps
   shape: "rotated_rect"
   width: Distance
   height: Distance
+  cornerRadius?: Distance
   ccwRotation: number
   portHints?: PortHints
   coveredWithSolderMask?: boolean

--- a/lib/components/trace.ts
+++ b/lib/components/trace.ts
@@ -15,7 +15,7 @@ const baseTraceProps = z.object({
   schematicRouteHints: z.array(point).optional(),
   pcbRouteHints: z.array(route_hint_point).optional(),
   pcbPathRelativeTo: z.string().optional(),
-  pcbPath: z.array(point).optional(),
+  pcbPath: z.array(z.union([point, z.string()])).optional(),
   schDisplayLabel: z.string().optional(),
   schStroke: z.string().optional(),
   highlightColor: z.string().optional(),

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -14,3 +14,15 @@ test("parses arbitrary schStroke and highlightColor on trace", () => {
   expect(parsed.schStroke).toBe("green")
   expect(parsed.highlightColor).toBe("#123456")
 })
+
+test("accepts pin selector strings within pcbPath", () => {
+  const raw: TraceProps = {
+    from: "U1.1",
+    to: "U1.2",
+    pcbPath: ["U1.3", { x: 0, y: 0 }, "J1.1"],
+  }
+
+  const parsed = traceProps.parse(raw)
+
+  expect(parsed.pcbPath).toEqual(["U1.3", { x: 0, y: 0 }, "J1.1"])
+})


### PR DESCRIPTION
## Summary
- allow trace pcbPath definitions to mix coordinate points and pin selector strings
- add coverage to ensure selector strings are accepted when parsing trace props
- regenerate documentation after schema updates

## Testing
- bun test tests/trace.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68f155a92cf0832ea7e4c4a882f6eeef