### PR TITLE
Add edge alignment options to note dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,9 @@ export interface FabricationNoteDimensionProps
   color?: string;
   arrowSize?: string | number;
   units?: "in" | "mm";
+  outerEdgeToEdge?: true;
+  centerToCenter?: true;
+  innerEdgeToEdge?: true;
 }
 ```
 
@@ -910,6 +913,9 @@ export interface PcbNoteDimensionProps
   color?: string;
   arrowSize?: string | number;
   units?: "in" | "mm";
+  outerEdgeToEdge?: true;
+  centerToCenter?: true;
+  innerEdgeToEdge?: true;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1018,6 +1018,9 @@ export interface FabricationNoteDimensionProps
   color?: string
   arrowSize?: string | number
   units?: "in" | "mm"
+  outerEdgeToEdge?: true
+  centerToCenter?: true
+  innerEdgeToEdge?: true
 }
 export const fabricationNoteDimensionProps = pcbLayoutProps
   .omit({
@@ -1037,6 +1040,9 @@ export const fabricationNoteDimensionProps = pcbLayoutProps
     color: z.string().optional(),
     arrowSize: distance.optional(),
     units: z.enum(["in", "mm"]).optional(),
+    outerEdgeToEdge: z.literal(true).optional(),
+    centerToCenter: z.literal(true).optional(),
+    innerEdgeToEdge: z.literal(true).optional(),
   })
 ```
 
@@ -1855,6 +1861,9 @@ export interface PcbNoteDimensionProps
   color?: string
   arrowSize?: string | number
   units?: "in" | "mm"
+  outerEdgeToEdge?: true
+  centerToCenter?: true
+  innerEdgeToEdge?: true
 }
 export const pcbNoteDimensionProps = pcbLayoutProps
   .omit({
@@ -1874,6 +1883,9 @@ export const pcbNoteDimensionProps = pcbLayoutProps
     color: z.string().optional(),
     arrowSize: distance.optional(),
     units: z.enum(["in", "mm"]).optional(),
+    outerEdgeToEdge: z.literal(true).optional(),
+    centerToCenter: z.literal(true).optional(),
+    innerEdgeToEdge: z.literal(true).optional(),
   })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -637,6 +637,9 @@ export interface FabricationNoteDimensionProps
   color?: string
   arrowSize?: string | number
   units?: "in" | "mm"
+  outerEdgeToEdge?: true
+  centerToCenter?: true
+  innerEdgeToEdge?: true
 }
 
 
@@ -938,6 +941,9 @@ export interface PcbNoteDimensionProps
   color?: string
   arrowSize?: string | number
   units?: "in" | "mm"
+  outerEdgeToEdge?: true
+  centerToCenter?: true
+  innerEdgeToEdge?: true
 }
 
 

--- a/lib/components/fabrication-note-dimension.ts
+++ b/lib/components/fabrication-note-dimension.ts
@@ -20,6 +20,9 @@ export interface FabricationNoteDimensionProps
   color?: string
   arrowSize?: string | number
   units?: "in" | "mm"
+  outerEdgeToEdge?: true
+  centerToCenter?: true
+  innerEdgeToEdge?: true
 }
 
 export const fabricationNoteDimensionProps = pcbLayoutProps
@@ -40,6 +43,9 @@ export const fabricationNoteDimensionProps = pcbLayoutProps
     color: z.string().optional(),
     arrowSize: distance.optional(),
     units: z.enum(["in", "mm"]).optional(),
+    outerEdgeToEdge: z.literal(true).optional(),
+    centerToCenter: z.literal(true).optional(),
+    innerEdgeToEdge: z.literal(true).optional(),
   })
 
 expectTypesMatch<

--- a/lib/components/pcb-note-dimension.ts
+++ b/lib/components/pcb-note-dimension.ts
@@ -20,6 +20,9 @@ export interface PcbNoteDimensionProps
   color?: string
   arrowSize?: string | number
   units?: "in" | "mm"
+  outerEdgeToEdge?: true
+  centerToCenter?: true
+  innerEdgeToEdge?: true
 }
 
 export const pcbNoteDimensionProps = pcbLayoutProps
@@ -40,6 +43,9 @@ export const pcbNoteDimensionProps = pcbLayoutProps
     color: z.string().optional(),
     arrowSize: distance.optional(),
     units: z.enum(["in", "mm"]).optional(),
+    outerEdgeToEdge: z.literal(true).optional(),
+    centerToCenter: z.literal(true).optional(),
+    innerEdgeToEdge: z.literal(true).optional(),
   })
 
 expectTypesMatch<PcbNoteDimensionProps, z.input<typeof pcbNoteDimensionProps>>(


### PR DESCRIPTION
## Summary
- add optional outerEdgeToEdge, centerToCenter, and innerEdgeToEdge flags to pcb and fabrication note dimension props
- regenerate generated documentation to surface the new note dimension options

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68fac4af0910832ea93ac71892f4aaa4