### PR TITLE
Add resolveProjectStaticFileImportUrl to platform config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1589,6 +1589,8 @@ export interface PlatformConfig {
   >;
 
   footprintFileParserMap?: Record<string, FootprintFileParserEntry>;
+
+  resolveProjectStaticFileImportUrl?: (path: string) => string;
 }
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1228,6 +1228,8 @@ export interface PlatformConfig {
   >
 
   footprintFileParserMap?: Record<string, FootprintFileParserEntry>
+
+  resolveProjectStaticFileImportUrl?: (path: string) => string
 }
 
 

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -83,6 +83,8 @@ export interface PlatformConfig {
   >
 
   footprintFileParserMap?: Record<string, FootprintFileParserEntry>
+
+  resolveProjectStaticFileImportUrl?: (path: string) => string
 }
 
 const unvalidatedCircuitJson = z.array(z.any()).describe("Circuit JSON")
@@ -189,6 +191,14 @@ export const platformConfig = z.object({
     .optional(),
   footprintFileParserMap: z
     .record(z.string(), footprintFileParserEntry)
+    .optional(),
+  resolveProjectStaticFileImportUrl: z
+    .function()
+    .args(z.string())
+    .returns(z.string())
+    .describe(
+      "A function that returns a string URL for static files for the project",
+    )
     .optional(),
 }) as z.ZodType<PlatformConfig>
 

--- a/tests/resolveProjectStaticFileImportUrl.test.ts
+++ b/tests/resolveProjectStaticFileImportUrl.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test"
+import { platformConfig } from "lib/platformConfig"
+
+test("resolveProjectStaticFileImportUrl returns the provided string", () => {
+  const config = platformConfig.parse({
+    resolveProjectStaticFileImportUrl: (path: string) =>
+      `https://cdn.example.com/${path}`,
+  })
+
+  expect(config.resolveProjectStaticFileImportUrl).toBeDefined()
+  const url = config.resolveProjectStaticFileImportUrl?.("images/logo.png")
+  expect(url).toBe("https://cdn.example.com/images/logo.png")
+})


### PR DESCRIPTION
## Summary
- add the optional resolveProjectStaticFileImportUrl handler to the platform configuration schema
- regenerate platform configuration documentation to include the new option
- cover the new option with a parsing test

## Testing
- bun test tests/resolveProjectStaticFileImportUrl.test.ts
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68fbf8f17af4832e9f819fb5930060e7