### PR TITLE
Add silkscreen text options to pcb style

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -323,9 +323,28 @@ export const lrPolarPins = [
 ```typescript
 export interface PcbStyle {
   silkscreenFontSize?: string | number
+  silkscreenTextPosition?:
+    | "centered"
+    | "outside"
+    | "none"
+    | {
+        offsetX: number
+        offsetY: number
+      }
+  silkscreenTextVisibility?: "hidden" | "visible" | "inherit"
 }
 export const pcbStyle = z.object({
   silkscreenFontSize: distance.optional(),
+  silkscreenTextPosition: z
+    .union([
+      z.enum(["centered", "outside", "none"]),
+      z.object({
+        offsetX: z.number(),
+        offsetY: z.number(),
+      }),
+    ])
+    .optional(),
+  silkscreenTextVisibility: z.enum(["hidden", "visible", "inherit"]).optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1010,6 +1010,15 @@ export interface PcbRouteCache {
 
 export interface PcbStyle {
   silkscreenFontSize?: string | number
+  silkscreenTextPosition?:
+    | "centered"
+    | "outside"
+    | "none"
+    | {
+        offsetX: number
+        offsetY: number
+      }
+  silkscreenTextVisibility?: "hidden" | "visible" | "inherit"
 }
 
 

--- a/lib/common/pcbStyle.ts
+++ b/lib/common/pcbStyle.ts
@@ -4,10 +4,29 @@ import { z } from "zod"
 
 export interface PcbStyle {
   silkscreenFontSize?: string | number
+  silkscreenTextPosition?:
+    | "centered"
+    | "outside"
+    | "none"
+    | {
+        offsetX: number
+        offsetY: number
+      }
+  silkscreenTextVisibility?: "hidden" | "visible" | "inherit"
 }
 
 export const pcbStyle = z.object({
   silkscreenFontSize: distance.optional(),
+  silkscreenTextPosition: z
+    .union([
+      z.enum(["centered", "outside", "none"]),
+      z.object({
+        offsetX: z.number(),
+        offsetY: z.number(),
+      }),
+    ])
+    .optional(),
+  silkscreenTextVisibility: z.enum(["hidden", "visible", "inherit"]).optional(),
 })
 
 expectTypesMatch<PcbStyle, z.input<typeof pcbStyle>>(true)


### PR DESCRIPTION
## Summary
- extend `PcbStyle` to support silkscreen text positioning and visibility controls
- regenerate component type and props overview documentation to capture the new API

## Testing
- `bun scripts/generate-component-types.ts`
- `bun scripts/generate-manual-edits-docs.ts`
- `bun scripts/generate-readme-docs.ts`
- `bun scripts/generate-props-overview.ts`
- `bunx tsc --noEmit`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_6901046ef548832ea3fdaf29a3165b6f