### PR TITLE
Add power and ground net flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,6 +847,8 @@ export interface NetProps {
   name: string;
   connectsTo?: string | string[];
   highlightColor?: string;
+  isPowerNet?: boolean;
+  isGroundNet?: boolean;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1799,11 +1799,15 @@ export interface NetProps {
   name: string
   connectsTo?: string | string[]
   highlightColor?: string
+  isPowerNet?: boolean
+  isGroundNet?: boolean
 }
 export const netProps = z.object({
   name: z.string(),
   connectsTo: z.string().or(z.array(z.string())).optional(),
   highlightColor: z.string().optional(),
+  isPowerNet: z.boolean().optional(),
+  isGroundNet: z.boolean().optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -869,6 +869,8 @@ export interface NetProps {
   name: string
   connectsTo?: string | string[]
   highlightColor?: string
+  isPowerNet?: boolean
+  isGroundNet?: boolean
 }
 
 

--- a/lib/components/net.ts
+++ b/lib/components/net.ts
@@ -5,12 +5,16 @@ export interface NetProps {
   name: string
   connectsTo?: string | string[]
   highlightColor?: string
+  isPowerNet?: boolean
+  isGroundNet?: boolean
 }
 
 export const netProps = z.object({
   name: z.string(),
   connectsTo: z.string().or(z.array(z.string())).optional(),
   highlightColor: z.string().optional(),
+  isPowerNet: z.boolean().optional(),
+  isGroundNet: z.boolean().optional(),
 })
 
 type InferredNetProps = z.input<typeof netProps>


### PR DESCRIPTION
## Summary
- add optional `isPowerNet` and `isGroundNet` flags to the `<net />` props
- regenerate the docs to describe the new net properties

## Testing
- bunx tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_b_690405868b58832eaf461259627e7e00