### PR TITLE
Add laser_prefab autorouter preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -979,6 +979,7 @@ export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   hasStroke?: boolean;
   isStrokeDashed?: boolean;
   color?: string;
+  cornerRadius?: string | number;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1123,6 +1123,7 @@ export const fabricationNoteRectProps = pcbLayoutProps
     hasStroke: z.boolean().optional(),
     isStrokeDashed: z.boolean().optional(),
     color: z.string().optional(),
+    cornerRadius: distance.optional(),
   })
 ```
 
@@ -1466,6 +1467,7 @@ export interface AutorouterConfig {
     | "auto_local"
     | "auto_cloud"
     | "freerouting"
+    | "laser_prefab" // Prefabricated PCB with laser copper ablation
     | /** @deprecated Use "sequential_trace" */ "sequential-trace"
     | /** @deprecated Use "auto_local" */ "auto-local"
     | /** @deprecated Use "auto_cloud" */ "auto-cloud"
@@ -1493,6 +1495,7 @@ export const autorouterConfig = z.object({
       "auto_local",
       "auto_cloud",
       "freerouting",
+      "laser_prefab",
       "sequential-trace",
       "auto-local",
       "auto-cloud",
@@ -2010,6 +2013,7 @@ export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   hasStroke?: boolean
   isStrokeDashed?: boolean
   color?: string
+  cornerRadius?: string | number
 }
 export const pcbNoteRectProps = pcbLayoutProps
   .omit({ pcbRotation: true })
@@ -2021,6 +2025,7 @@ export const pcbNoteRectProps = pcbLayoutProps
     hasStroke: z.boolean().optional(),
     isStrokeDashed: z.boolean().optional(),
     color: z.string().optional(),
+    cornerRadius: distance.optional(),
   })
 ```
 
@@ -2490,6 +2495,7 @@ export const schematicRectProps = z.object({
   isFilled: z.boolean().optional().default(false),
   fillColor: z.string().optional(),
   isDashed: z.boolean().optional().default(false),
+  cornerRadius: distance.optional(),
 })
 ```
 
@@ -2606,6 +2612,7 @@ export const silkscreenRectProps = pcbLayoutProps
     strokeWidth: distance.optional(),
     width: distance,
     height: distance,
+    cornerRadius: distance.optional(),
   })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -46,6 +46,7 @@ export interface AutorouterConfig {
     | "auto_local"
     | "auto_cloud"
     | "freerouting"
+    | "laser_prefab" // Prefabricated PCB with laser copper ablation
     | /** @deprecated Use "sequential_trace" */ "sequential-trace"
     | /** @deprecated Use "auto_local" */ "auto-local"
     | /** @deprecated Use "auto_cloud" */ "auto-cloud"
@@ -985,6 +986,7 @@ export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   hasStroke?: boolean
   isStrokeDashed?: boolean
   color?: string
+  cornerRadius?: string | number
 }
 
 

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -313,6 +313,7 @@ export interface AutorouterConfig {
     | "auto_local"
     | "auto_cloud"
     | "freerouting"
+    | "laser_prefab" // Prefabricated PCB with laser copper ablation
     | /** @deprecated Use "sequential_trace" */ "sequential-trace"
     | /** @deprecated Use "auto_local" */ "auto-local"
     | /** @deprecated Use "auto_cloud" */ "auto-cloud"
@@ -325,6 +326,7 @@ export type AutorouterPreset =
   | "auto_local"
   | "auto_cloud"
   | "freerouting"
+  | "laser_prefab"
   | "sequential-trace"
   | "auto-local"
   | "auto-cloud"
@@ -360,6 +362,7 @@ export const autorouterConfig = z.object({
       "auto_local",
       "auto_cloud",
       "freerouting",
+      "laser_prefab",
       "sequential-trace",
       "auto-local",
       "auto-cloud",
@@ -375,6 +378,7 @@ export const autorouterPreset = z.union([
   z.literal("auto_local"),
   z.literal("auto_cloud"),
   z.literal("freerouting"),
+  z.literal("laser_prefab"), // Prefabricated PCB with laser copper ablation
   z.literal("sequential-trace"),
   z.literal("auto-local"),
   z.literal("auto-cloud"),

--- a/tests/autorouter.test.ts
+++ b/tests/autorouter.test.ts
@@ -11,6 +11,11 @@ test("supports snake_case presets", () => {
   expect(result).toBe("auto_cloud")
 })
 
+test("supports laser prefab preset", () => {
+  const result = autorouterProp.parse("laser_prefab")
+  expect(result).toBe("laser_prefab")
+})
+
 test("still supports deprecated kebab-case presets", () => {
   const result = autorouterProp.parse("auto-cloud")
   expect(result).toBe("auto-cloud")


### PR DESCRIPTION
## Summary
- add the laser_prefab autorouter preset and document its purpose
- regenerate component documentation to surface the new preset and the latest generated prop data
- extend autorouter tests to cover the new preset option

## Testing
- bun test tests/autorouter.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_6903b16e8ab4832e9977859b1951f682