### PR TITLE
feat: add circuitJson prop to subcircuit component

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1451,6 +1451,8 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
 
   autorouter?: AutorouterProp
 
+  circuitJson?: any[]
+
   schAutoLayoutEnabled?: boolean
 
   schTraceAutoLabelEnabled?: boolean
@@ -1589,6 +1591,7 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   outline: z.array(point).optional(),
   outlineOffsetX: distance.optional(),
   outlineOffsetY: distance.optional(),
+  circuitJson: z.array(z.any()).optional(),
 })
 export const subcircuitGroupPropsWithBool = subcircuitGroupProps.extend({
   subcircuit: z.literal(true),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1405,6 +1405,11 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
   autorouter?: AutorouterProp
 
   /**
+   * Serialized circuit JSON describing a precompiled subcircuit
+   */
+  circuitJson?: any[]
+
+  /**
    * If true, we'll automatically layout the schematic for this group. Must be
    * a subcircuit (currently). This is eventually going to be replaced with more
    * sophisticated layout options/modes and will be enabled by default.

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -397,6 +397,11 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
   autorouter?: AutorouterProp
 
   /**
+   * Serialized circuit JSON describing a precompiled subcircuit
+   */
+  circuitJson?: any[]
+
+  /**
    * If true, we'll automatically layout the schematic for this group. Must be
    * a subcircuit (currently). This is eventually going to be replaced with more
    * sophisticated layout options/modes and will be enabled by default.
@@ -553,6 +558,7 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   outline: z.array(point).optional(),
   outlineOffsetX: distance.optional(),
   outlineOffsetY: distance.optional(),
+  circuitJson: z.array(z.any()).optional(),
 })
 
 export const subcircuitGroupPropsWithBool = subcircuitGroupProps.extend({


### PR DESCRIPTION
## Summary
- allow subcircuits to accept an optional `circuitJson` payload for precompiled boards
- regenerate component type and props overview documentation to capture the new prop

## Testing
- bunx tsc --noEmit
- bun test tests/group.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68f54b8ed100832ebfc99e6c11a60904