### PR TITLE
Add pcbOffsetX, pcbOffsetY and pcbPositionMode as layout properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ export interface CadModelProps extends CadModelBase {
   stepUrl?: string;
   pcbX?: Distance;
   pcbY?: Distance;
+  pcbOffsetX?: Distance;
+  pcbOffsetY?: Distance;
   pcbZ?: Distance;
 }
 ```
@@ -503,7 +505,10 @@ export interface DiodeProps<PinLabel extends string = string>
 
 ```ts
 export interface FabricationNoteDimensionProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   from: string | Point;
   to: string | Point;
   text?: string;
@@ -662,7 +667,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbPaddingTop?: Distance;
   pcbPaddingBottom?: Distance;
   /**
-   * Anchor to use when interpreting pcbX/pcbY relative to pcbPosition
+   * Anchor to use when interpreting pcbX/pcbY/pcbOffsetX/pcbOffsetY relative to pcbPosition
    */
   pcbPositionAnchor?: AutocompleteString<z.infer<typeof ninePointAnchor>>;
 
@@ -890,7 +895,10 @@ export type PcbKeepoutProps = z.input<typeof pcbKeepoutProps>;
 
 ```ts
 export interface PcbNoteDimensionProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   from: string | Point;
   to: string | Point;
   text?: string;
@@ -908,7 +916,10 @@ export interface PcbNoteDimensionProps
 
 ```ts
 export interface PcbNoteLineProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   x1: string | number;
   y1: string | number;
   x2: string | number;
@@ -925,7 +936,10 @@ export interface PcbNoteLineProps
 
 ```ts
 export interface PcbNotePathProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   route: RouteHintPointInput[];
   strokeWidth?: string | number;
   color?: string;
@@ -1545,6 +1559,7 @@ export interface PlatformConfig {
   url?: string;
   printBoardInformationToSilkscreen?: boolean;
   includeBoardFiles?: string[];
+  snapshotsDir?: string;
 
   pcbDisabled?: boolean;
   schematicDisabled?: boolean;
@@ -1585,6 +1600,7 @@ export interface ProjectConfig
     | "url"
     | "printBoardInformationToSilkscreen"
     | "includeBoardFiles"
+    | "snapshotsDir"
   > {}
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -127,8 +127,11 @@ export type FootprintSoupElements = {
 export interface PcbLayoutProps {
   pcbX?: string | number
   pcbY?: string | number
+  pcbOffsetX?: string | number
+  pcbOffsetY?: string | number
   pcbRotation?: string | number
   pcbPositionAnchor?: string
+  pcbPositionMode?: PcbPositionMode
   layer?: LayerRefInput
   pcbMarginTop?: string | number
   pcbMarginRight?: string | number
@@ -145,8 +148,11 @@ export interface PcbLayoutProps {
 export interface CommonLayoutProps {
   pcbX?: string | number
   pcbY?: string | number
+  pcbOffsetX?: string | number
+  pcbOffsetY?: string | number
   pcbRotation?: string | number
   pcbPositionAnchor?: string
+  pcbPositionMode?: PcbPositionMode
 
   pcbMarginTop?: string | number
   pcbMarginRight?: string | number
@@ -182,8 +188,18 @@ export interface CommonLayoutProps {
 export const pcbLayoutProps = z.object({
   pcbX: distance.optional(),
   pcbY: distance.optional(),
+  pcbOffsetX: distance.optional(),
+  pcbOffsetY: distance.optional(),
   pcbRotation: rotation.optional(),
   pcbPositionAnchor: z.string().optional(),
+  pcbPositionMode: z
+    .enum([
+      "relative_to_group_anchor",
+      "auto",
+      "relative_to_board_anchor",
+      "relative_to_component_anchor",
+    ])
+    .optional(),
   layer: layer_ref.optional(),
   pcbMarginTop: distance.optional(),
   pcbMarginRight: distance.optional(),
@@ -197,8 +213,18 @@ export const pcbLayoutProps = z.object({
 export const commonLayoutProps = z.object({
   pcbX: distance.optional(),
   pcbY: distance.optional(),
+  pcbOffsetX: distance.optional(),
+  pcbOffsetY: distance.optional(),
   pcbRotation: rotation.optional(),
   pcbPositionAnchor: z.string().optional(),
+  pcbPositionMode: z
+    .enum([
+      "relative_to_group_anchor",
+      "auto",
+      "relative_to_board_anchor",
+      "relative_to_component_anchor",
+    ])
+    .optional(),
   pcbMarginTop: distance.optional(),
   pcbMarginRight: distance.optional(),
   pcbMarginBottom: distance.optional(),
@@ -550,6 +576,8 @@ export interface CadModelProps extends CadModelBase {
   stepUrl?: string
   pcbX?: Distance
   pcbY?: Distance
+  pcbOffsetX?: Distance
+  pcbOffsetY?: Distance
   pcbZ?: Distance
 }
 const cadModelBaseWithUrl = cadModelBase.extend({
@@ -825,7 +853,13 @@ export const copperPourProps = z.object({
 
 ```typescript
 export const courtyardOutlineProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     outline: z.array(point),
     strokeWidth: length.optional(),
@@ -969,7 +1003,10 @@ export interface DiodeProps<PinLabel extends string = string>
 
 ```typescript
 export interface FabricationNoteDimensionProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   from: string | Point
   to: string | Point
   text?: string
@@ -980,7 +1017,13 @@ export interface FabricationNoteDimensionProps
   arrowSize?: string | number
 }
 export const fabricationNoteDimensionProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     from: dimensionTarget,
     to: dimensionTarget,
@@ -997,7 +1040,13 @@ export const fabricationNoteDimensionProps = pcbLayoutProps
 
 ```typescript
 export const fabricationNotePathProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     route: z.array(route_hint_point),
     strokeWidth: length.optional(),
@@ -1786,7 +1835,10 @@ pcbLayoutProps.extend({
 
 ```typescript
 export interface PcbNoteDimensionProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   from: string | Point
   to: string | Point
   text?: string
@@ -1797,7 +1849,13 @@ export interface PcbNoteDimensionProps
   arrowSize?: string | number
 }
 export const pcbNoteDimensionProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     from: dimensionTarget,
     to: dimensionTarget,
@@ -1814,7 +1872,10 @@ export const pcbNoteDimensionProps = pcbLayoutProps
 
 ```typescript
 export interface PcbNoteLineProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   x1: string | number
   y1: string | number
   x2: string | number
@@ -1824,7 +1885,13 @@ export interface PcbNoteLineProps
   isDashed?: boolean
 }
 export const pcbNoteLineProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     x1: distance,
     y1: distance,
@@ -1840,13 +1907,22 @@ export const pcbNoteLineProps = pcbLayoutProps
 
 ```typescript
 export interface PcbNotePathProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   route: RouteHintPointInput[]
   strokeWidth?: string | number
   color?: string
 }
 export const pcbNotePathProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     route: z.array(route_hint_point),
     strokeWidth: length.optional(),
@@ -2417,7 +2493,13 @@ export const silkscreenCircleProps = pcbLayoutProps
 
 ```typescript
 export const silkscreenLineProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     strokeWidth: distance,
     x1: distance,
@@ -2431,7 +2513,13 @@ export const silkscreenLineProps = pcbLayoutProps
 
 ```typescript
 export const silkscreenPathProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     route: z.array(route_hint_point),
     strokeWidth: length.optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -121,7 +121,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbPaddingTop?: Distance
   pcbPaddingBottom?: Distance
   /**
-   * Anchor to use when interpreting pcbX/pcbY relative to pcbPosition
+   * Anchor to use when interpreting pcbX/pcbY/pcbOffsetX/pcbOffsetY relative to pcbPosition
    */
   pcbPositionAnchor?: AutocompleteString<z.infer<typeof ninePointAnchor>>
 
@@ -312,6 +312,8 @@ export interface CadModelProps extends CadModelBase {
   stepUrl?: string
   pcbX?: Distance
   pcbY?: Distance
+  pcbOffsetX?: Distance
+  pcbOffsetY?: Distance
   pcbZ?: Distance
 }
 
@@ -457,8 +459,11 @@ export interface CommonComponentProps<PinLabel extends string = string>
 export interface CommonLayoutProps {
   pcbX?: string | number
   pcbY?: string | number
+  pcbOffsetX?: string | number
+  pcbOffsetY?: string | number
   pcbRotation?: string | number
   pcbPositionAnchor?: string
+  pcbPositionMode?: PcbPositionMode
 
   pcbMarginTop?: string | number
   pcbMarginRight?: string | number
@@ -618,7 +623,10 @@ export interface EditTraceHintEvent extends BaseManualEditEvent {
 
 
 export interface FabricationNoteDimensionProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   from: string | Point
   to: string | Point
   text?: string
@@ -891,8 +899,11 @@ export interface PanelProps extends BaseGroupProps {
 export interface PcbLayoutProps {
   pcbX?: string | number
   pcbY?: string | number
+  pcbOffsetX?: string | number
+  pcbOffsetY?: string | number
   pcbRotation?: string | number
   pcbPositionAnchor?: string
+  pcbPositionMode?: PcbPositionMode
   layer?: LayerRefInput
   pcbMarginTop?: string | number
   pcbMarginRight?: string | number
@@ -912,7 +923,10 @@ export interface PcbLayoutProps {
 
 
 export interface PcbNoteDimensionProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   from: string | Point
   to: string | Point
   text?: string
@@ -925,7 +939,10 @@ export interface PcbNoteDimensionProps
 
 
 export interface PcbNoteLineProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   x1: string | number
   y1: string | number
   x2: string | number
@@ -937,7 +954,10 @@ export interface PcbNoteLineProps
 
 
 export interface PcbNotePathProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   route: RouteHintPointInput[]
   strokeWidth?: string | number
   color?: string
@@ -1179,6 +1199,7 @@ export interface PlatformConfig {
   url?: string
   printBoardInformationToSilkscreen?: boolean
   includeBoardFiles?: string[]
+  snapshotsDir?: string
 
   pcbDisabled?: boolean
   schematicDisabled?: boolean

--- a/lib/common/layout.ts
+++ b/lib/common/layout.ts
@@ -11,11 +11,23 @@ import { type CadModelProp, cadModelProp } from "./cadModel"
 import { type FootprintProp, footprintProp } from "./footprintProp"
 import { type SymbolProp, symbolProp } from "./symbolProp"
 
+export type PcbPositionMode =
+  | "relative_to_group_anchor"
+  | "auto"
+  | "relative_to_board_anchor"
+  | "relative_to_component_anchor"
+
+/** @deprecated Use {@link PcbPositionMode} instead. */
+export type PositionMode = PcbPositionMode
+
 export interface PcbLayoutProps {
   pcbX?: string | number
   pcbY?: string | number
+  pcbOffsetX?: string | number
+  pcbOffsetY?: string | number
   pcbRotation?: string | number
   pcbPositionAnchor?: string
+  pcbPositionMode?: PcbPositionMode
   layer?: LayerRefInput
   pcbMarginTop?: string | number
   pcbMarginRight?: string | number
@@ -36,8 +48,11 @@ export interface PcbLayoutProps {
 export interface CommonLayoutProps {
   pcbX?: string | number
   pcbY?: string | number
+  pcbOffsetX?: string | number
+  pcbOffsetY?: string | number
   pcbRotation?: string | number
   pcbPositionAnchor?: string
+  pcbPositionMode?: PcbPositionMode
 
   pcbMarginTop?: string | number
   pcbMarginRight?: string | number
@@ -80,8 +95,18 @@ export interface CommonLayoutProps {
 export const pcbLayoutProps = z.object({
   pcbX: distance.optional(),
   pcbY: distance.optional(),
+  pcbOffsetX: distance.optional(),
+  pcbOffsetY: distance.optional(),
   pcbRotation: rotation.optional(),
   pcbPositionAnchor: z.string().optional(),
+  pcbPositionMode: z
+    .enum([
+      "relative_to_group_anchor",
+      "auto",
+      "relative_to_board_anchor",
+      "relative_to_component_anchor",
+    ])
+    .optional(),
   layer: layer_ref.optional(),
   pcbMarginTop: distance.optional(),
   pcbMarginRight: distance.optional(),
@@ -98,8 +123,18 @@ expectTypesMatch<PcbLayoutProps, InferredPcbLayoutProps>(true)
 export const commonLayoutProps = z.object({
   pcbX: distance.optional(),
   pcbY: distance.optional(),
+  pcbOffsetX: distance.optional(),
+  pcbOffsetY: distance.optional(),
   pcbRotation: rotation.optional(),
   pcbPositionAnchor: z.string().optional(),
+  pcbPositionMode: z
+    .enum([
+      "relative_to_group_anchor",
+      "auto",
+      "relative_to_board_anchor",
+      "relative_to_component_anchor",
+    ])
+    .optional(),
   pcbMarginTop: distance.optional(),
   pcbMarginRight: distance.optional(),
   pcbMarginBottom: distance.optional(),

--- a/lib/components/cadmodel.ts
+++ b/lib/components/cadmodel.ts
@@ -8,12 +8,16 @@ export interface CadModelProps extends CadModelBase {
   stepUrl?: string
   pcbX?: Distance
   pcbY?: Distance
+  pcbOffsetX?: Distance
+  pcbOffsetY?: Distance
   pcbZ?: Distance
 }
 
 const pcbPosition = z.object({
   pcbX: distance.optional(),
   pcbY: distance.optional(),
+  pcbOffsetX: distance.optional(),
+  pcbOffsetY: distance.optional(),
   pcbZ: distance.optional(),
 })
 

--- a/lib/components/courtyard-outline.ts
+++ b/lib/components/courtyard-outline.ts
@@ -4,7 +4,13 @@ import { point } from "lib/common/point"
 import { z } from "zod"
 
 export const courtyardOutlineProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     outline: z.array(point),
     strokeWidth: length.optional(),

--- a/lib/components/fabrication-note-dimension.ts
+++ b/lib/components/fabrication-note-dimension.ts
@@ -7,7 +7,10 @@ import { z } from "zod"
 const dimensionTarget = z.union([z.string(), point])
 
 export interface FabricationNoteDimensionProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   from: string | Point
   to: string | Point
   text?: string
@@ -19,7 +22,13 @@ export interface FabricationNoteDimensionProps
 }
 
 export const fabricationNoteDimensionProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     from: dimensionTarget,
     to: dimensionTarget,

--- a/lib/components/fabrication-note-path.ts
+++ b/lib/components/fabrication-note-path.ts
@@ -3,7 +3,13 @@ import { pcbLayoutProps } from "lib/common/layout"
 import { z } from "zod"
 
 export const fabricationNotePathProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     route: z.array(route_hint_point),
     strokeWidth: length.optional(),

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -212,7 +212,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   pcbPaddingTop?: Distance
   pcbPaddingBottom?: Distance
   /**
-   * Anchor to use when interpreting pcbX/pcbY relative to pcbPosition
+   * Anchor to use when interpreting pcbX/pcbY/pcbOffsetX/pcbOffsetY relative to pcbPosition
    */
   pcbPositionAnchor?: AutocompleteString<z.infer<typeof ninePointAnchor>>
 

--- a/lib/components/pcb-note-dimension.ts
+++ b/lib/components/pcb-note-dimension.ts
@@ -7,7 +7,10 @@ import { z } from "zod"
 const dimensionTarget = z.union([z.string(), point])
 
 export interface PcbNoteDimensionProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   from: string | Point
   to: string | Point
   text?: string
@@ -19,7 +22,13 @@ export interface PcbNoteDimensionProps
 }
 
 export const pcbNoteDimensionProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     from: dimensionTarget,
     to: dimensionTarget,

--- a/lib/components/pcb-note-line.ts
+++ b/lib/components/pcb-note-line.ts
@@ -4,7 +4,10 @@ import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
 export interface PcbNoteLineProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   x1: string | number
   y1: string | number
   x2: string | number
@@ -15,7 +18,13 @@ export interface PcbNoteLineProps
 }
 
 export const pcbNoteLineProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     x1: distance,
     y1: distance,

--- a/lib/components/pcb-note-path.ts
+++ b/lib/components/pcb-note-path.ts
@@ -8,14 +8,23 @@ import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
 export interface PcbNotePathProps
-  extends Omit<PcbLayoutProps, "pcbX" | "pcbY" | "pcbRotation"> {
+  extends Omit<
+    PcbLayoutProps,
+    "pcbX" | "pcbY" | "pcbOffsetX" | "pcbOffsetY" | "pcbRotation"
+  > {
   route: RouteHintPointInput[]
   strokeWidth?: string | number
   color?: string
 }
 
 export const pcbNotePathProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     route: z.array(route_hint_point),
     strokeWidth: length.optional(),

--- a/lib/components/silkscreen-line.ts
+++ b/lib/components/silkscreen-line.ts
@@ -3,7 +3,13 @@ import { pcbLayoutProps } from "lib/common/layout"
 import type { z } from "zod"
 
 export const silkscreenLineProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     strokeWidth: distance,
     x1: distance,

--- a/lib/components/silkscreen-path.ts
+++ b/lib/components/silkscreen-path.ts
@@ -3,7 +3,13 @@ import { pcbLayoutProps } from "lib/common/layout"
 import { z } from "zod"
 
 export const silkscreenPathProps = pcbLayoutProps
-  .omit({ pcbX: true, pcbY: true, pcbRotation: true })
+  .omit({
+    pcbX: true,
+    pcbY: true,
+    pcbOffsetX: true,
+    pcbOffsetY: true,
+    pcbRotation: true,
+  })
   .extend({
     route: z.array(route_hint_point),
     strokeWidth: length.optional(),

--- a/tests/breakout.test.ts
+++ b/tests/breakout.test.ts
@@ -29,3 +29,17 @@ test("should parse breakout point props", () => {
   expect(parsed.pcbY).toBe(2)
   expect(parsed.connection).toBe(".R1 > .pin1")
 })
+
+test("should parse breakout point offsets and position mode", () => {
+  const raw = {
+    pcbOffsetX: 1,
+    pcbOffsetY: "3mm",
+    pcbPositionMode: "relative_to_board_anchor" as const,
+    connection: ".R2 > .pin1",
+  }
+
+  const parsed = breakoutPointProps.parse(raw)
+  expect(parsed.pcbOffsetX).toBe(1)
+  expect(parsed.pcbOffsetY).toBeCloseTo(3)
+  expect(parsed.pcbPositionMode).toBe("relative_to_board_anchor")
+})

--- a/tests/cadmodel.test.ts
+++ b/tests/cadmodel.test.ts
@@ -20,6 +20,22 @@ test("cadmodel accepts pcb coordinates", () => {
   expect(parsed.pcbZ).toBe(3)
 })
 
+test("cadmodel accepts pcb offsets", () => {
+  const raw: CadModelPropsInput = {
+    modelUrl: "https://example.com/model.stl",
+    pcbOffsetX: "1mm",
+    pcbOffsetY: 2,
+  }
+
+  const parsed = cadmodelProps.parse(raw) as Exclude<
+    CadModelPropsInput,
+    null | string
+  >
+
+  expect(parsed.pcbOffsetX).toBeCloseTo(1)
+  expect(parsed.pcbOffsetY).toBe(2)
+})
+
 test("cadmodel accepts optional stepUrl", () => {
   const raw: CadModelPropsInput = {
     modelUrl: "https://example.com/model.stl",

--- a/tests/fabrication-note.test.ts
+++ b/tests/fabrication-note.test.ts
@@ -29,6 +29,22 @@ test("fabrication note rect parses minimal props", () => {
   expect(parsed.color).toBeUndefined()
 })
 
+test("fabrication note rect accepts pcb offsets and position mode", () => {
+  const rect = {
+    pcbOffsetX: "2mm",
+    pcbOffsetY: 3,
+    pcbPositionMode: "relative_to_group_anchor" as const,
+    width: 5,
+    height: 4,
+  }
+
+  const parsed = fabricationNoteRectProps.parse(rect)
+
+  expect(parsed.pcbOffsetX).toBeCloseTo(2)
+  expect(parsed.pcbOffsetY).toBe(3)
+  expect(parsed.pcbPositionMode).toBe("relative_to_group_anchor")
+})
+
 test("fabrication note rect allows styling overrides", () => {
   const parsed = fabricationNoteRectProps.parse({
     width: "3mm",


### PR DESCRIPTION
## Summary
- rename the shared layout `positionMode` property to `pcbPositionMode` and add a deprecated type alias for compatibility
- update fabrication note and breakout tests along with generated docs to use the new property name

## Testing
- bunx tsc --noEmit
- bun test tests/fabrication-note.test.ts
- bun test tests/breakout.test.ts
- bun test tests/cadmodel.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68f271ecbec4832ea6a7bfc70692ec1d