### PR TITLE
Allow specifying units on note dimension components

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ export interface FabricationNoteDimensionProps
   fontSize?: string | number;
   color?: string;
   arrowSize?: string | number;
+  units?: "in" | "mm";
 }
 ```
 
@@ -908,6 +909,7 @@ export interface PcbNoteDimensionProps
   fontSize?: string | number;
   color?: string;
   arrowSize?: string | number;
+  units?: "in" | "mm";
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1017,6 +1017,7 @@ export interface FabricationNoteDimensionProps
   fontSize?: string | number
   color?: string
   arrowSize?: string | number
+  units?: "in" | "mm"
 }
 export const fabricationNoteDimensionProps = pcbLayoutProps
   .omit({
@@ -1035,6 +1036,7 @@ export const fabricationNoteDimensionProps = pcbLayoutProps
     fontSize: length.optional(),
     color: z.string().optional(),
     arrowSize: distance.optional(),
+    units: z.enum(["in", "mm"]).optional(),
   })
 ```
 
@@ -1852,6 +1854,7 @@ export interface PcbNoteDimensionProps
   fontSize?: string | number
   color?: string
   arrowSize?: string | number
+  units?: "in" | "mm"
 }
 export const pcbNoteDimensionProps = pcbLayoutProps
   .omit({
@@ -1870,6 +1873,7 @@ export const pcbNoteDimensionProps = pcbLayoutProps
     fontSize: length.optional(),
     color: z.string().optional(),
     arrowSize: distance.optional(),
+    units: z.enum(["in", "mm"]).optional(),
   })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -636,6 +636,7 @@ export interface FabricationNoteDimensionProps
   fontSize?: string | number
   color?: string
   arrowSize?: string | number
+  units?: "in" | "mm"
 }
 
 
@@ -936,6 +937,7 @@ export interface PcbNoteDimensionProps
   fontSize?: string | number
   color?: string
   arrowSize?: string | number
+  units?: "in" | "mm"
 }
 
 

--- a/lib/components/fabrication-note-dimension.ts
+++ b/lib/components/fabrication-note-dimension.ts
@@ -19,6 +19,7 @@ export interface FabricationNoteDimensionProps
   fontSize?: string | number
   color?: string
   arrowSize?: string | number
+  units?: "in" | "mm"
 }
 
 export const fabricationNoteDimensionProps = pcbLayoutProps
@@ -38,6 +39,7 @@ export const fabricationNoteDimensionProps = pcbLayoutProps
     fontSize: length.optional(),
     color: z.string().optional(),
     arrowSize: distance.optional(),
+    units: z.enum(["in", "mm"]).optional(),
   })
 
 expectTypesMatch<

--- a/lib/components/pcb-note-dimension.ts
+++ b/lib/components/pcb-note-dimension.ts
@@ -19,6 +19,7 @@ export interface PcbNoteDimensionProps
   fontSize?: string | number
   color?: string
   arrowSize?: string | number
+  units?: "in" | "mm"
 }
 
 export const pcbNoteDimensionProps = pcbLayoutProps
@@ -38,6 +39,7 @@ export const pcbNoteDimensionProps = pcbLayoutProps
     fontSize: length.optional(),
     color: z.string().optional(),
     arrowSize: distance.optional(),
+    units: z.enum(["in", "mm"]).optional(),
   })
 
 expectTypesMatch<PcbNoteDimensionProps, z.input<typeof pcbNoteDimensionProps>>(


### PR DESCRIPTION
## Summary
- allow fabrication and pcb note dimension components to accept explicit units
- regenerate component documentation to include the new units property

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68fa7f461944832e86498376606f4ad2