### PR TITLE
Add circuitJson prop to footprint component

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,10 @@ export interface FootprintProps {
    * "top" and this is most intuitive.
    */
   originalLayer?: LayerRef;
+  /**
+   * Serialized circuit JSON describing a precompiled footprint
+   */
+  circuitJson?: any[];
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1169,20 +1169,15 @@ export const fabricationNoteTextProps = pcbLayoutProps.extend({
 export interface FootprintProps {
   children?: any
   originalLayer?: LayerRef
+  circuitJson?: any[]
 }
 /**
-   * The layer that the footprint is designed for. If you set this to "top"
-   * then it means the children were intended to represent the top layer. If
-   * the <chip /> with this footprint is moved to the bottom layer, then the
-   * components will be mirrored.
-   *
-   * Generally, you shouldn't set this except where it can help prevent
-   * confusion because you have a complex multi-layer footprint. Default is
-   * "top" and this is most intuitive.
+   * Serialized circuit JSON describing a precompiled footprint
    */
 export const footprintProps = z.object({
   children: z.any().optional(),
   originalLayer: layer_ref.default("top").optional(),
+  circuitJson: z.array(z.any()).optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -692,6 +692,10 @@ export interface FootprintProps {
    * "top" and this is most intuitive.
    */
   originalLayer?: LayerRef
+  /**
+   * Serialized circuit JSON describing a precompiled footprint
+   */
+  circuitJson?: any[]
 }
 
 

--- a/lib/components/footprint.ts
+++ b/lib/components/footprint.ts
@@ -15,11 +15,16 @@ export interface FootprintProps {
    * "top" and this is most intuitive.
    */
   originalLayer?: LayerRef
+  /**
+   * Serialized circuit JSON describing a precompiled footprint
+   */
+  circuitJson?: any[]
 }
 
 export const footprintProps = z.object({
   children: z.any().optional(),
   originalLayer: layer_ref.default("top").optional(),
+  circuitJson: z.array(z.any()).optional(),
 })
 
 export type FootprintPropsInput = z.input<typeof footprintProps>


### PR DESCRIPTION
## Summary
- add an optional `circuitJson` property to the `<footprint />` component API and schema
- regenerate the docs to describe the new footprint property

## Testing
- bunx tsc --noEmit


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691565b06550832e88049c3e55ce7acf)