### PR TITLE
Add netIsAssignable property to via components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1519,6 +1519,7 @@ export interface ViaProps extends CommonLayoutProps {
   holeDiameter: number | string;
   outerDiameter: number | string;
   connectsTo?: string | string[];
+  netIsAssignable?: boolean;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2980,6 +2980,7 @@ export interface ViaProps extends CommonLayoutProps {
   holeDiameter: number | string
   outerDiameter: number | string
   connectsTo?: string | string[]
+  netIsAssignable?: boolean
 }
 export const viaProps = commonLayoutProps.extend({
   name: z.string().optional(),
@@ -2988,6 +2989,7 @@ export const viaProps = commonLayoutProps.extend({
   holeDiameter: distance,
   outerDiameter: distance,
   connectsTo: z.string().or(z.array(z.string())).optional(),
+  netIsAssignable: z.boolean().optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1554,6 +1554,7 @@ export interface ViaProps extends CommonLayoutProps {
   holeDiameter: number | string
   outerDiameter: number | string
   connectsTo?: string | string[]
+  netIsAssignable?: boolean
 }
 
 

--- a/lib/components/via.ts
+++ b/lib/components/via.ts
@@ -10,6 +10,7 @@ export interface ViaProps extends CommonLayoutProps {
   holeDiameter: number | string
   outerDiameter: number | string
   connectsTo?: string | string[]
+  netIsAssignable?: boolean
 }
 
 export const viaProps = commonLayoutProps.extend({
@@ -19,6 +20,7 @@ export const viaProps = commonLayoutProps.extend({
   holeDiameter: distance,
   outerDiameter: distance,
   connectsTo: z.string().or(z.array(z.string())).optional(),
+  netIsAssignable: z.boolean().optional(),
 })
 export type InferredViaProps = z.input<typeof viaProps>
 expectTypesMatch<ViaProps, InferredViaProps>(true)


### PR DESCRIPTION
## Summary
- add an optional netIsAssignable flag to via props so they can opt out of automatic net assignment
- regenerate component type documentation to surface the new property

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_6903b510fb04832eb02910d1c931375e