### PR TITLE
Add width alias for trace thickness

### DIFF
--- a/lib/components/trace.ts
+++ b/lib/components/trace.ts
@@ -12,6 +12,7 @@ export const portRef = z.union([
 const baseTraceProps = z.object({
   key: z.string().optional(),
   thickness: distance.optional(),
+  width: distance.optional().describe("Alias for trace thickness"),
   schematicRouteHints: z.array(point).optional(),
   pcbRouteHints: z.array(route_hint_point).optional(),
   pcbPathRelativeTo: z.string().optional(),


### PR DESCRIPTION
## Summary
- add an optional `width` property to the trace props schema as an alias for `thickness`

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68fa9efc8eac832eb4c1baf82e52ce30