### PR TITLE
feat: add connections prop to testpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1455,6 +1455,7 @@ export interface TestpointProps extends CommonComponentProps {
    * Height of the pad when padShape is rect
    */
   height?: number | string;
+  connections?: TestpointConnections;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2799,6 +2799,12 @@ export const symbolProps = z.object({
 ### testpoint
 
 ```typescript
+export type TestpointPinLabels = (typeof testpointPins)[number]
+
+const testpointConnectionsProp = z
+  .object({
+    pin1: connectionTarget,
+  })
 export interface TestpointProps extends CommonComponentProps {
   footprintVariant?: "pad" | "through_hole"
   padShape?: "rect" | "circle"
@@ -2806,8 +2812,10 @@ export interface TestpointProps extends CommonComponentProps {
   holeDiameter?: number | string
   width?: number | string
   height?: number | string
+  connections?: TestpointConnections
 }
 .extend({
+    connections: testpointConnectionsProp.optional(),
     footprintVariant: z.enum(["pad", "through_hole"]).optional(),
     padShape: z.enum(["rect", "circle"]).optional().default("circle"),
     padDiameter: distance.optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1506,6 +1506,7 @@ export interface TestpointProps extends CommonComponentProps {
    * Height of the pad when padShape is rect
    */
   height?: number | string
+  connections?: TestpointConnections
 }
 
 

--- a/lib/components/testpoint.ts
+++ b/lib/components/testpoint.ts
@@ -5,6 +5,18 @@ import {
 } from "lib/common/layout"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
+import { connectionTarget } from "lib/common/connectionsProp"
+
+export const testpointPins = ["pin1"] as const
+export type TestpointPinLabels = (typeof testpointPins)[number]
+
+const testpointConnectionsProp = z
+  .object({
+    pin1: connectionTarget,
+  })
+  .strict()
+
+export type TestpointConnections = z.infer<typeof testpointConnectionsProp>
 
 export interface TestpointProps extends CommonComponentProps {
   /**
@@ -31,10 +43,12 @@ export interface TestpointProps extends CommonComponentProps {
    * Height of the pad when padShape is rect
    */
   height?: number | string
+  connections?: TestpointConnections
 }
 
 export const testpointProps = commonComponentProps
   .extend({
+    connections: testpointConnectionsProp.optional(),
     footprintVariant: z.enum(["pad", "through_hole"]).optional(),
     padShape: z.enum(["rect", "circle"]).optional().default("circle"),
     padDiameter: distance.optional(),

--- a/tests/testpoint.test.ts
+++ b/tests/testpoint.test.ts
@@ -31,10 +31,14 @@ test("should parse through_hole testpoint", () => {
     footprintVariant: "through_hole",
     padDiameter: 2,
     holeDiameter: 1,
+    connections: {
+      pin1: ".U1 > .pin1",
+    },
   }
   const parsed = testpointProps.parse(rawProps)
   expect(parsed.footprintVariant).toBe("through_hole")
   expect(parsed.holeDiameter).toBe(1)
+  expect(parsed.connections?.pin1).toBe(".U1 > .pin1")
 })
 
 test("should require holeDiameter for through_hole variant", () => {
@@ -44,5 +48,26 @@ test("should require holeDiameter for through_hole variant", () => {
       footprintVariant: "through_hole",
       padDiameter: 2,
     } as TestpointProps),
+  ).toThrow(z.ZodError)
+})
+
+test("should require pin1 connection when connections provided", () => {
+  expect(() =>
+    testpointProps.parse({
+      name: "tp4",
+      connections: {} as TestpointProps["connections"],
+    }),
+  ).toThrow(z.ZodError)
+})
+
+test("should reject unknown connection labels", () => {
+  expect(() =>
+    testpointProps.parse({
+      name: "tp5",
+      connections: {
+        pin1: ".U1 > .pin1",
+        pin2: ".U1 > .pin2",
+      } as unknown as TestpointProps["connections"],
+    }),
   ).toThrow(z.ZodError)
 })


### PR DESCRIPTION
## Summary
- add a strictly typed connections prop to the testpoint component
- update documentation to describe the new testpoint connections type
- extend test coverage for testpoint connections parsing and validation

## Testing
- bun test tests/testpoint.test.ts
- bunx tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_b_68f7b1f2377c832e9491407fbef73a47