### PR TITLE
feat: add minTraceWidth in group

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
 
   pcbWidth?: Distance;
   pcbHeight?: Distance;
+  minTraceWidth?: Distance;
   schWidth?: Distance;
   schHeight?: Distance;
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -875,6 +875,9 @@ export interface CopperPourProps {
   connectsTo: string
   padMargin?: Distance
   traceMargin?: Distance
+  clearance?: Distance
+  boardEdgeMargin?: Distance
+  coveredWithSolderMask?: boolean
 }
 export const copperPourProps = z.object({
   name: z.string().optional(),
@@ -882,6 +885,9 @@ export const copperPourProps = z.object({
   connectsTo: z.string(),
   padMargin: distance.optional(),
   traceMargin: distance.optional(),
+  clearance: distance.optional(),
+  boardEdgeMargin: distance.optional(),
+  coveredWithSolderMask: z.boolean().optional().default(true),
 })
 ```
 
@@ -1357,6 +1363,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
 
   pcbWidth?: Distance
   pcbHeight?: Distance
+  minTraceWidth?: Distance
   schWidth?: Distance
   schHeight?: Distance
 
@@ -1615,6 +1622,7 @@ export const baseGroupProps = commonLayoutProps.extend({
   schMatchAdapt: z.boolean().optional(),
   pcbWidth: length.optional(),
   pcbHeight: length.optional(),
+  minTraceWidth: length.optional(),
   schWidth: length.optional(),
   schHeight: length.optional(),
   pcbLayout: layoutConfig.optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -106,6 +106,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
 
   pcbWidth?: Distance
   pcbHeight?: Distance
+  minTraceWidth?: Distance
   schWidth?: Distance
   schHeight?: Distance
 
@@ -546,6 +547,9 @@ export interface CopperPourProps {
   connectsTo: string
   padMargin?: Distance
   traceMargin?: Distance
+  clearance?: Distance
+  boardEdgeMargin?: Distance
+  coveredWithSolderMask?: boolean
 }
 
 
@@ -1242,10 +1246,17 @@ export interface PlatformConfig {
 
   footprintLibraryMap?: Record<
     string,
-    | ((path: string) => Promise<FootprintLibraryResult>)
+    | ((
+        path: string,
+        options?: { resolvedPcbStyle?: PcbStyle },
+      ) => Promise<FootprintLibraryResult>)
     | Record<
         string,
-        any[] | ((path: string) => Promise<FootprintLibraryResult>)
+        | any[]
+        | ((
+            path: string,
+            options?: { resolvedPcbStyle?: PcbStyle },
+          ) => Promise<FootprintLibraryResult>)
       >
   >
 

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -196,6 +196,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
 
   pcbWidth?: Distance
   pcbHeight?: Distance
+  minTraceWidth?: Distance
   schWidth?: Distance
   schHeight?: Distance
 
@@ -525,6 +526,7 @@ export const baseGroupProps = commonLayoutProps.extend({
   schMatchAdapt: z.boolean().optional(),
   pcbWidth: length.optional(),
   pcbHeight: length.optional(),
+  minTraceWidth: length.optional(),
   schWidth: length.optional(),
   schHeight: length.optional(),
   pcbLayout: layoutConfig.optional(),


### PR DESCRIPTION
This pull request introduces support for a new optional property, `minTraceWidth`, across the codebase for group components. The changes update both the TypeScript interfaces and the associated schema validation to ensure consistency and proper type-checking.

Add support for `minTraceWidth` property:

**Type and Interface Updates**
* Added `minTraceWidth?: Distance` to the `BaseGroupProps` TypeScript interface in both `lib/components/group.ts` and the documentation in `README.md`, allowing group components to optionally specify a minimum trace width. [[1]](diffhunk://#diff-fb507e0fca2930b0b83ea9c3c84ba4a268007ca8b0e91651fb149ffd8c86b287R199) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R670)

**Schema Validation**
* Updated the `baseGroupProps` Zod schema to include an optional `minTraceWidth` property, ensuring that the new property is validated when present.

This would allow `<group minTraceWidth={0.3}>` syntax

Required for group-level trace width inheritance