### PR TITLE
add cornerRadius to rect components

### DIFF
--- a/lib/components/courtyard-rect.ts
+++ b/lib/components/courtyard-rect.ts
@@ -12,5 +12,6 @@ export const courtyardRectProps = pcbLayoutProps
     hasStroke: z.boolean().optional(),
     isStrokeDashed: z.boolean().optional(),
     color: z.string().optional(),
+    cornerRadius: distance.optional(),
   })
 export type CourtyardRectProps = z.input<typeof courtyardRectProps>

--- a/lib/components/fabrication-note-rect.ts
+++ b/lib/components/fabrication-note-rect.ts
@@ -12,5 +12,6 @@ export const fabricationNoteRectProps = pcbLayoutProps
     hasStroke: z.boolean().optional(),
     isStrokeDashed: z.boolean().optional(),
     color: z.string().optional(),
+    cornerRadius: distance.optional(),
   })
 export type FabricationNoteRectProps = z.input<typeof fabricationNoteRectProps>

--- a/lib/components/pcb-note-rect.ts
+++ b/lib/components/pcb-note-rect.ts
@@ -11,6 +11,7 @@ export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   hasStroke?: boolean
   isStrokeDashed?: boolean
   color?: string
+  cornerRadius?: string | number
 }
 
 export const pcbNoteRectProps = pcbLayoutProps
@@ -23,6 +24,7 @@ export const pcbNoteRectProps = pcbLayoutProps
     hasStroke: z.boolean().optional(),
     isStrokeDashed: z.boolean().optional(),
     color: z.string().optional(),
+    cornerRadius: distance.optional(),
   })
 
 expectTypesMatch<PcbNoteRectProps, z.input<typeof pcbNoteRectProps>>(true)

--- a/lib/components/schematic-rect.ts
+++ b/lib/components/schematic-rect.ts
@@ -12,6 +12,7 @@ export const schematicRectProps = z.object({
   isFilled: z.boolean().optional().default(false),
   fillColor: z.string().optional(),
   isDashed: z.boolean().optional().default(false),
+  cornerRadius: distance.optional(),
 })
 
 export type SchematicRectProps = z.input<typeof schematicRectProps>

--- a/lib/components/silkscreen-rect.ts
+++ b/lib/components/silkscreen-rect.ts
@@ -10,5 +10,6 @@ export const silkscreenRectProps = pcbLayoutProps
     strokeWidth: distance.optional(),
     width: distance,
     height: distance,
+    cornerRadius: distance.optional(),
   })
 export type SilkscreenRectProps = z.input<typeof silkscreenRectProps>


### PR DESCRIPTION
claim https://github.com/tscircuit/tscircuit/issues/1190

Adding cornerRadius prop to rect components.

Hi @seveibar, could you please have a quick look and let me know if this is the change you had in mind for https://github.com/tscircuit/tscircuit/issues/1190