### PR TITLE
Add optional children prop to footprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ export interface FabricationNoteTextProps extends PcbLayoutProps {
 
 ```ts
 export interface FootprintProps {
+  children?: any;
   /**
    * The layer that the footprint is designed for. If you set this to "top"
    * then it means the children were intended to represent the top layer. If

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1167,6 +1167,7 @@ export const fabricationNoteTextProps = pcbLayoutProps.extend({
 
 ```typescript
 export interface FootprintProps {
+  children?: any
   originalLayer?: LayerRef
 }
 /**
@@ -1180,6 +1181,7 @@ export interface FootprintProps {
    * "top" and this is most intuitive.
    */
 export const footprintProps = z.object({
+  children: z.any().optional(),
   originalLayer: layer_ref.default("top").optional(),
 })
 ```

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -680,6 +680,7 @@ export interface FootprintLibraryResult {
 
 
 export interface FootprintProps {
+  children?: any
   /**
    * The layer that the footprint is designed for. If you set this to "top"
    * then it means the children were intended to represent the top layer. If

--- a/lib/components/footprint.ts
+++ b/lib/components/footprint.ts
@@ -3,6 +3,7 @@ import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
 export interface FootprintProps {
+  children?: any
   /**
    * The layer that the footprint is designed for. If you set this to "top"
    * then it means the children were intended to represent the top layer. If
@@ -17,6 +18,7 @@ export interface FootprintProps {
 }
 
 export const footprintProps = z.object({
+  children: z.any().optional(),
   originalLayer: layer_ref.default("top").optional(),
 })
 


### PR DESCRIPTION
## Summary
- add an optional `children` property to the footprint component props interface and schema
- regenerate generated documentation to reflect the new property

## Testing
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6912c0235684832eb9554aed4eeef934)