### PR TITLE
Add spice engine configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ export interface AnalogSimulationProps {
   simulationType?: "spice_transient_analysis";
   duration?: number | string;
   timePerStep?: number | string;
+  spiceEngine?: AutocompleteString<"spicey" | "ngspice">;
 }
 ```
 
@@ -1561,6 +1562,8 @@ export interface PlatformConfig {
   includeBoardFiles?: string[];
   snapshotsDir?: string;
 
+  defaultSpiceEngine?: AutocompleteString<"spicey" | "ngspice">;
+
   pcbDisabled?: boolean;
   schematicDisabled?: boolean;
   partsEngineDisabled?: boolean;
@@ -1601,6 +1604,7 @@ export interface ProjectConfig
     | "printBoardInformationToSilkscreen"
     | "includeBoardFiles"
     | "snapshotsDir"
+    | "defaultSpiceEngine"
   > {}
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -440,6 +440,7 @@ export interface AnalogSimulationProps {
   simulationType?: "spice_transient_analysis"
   duration?: number | string
   timePerStep?: number | string
+  spiceEngine?: AutocompleteString<"spicey" | "ngspice">
 }
 export const analogSimulationProps = z.object({
   simulationType: z
@@ -447,6 +448,7 @@ export const analogSimulationProps = z.object({
     .default("spice_transient_analysis"),
   duration: ms.optional(),
   timePerStep: ms.optional(),
+  spiceEngine: spiceEngine.optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -22,6 +22,7 @@ export interface AnalogSimulationProps {
   simulationType?: "spice_transient_analysis"
   duration?: number | string
   timePerStep?: number | string
+  spiceEngine?: AutocompleteString<"spicey" | "ngspice">
 }
 
 
@@ -1200,6 +1201,8 @@ export interface PlatformConfig {
   printBoardInformationToSilkscreen?: boolean
   includeBoardFiles?: string[]
   snapshotsDir?: string
+
+  defaultSpiceEngine?: AutocompleteString<"spicey" | "ngspice">
 
   pcbDisabled?: boolean
   schematicDisabled?: boolean

--- a/lib/components/analogsimulation.ts
+++ b/lib/components/analogsimulation.ts
@@ -1,4 +1,5 @@
 import { ms } from "circuit-json"
+import type { AutocompleteString } from "lib/common/autocomplete"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
@@ -6,7 +7,12 @@ export interface AnalogSimulationProps {
   simulationType?: "spice_transient_analysis"
   duration?: number | string
   timePerStep?: number | string
+  spiceEngine?: AutocompleteString<"spicey" | "ngspice">
 }
+
+const spiceEngine = z.custom<AutocompleteString<"spicey" | "ngspice">>(
+  (value) => typeof value === "string",
+)
 
 export const analogSimulationProps = z.object({
   simulationType: z
@@ -14,6 +20,7 @@ export const analogSimulationProps = z.object({
     .default("spice_transient_analysis"),
   duration: ms.optional(),
   timePerStep: ms.optional(),
+  spiceEngine: spiceEngine.optional(),
 })
 
 expectTypesMatch<AnalogSimulationProps, z.input<typeof analogSimulationProps>>(

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -4,6 +4,7 @@ import {
   type PartsEngine,
   partsEngine,
 } from "./components/group"
+import type { AutocompleteString } from "./common/autocomplete"
 import { expectTypesMatch } from "./typecheck"
 import { z } from "zod"
 import { type CadModelProp, cadModelProp } from "./common/cadModel"
@@ -64,6 +65,8 @@ export interface PlatformConfig {
   includeBoardFiles?: string[]
   snapshotsDir?: string
 
+  defaultSpiceEngine?: AutocompleteString<"spicey" | "ngspice">
+
   pcbDisabled?: boolean
   schematicDisabled?: boolean
   partsEngineDisabled?: boolean
@@ -118,6 +121,10 @@ const spiceEngineZod = z.object({
     ),
 })
 
+const defaultSpiceEngine = z.custom<AutocompleteString<"spicey" | "ngspice">>(
+  (value) => typeof value === "string",
+)
+
 const autorouterInstance = z.object({
   run: z
     .function()
@@ -162,6 +169,7 @@ export const platformConfig = z.object({
       'The directory where snapshots are stored for "tsci snapshot", defaults to "tests/__snapshots__"',
     )
     .optional(),
+  defaultSpiceEngine: defaultSpiceEngine.optional(),
   localCacheEngine: z.any().optional(),
   pcbDisabled: z.boolean().optional(),
   schematicDisabled: z.boolean().optional(),

--- a/lib/projectConfig.ts
+++ b/lib/projectConfig.ts
@@ -12,6 +12,7 @@ export interface ProjectConfig
     | "printBoardInformationToSilkscreen"
     | "includeBoardFiles"
     | "snapshotsDir"
+    | "defaultSpiceEngine"
   > {}
 
 const platformConfigObject = platformConfig as z.ZodObject<any>
@@ -24,6 +25,7 @@ export const projectConfig = platformConfigObject.pick({
   printBoardInformationToSilkscreen: true,
   includeBoardFiles: true,
   snapshotsDir: true,
+  defaultSpiceEngine: true,
 }) as z.ZodType<ProjectConfig>
 
 expectTypesMatch<ProjectConfig, z.infer<typeof projectConfig>>(true)

--- a/tests/analogsimulation.test.ts
+++ b/tests/analogsimulation.test.ts
@@ -27,3 +27,14 @@ test("analog simulation accepts time parameters", () => {
   expect(parsed.duration).toBe(1)
   expect(parsed.timePerStep).toBe(0.001)
 })
+
+test("analog simulation accepts spice engine selection", () => {
+  const raw: AnalogSimulationProps = {
+    spiceEngine: "spicey",
+  }
+
+  expectTypeOf(raw).toMatchTypeOf<z.input<typeof analogSimulationProps>>()
+
+  const parsed = analogSimulationProps.parse(raw)
+  expect(parsed.spiceEngine).toBe("spicey")
+})

--- a/tests/projectConfig.test.ts
+++ b/tests/projectConfig.test.ts
@@ -10,6 +10,7 @@ test("projectConfig only includes project-specific fields", () => {
     printBoardInformationToSilkscreen: true,
     includeBoardFiles: ["boards/main.circuit.tsx"],
     snapshotsDir: "custom/snapshots",
+    defaultSpiceEngine: "spicey",
     pcbDisabled: true,
     schematicDisabled: true,
     partsEngineDisabled: true,
@@ -24,6 +25,7 @@ test("projectConfig only includes project-specific fields", () => {
     printBoardInformationToSilkscreen: true,
     includeBoardFiles: ["boards/main.circuit.tsx"],
     snapshotsDir: "custom/snapshots",
+    defaultSpiceEngine: "spicey",
   })
 })
 


### PR DESCRIPTION
## Summary
- add an optional `spiceEngine` field to analog simulation props with autocomplete hints for supported engines
- add `defaultSpiceEngine` to platform and project configuration typing and documentation
- extend analog simulation and project config tests and regenerate docs

## Testing
- bun test tests/analogsimulation.test.ts
- bun test tests/projectConfig.test.ts
- bunx tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_b_68f7a02be0dc832ea319ce2e1510427f