### PR TITLE
Add width alias for trace thickness

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2862,12 +2862,12 @@ export const portRef = z.union([
   z.string(),
   z.custom<{ getPortSelector: () => string }>((v) =>
 baseTraceProps.extend({
-    path: z.array(portRef),
-  }),
+      path: z.array(portRef),
+    }),
 baseTraceProps.extend({
-    from: portRef,
-    to: portRef,
-  }),
+      from: portRef,
+      to: portRef,
+    }),
 ```
 
 ### transistor

--- a/lib/components/trace.ts
+++ b/lib/components/trace.ts
@@ -12,6 +12,7 @@ export const portRef = z.union([
 const baseTraceProps = z.object({
   key: z.string().optional(),
   thickness: distance.optional(),
+  width: distance.optional(),
   schematicRouteHints: z.array(point).optional(),
   pcbRouteHints: z.array(route_hint_point).optional(),
   pcbPathRelativeTo: z.string().optional(),
@@ -22,14 +23,19 @@ const baseTraceProps = z.object({
   maxLength: distance.optional(),
 })
 
-export const traceProps = z.union([
-  baseTraceProps.extend({
-    path: z.array(portRef),
-  }),
-  baseTraceProps.extend({
-    from: portRef,
-    to: portRef,
-  }),
-])
+export const traceProps = z
+  .union([
+    baseTraceProps.extend({
+      path: z.array(portRef),
+    }),
+    baseTraceProps.extend({
+      from: portRef,
+      to: portRef,
+    }),
+  ])
+  .transform((trace) => ({
+    ...trace,
+    thickness: trace.thickness ?? trace.width,
+  }))
 
 export type TraceProps = z.input<typeof traceProps>

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -26,3 +26,16 @@ test("accepts pin selector strings within pcbPath", () => {
 
   expect(parsed.pcbPath).toEqual(["U1.3", { x: 0, y: 0 }, "J1.1"])
 })
+
+test("treats width as an alias for thickness", () => {
+  const raw: TraceProps = {
+    from: "A",
+    to: "B",
+    width: 1,
+  }
+
+  const parsed = traceProps.parse(raw)
+
+  expect(parsed.width).toBe(1)
+  expect(parsed.thickness).toBe(1)
+})


### PR DESCRIPTION
## Summary
- allow `<trace />` props to accept a new `width` distance
- map the parsed trace thickness to the provided width when no explicit thickness is supplied
- cover the new alias with a dedicated test and regenerate component type docs

## Testing
- bun test tests/trace.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68fa973911bc832ea08e91c61d2178bb