### PR TITLE
feat: make resolveProjectStaticFileImportUrl async

### DIFF
--- a/README.md
+++ b/README.md
@@ -1590,7 +1590,7 @@ export interface PlatformConfig {
 
   footprintFileParserMap?: Record<string, FootprintFileParserEntry>;
 
-  resolveProjectStaticFileImportUrl?: (path: string) => string;
+  resolveProjectStaticFileImportUrl?: (path: string) => Promise<string>;
 }
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1229,7 +1229,7 @@ export interface PlatformConfig {
 
   footprintFileParserMap?: Record<string, FootprintFileParserEntry>
 
-  resolveProjectStaticFileImportUrl?: (path: string) => string
+  resolveProjectStaticFileImportUrl?: (path: string) => Promise<string>
 }
 
 

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -84,7 +84,7 @@ export interface PlatformConfig {
 
   footprintFileParserMap?: Record<string, FootprintFileParserEntry>
 
-  resolveProjectStaticFileImportUrl?: (path: string) => string
+  resolveProjectStaticFileImportUrl?: (path: string) => Promise<string>
 }
 
 const unvalidatedCircuitJson = z.array(z.any()).describe("Circuit JSON")
@@ -195,7 +195,7 @@ export const platformConfig = z.object({
   resolveProjectStaticFileImportUrl: z
     .function()
     .args(z.string())
-    .returns(z.string())
+    .returns(z.promise(z.string()))
     .describe(
       "A function that returns a string URL for static files for the project",
     )

--- a/tests/resolveProjectStaticFileImportUrl.test.ts
+++ b/tests/resolveProjectStaticFileImportUrl.test.ts
@@ -1,13 +1,14 @@
 import { expect, test } from "bun:test"
 import { platformConfig } from "lib/platformConfig"
 
-test("resolveProjectStaticFileImportUrl returns the provided string", () => {
+test("resolveProjectStaticFileImportUrl returns the provided string", async () => {
   const config = platformConfig.parse({
-    resolveProjectStaticFileImportUrl: (path: string) =>
+    resolveProjectStaticFileImportUrl: async (path: string) =>
       `https://cdn.example.com/${path}`,
   })
 
   expect(config.resolveProjectStaticFileImportUrl).toBeDefined()
-  const url = config.resolveProjectStaticFileImportUrl?.("images/logo.png")
+  const resolver = config.resolveProjectStaticFileImportUrl
+  const url = resolver ? await resolver("images/logo.png") : undefined
   expect(url).toBe("https://cdn.example.com/images/logo.png")
 })


### PR DESCRIPTION
## Summary
- update the platform configuration typing so `resolveProjectStaticFileImportUrl` returns a `Promise<string>`
- regenerate documentation to reflect the async contract
- adjust the unit test to await the resolver

## Testing
- bun test tests/resolveProjectStaticFileImportUrl.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68fc14af3590832ea9ee48bbd9046fb0