### PR TITLE
feat: add pcb layout style options

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -139,6 +139,9 @@ export interface PcbLayoutProps {
   pcbMarginLeft?: string | number
   pcbMarginX?: string | number
   pcbMarginY?: string | number
+  pcbStyle?: {
+    silkscreenFontSize?: string | number
+  }
   pcbRelative?: boolean
   relative?: boolean
 }
@@ -160,6 +163,9 @@ export interface CommonLayoutProps {
   pcbMarginLeft?: string | number
   pcbMarginX?: string | number
   pcbMarginY?: string | number
+  pcbStyle?: {
+    silkscreenFontSize?: string | number
+  }
 
   schMarginTop?: string | number
   schMarginRight?: string | number
@@ -207,6 +213,11 @@ export const pcbLayoutProps = z.object({
   pcbMarginLeft: distance.optional(),
   pcbMarginX: distance.optional(),
   pcbMarginY: distance.optional(),
+  pcbStyle: z
+    .object({
+      silkscreenFontSize: distance.optional(),
+    })
+    .optional(),
   pcbRelative: z.boolean().optional(),
   relative: z.boolean().optional(),
 })
@@ -231,6 +242,11 @@ export const commonLayoutProps = z.object({
   pcbMarginLeft: distance.optional(),
   pcbMarginX: distance.optional(),
   pcbMarginY: distance.optional(),
+  pcbStyle: z
+    .object({
+      silkscreenFontSize: distance.optional(),
+    })
+    .optional(),
   schMarginTop: distance.optional(),
   schMarginRight: distance.optional(),
   schMarginBottom: distance.optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -472,6 +472,9 @@ export interface CommonLayoutProps {
   pcbMarginLeft?: string | number
   pcbMarginX?: string | number
   pcbMarginY?: string | number
+  pcbStyle?: {
+    silkscreenFontSize?: string | number
+  }
 
   schMarginTop?: string | number
   schMarginRight?: string | number
@@ -916,6 +919,9 @@ export interface PcbLayoutProps {
   pcbMarginLeft?: string | number
   pcbMarginX?: string | number
   pcbMarginY?: string | number
+  pcbStyle?: {
+    silkscreenFontSize?: string | number
+  }
   /**
    * If true, pcbX/pcbY will be interpreted relative to the parent group
    */

--- a/lib/common/layout.ts
+++ b/lib/common/layout.ts
@@ -35,6 +35,9 @@ export interface PcbLayoutProps {
   pcbMarginLeft?: string | number
   pcbMarginX?: string | number
   pcbMarginY?: string | number
+  pcbStyle?: {
+    silkscreenFontSize?: string | number
+  }
   /**
    * If true, pcbX/pcbY will be interpreted relative to the parent group
    */
@@ -60,6 +63,9 @@ export interface CommonLayoutProps {
   pcbMarginLeft?: string | number
   pcbMarginX?: string | number
   pcbMarginY?: string | number
+  pcbStyle?: {
+    silkscreenFontSize?: string | number
+  }
 
   schMarginTop?: string | number
   schMarginRight?: string | number
@@ -114,6 +120,11 @@ export const pcbLayoutProps = z.object({
   pcbMarginLeft: distance.optional(),
   pcbMarginX: distance.optional(),
   pcbMarginY: distance.optional(),
+  pcbStyle: z
+    .object({
+      silkscreenFontSize: distance.optional(),
+    })
+    .optional(),
   pcbRelative: z.boolean().optional(),
   relative: z.boolean().optional(),
 })
@@ -141,6 +152,11 @@ export const commonLayoutProps = z.object({
   pcbMarginLeft: distance.optional(),
   pcbMarginX: distance.optional(),
   pcbMarginY: distance.optional(),
+  pcbStyle: z
+    .object({
+      silkscreenFontSize: distance.optional(),
+    })
+    .optional(),
   schMarginTop: distance.optional(),
   schMarginRight: distance.optional(),
   schMarginBottom: distance.optional(),


### PR DESCRIPTION
## Summary
- add an optional `pcbStyle` bag to the shared PCB layout props
- expose a `silkscreenFontSize` distance-based option and regenerate the docs

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68ffe5e53ebc832e9940033341a3aa79