### PR TITLE
Add schematicDisabled prop to board component

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ export interface BoardProps
   bottomSilkscreenColor?: BoardColor;
   /** Whether the board should be assembled on both sides */
   doubleSidedAssembly?: boolean;
+  /** Whether this board should be omitted from the schematic view */
+  schematicDisabled?: boolean;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -524,8 +524,9 @@ export interface BoardProps
   topSilkscreenColor?: BoardColor
   bottomSilkscreenColor?: BoardColor
   doubleSidedAssembly?: boolean
+  schematicDisabled?: boolean
 }
-/** Whether the board should be assembled on both sides */
+/** Whether this board should be omitted from the schematic view */
 export const boardProps = subcircuitGroupProps
   .omit({ connections: true })
   .extend({
@@ -543,6 +544,7 @@ export const boardProps = subcircuitGroupProps
     topSilkscreenColor: boardColor.optional(),
     bottomSilkscreenColor: boardColor.optional(),
     doubleSidedAssembly: z.boolean().optional().default(false),
+    schematicDisabled: z.boolean().optional(),
   })
 ```
 
@@ -877,6 +879,7 @@ export interface CopperPourProps {
   traceMargin?: Distance
   clearance?: Distance
   boardEdgeMargin?: Distance
+  cutoutMargin?: Distance
   coveredWithSolderMask?: boolean
 }
 export const copperPourProps = z.object({
@@ -887,6 +890,7 @@ export const copperPourProps = z.object({
   traceMargin: distance.optional(),
   clearance: distance.optional(),
   boardEdgeMargin: distance.optional(),
+  cutoutMargin: distance.optional(),
   coveredWithSolderMask: z.boolean().optional().default(true),
 })
 ```
@@ -1682,6 +1686,12 @@ export interface PillHoleProps extends PcbLayoutProps {
   width: Distance
   height: Distance
 }
+export interface RectHoleProps extends PcbLayoutProps {
+  name?: string
+  shape: "rect"
+  width: Distance
+  height: Distance
+}
 .extend({
     name: z.string().optional(),
     shape: z.literal("circle").optional(),
@@ -1691,6 +1701,12 @@ export interface PillHoleProps extends PcbLayoutProps {
 const pillHoleProps = pcbLayoutProps.extend({
   name: z.string().optional(),
   shape: z.literal("pill"),
+  width: distance,
+  height: distance,
+})
+const rectHoleProps = pcbLayoutProps.extend({
+  name: z.string().optional(),
+  shape: z.literal("rect"),
   width: distance,
   height: distance,
 })

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -233,6 +233,8 @@ export interface BoardProps
   bottomSilkscreenColor?: BoardColor
   /** Whether the board should be assembled on both sides */
   doubleSidedAssembly?: boolean
+  /** Whether this board should be omitted from the schematic view */
+  schematicDisabled?: boolean
 }
 
 
@@ -549,6 +551,7 @@ export interface CopperPourProps {
   traceMargin?: Distance
   clearance?: Distance
   boardEdgeMargin?: Distance
+  cutoutMargin?: Distance
   coveredWithSolderMask?: boolean
 }
 
@@ -1292,6 +1295,14 @@ export interface PotentiometerProps extends CommonComponentProps {
 
 export interface RectCutoutProps
   extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
+  name?: string
+  shape: "rect"
+  width: Distance
+  height: Distance
+}
+
+
+export interface RectHoleProps extends PcbLayoutProps {
   name?: string
   shape: "rect"
   width: Distance

--- a/lib/components/board.ts
+++ b/lib/components/board.ts
@@ -47,6 +47,8 @@ export interface BoardProps
   bottomSilkscreenColor?: BoardColor
   /** Whether the board should be assembled on both sides */
   doubleSidedAssembly?: boolean
+  /** Whether this board should be omitted from the schematic view */
+  schematicDisabled?: boolean
 }
 
 export const boardProps = subcircuitGroupProps
@@ -66,6 +68,7 @@ export const boardProps = subcircuitGroupProps
     topSilkscreenColor: boardColor.optional(),
     bottomSilkscreenColor: boardColor.optional(),
     doubleSidedAssembly: z.boolean().optional().default(false),
+    schematicDisabled: z.boolean().optional(),
   })
 
 type InferredBoardProps = z.input<typeof boardProps>

--- a/tests/board.test.ts
+++ b/tests/board.test.ts
@@ -64,3 +64,12 @@ test("should parse board color customization props", () => {
   expect(parsed.topSilkscreenColor).toBe("kicad:silkscreen_special")
   expect(parsed.bottomSilkscreenColor).toBe("ghost_white")
 })
+
+test("should parse schematicDisabled prop", () => {
+  const raw: BoardProps = {
+    name: "board",
+    schematicDisabled: true,
+  }
+  const parsed = boardProps.parse(raw)
+  expect(parsed.schematicDisabled).toBe(true)
+})


### PR DESCRIPTION
## Summary
- add the schematicDisabled flag to the <board /> props interface and schema
- regenerate documentation to surface the new board property
- extend the board unit tests to cover the new prop

## Testing
- bun test tests/board.test.ts
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69129a7d8960832eb95c84e908862ef7)