### PR TITLE
feat: share pcb style definition (allow pcbStyle to be defined on boards and groups)

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,8 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   key?: any;
   children?: any;
 
+  pcbStyle?: PcbStyle;
+
   /**
    * Title to display above this group in the schematic view
    */

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -139,9 +139,7 @@ export interface PcbLayoutProps {
   pcbMarginLeft?: string | number
   pcbMarginX?: string | number
   pcbMarginY?: string | number
-  pcbStyle?: {
-    silkscreenFontSize?: string | number
-  }
+  pcbStyle?: PcbStyle
   pcbRelative?: boolean
   relative?: boolean
 }
@@ -163,9 +161,7 @@ export interface CommonLayoutProps {
   pcbMarginLeft?: string | number
   pcbMarginX?: string | number
   pcbMarginY?: string | number
-  pcbStyle?: {
-    silkscreenFontSize?: string | number
-  }
+  pcbStyle?: PcbStyle
 
   schMarginTop?: string | number
   schMarginRight?: string | number
@@ -213,11 +209,7 @@ export const pcbLayoutProps = z.object({
   pcbMarginLeft: distance.optional(),
   pcbMarginX: distance.optional(),
   pcbMarginY: distance.optional(),
-  pcbStyle: z
-    .object({
-      silkscreenFontSize: distance.optional(),
-    })
-    .optional(),
+  pcbStyle: pcbStyle.optional(),
   pcbRelative: z.boolean().optional(),
   relative: z.boolean().optional(),
 })
@@ -242,11 +234,7 @@ export const commonLayoutProps = z.object({
   pcbMarginLeft: distance.optional(),
   pcbMarginX: distance.optional(),
   pcbMarginY: distance.optional(),
-  pcbStyle: z
-    .object({
-      silkscreenFontSize: distance.optional(),
-    })
-    .optional(),
+  pcbStyle: pcbStyle.optional(),
   schMarginTop: distance.optional(),
   schMarginRight: distance.optional(),
   schMarginBottom: distance.optional(),
@@ -328,6 +316,17 @@ export const lrPolarPins = [
   "cathode",
   "neg",
 ] as const
+```
+
+### pcbStyle
+
+```typescript
+export interface PcbStyle {
+  silkscreenFontSize?: string | number
+}
+export const pcbStyle = z.object({
+  silkscreenFontSize: distance.optional(),
+})
 ```
 
 ### point
@@ -1321,6 +1320,8 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   name?: string
   key?: any
   children?: any
+
+  pcbStyle?: PcbStyle
 
   schTitle?: string
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -71,6 +71,8 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   key?: any
   children?: any
 
+  pcbStyle?: PcbStyle
+
   /**
    * Title to display above this group in the schematic view
    */
@@ -472,9 +474,7 @@ export interface CommonLayoutProps {
   pcbMarginLeft?: string | number
   pcbMarginX?: string | number
   pcbMarginY?: string | number
-  pcbStyle?: {
-    silkscreenFontSize?: string | number
-  }
+  pcbStyle?: PcbStyle
 
   schMarginTop?: string | number
   schMarginRight?: string | number
@@ -919,9 +919,7 @@ export interface PcbLayoutProps {
   pcbMarginLeft?: string | number
   pcbMarginX?: string | number
   pcbMarginY?: string | number
-  pcbStyle?: {
-    silkscreenFontSize?: string | number
-  }
+  pcbStyle?: PcbStyle
   /**
    * If true, pcbX/pcbY will be interpreted relative to the parent group
    */
@@ -1007,6 +1005,11 @@ export interface PcbNoteTextProps extends PcbLayoutProps {
 export interface PcbRouteCache {
   pcbTraces: PcbTrace[]
   cacheKey: string
+}
+
+
+export interface PcbStyle {
+  silkscreenFontSize?: string | number
 }
 
 

--- a/lib/common/layout.ts
+++ b/lib/common/layout.ts
@@ -9,6 +9,7 @@ import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 import { type CadModelProp, cadModelProp } from "./cadModel"
 import { type FootprintProp, footprintProp } from "./footprintProp"
+import { pcbStyle, type PcbStyle } from "./pcbStyle"
 import { type SymbolProp, symbolProp } from "./symbolProp"
 
 export type PcbPositionMode =
@@ -35,9 +36,7 @@ export interface PcbLayoutProps {
   pcbMarginLeft?: string | number
   pcbMarginX?: string | number
   pcbMarginY?: string | number
-  pcbStyle?: {
-    silkscreenFontSize?: string | number
-  }
+  pcbStyle?: PcbStyle
   /**
    * If true, pcbX/pcbY will be interpreted relative to the parent group
    */
@@ -63,9 +62,7 @@ export interface CommonLayoutProps {
   pcbMarginLeft?: string | number
   pcbMarginX?: string | number
   pcbMarginY?: string | number
-  pcbStyle?: {
-    silkscreenFontSize?: string | number
-  }
+  pcbStyle?: PcbStyle
 
   schMarginTop?: string | number
   schMarginRight?: string | number
@@ -120,11 +117,7 @@ export const pcbLayoutProps = z.object({
   pcbMarginLeft: distance.optional(),
   pcbMarginX: distance.optional(),
   pcbMarginY: distance.optional(),
-  pcbStyle: z
-    .object({
-      silkscreenFontSize: distance.optional(),
-    })
-    .optional(),
+  pcbStyle: pcbStyle.optional(),
   pcbRelative: z.boolean().optional(),
   relative: z.boolean().optional(),
 })
@@ -152,11 +145,7 @@ export const commonLayoutProps = z.object({
   pcbMarginLeft: distance.optional(),
   pcbMarginX: distance.optional(),
   pcbMarginY: distance.optional(),
-  pcbStyle: z
-    .object({
-      silkscreenFontSize: distance.optional(),
-    })
-    .optional(),
+  pcbStyle: pcbStyle.optional(),
   schMarginTop: distance.optional(),
   schMarginRight: distance.optional(),
   schMarginBottom: distance.optional(),

--- a/lib/common/pcbStyle.ts
+++ b/lib/common/pcbStyle.ts
@@ -1,0 +1,13 @@
+import { distance } from "circuit-json"
+import { expectTypesMatch } from "lib/typecheck"
+import { z } from "zod"
+
+export interface PcbStyle {
+  silkscreenFontSize?: string | number
+}
+
+export const pcbStyle = z.object({
+  silkscreenFontSize: distance.optional(),
+})
+
+expectTypesMatch<PcbStyle, z.input<typeof pcbStyle>>(true)

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -6,6 +6,7 @@ import {
   commonLayoutProps,
   type SupplierPartNumbers,
 } from "lib/common/layout"
+import type { PcbStyle } from "lib/common/pcbStyle"
 import { ninePointAnchor } from "lib/common/ninePointAnchor"
 import { type Point, point } from "lib/common/point"
 import { expectTypesMatch } from "lib/typecheck"
@@ -160,6 +161,8 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   name?: string
   key?: any
   children?: any
+
+  pcbStyle?: PcbStyle
 
   /**
    * Title to display above this group in the schematic view


### PR DESCRIPTION
## Summary
- add a shared pcbStyle schema/type for reuse
- wire the shared definition into layout and group props
- regenerate docs to surface pcbStyle on groups

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68fff4a5d674832e919e24eb04195553