### PR TITLE
Add noConnect to chip props

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,11 @@ export interface ChipPropsSU<
   noSchematicRepresentation?: boolean;
   internallyConnectedPins?: (string | number)[][];
   externallyConnectedPins?: string[][];
+  /**
+   * Pins intentionally left unconnected. This is a shorthand for marking
+   * those pins as do-not-connect without repeating pinAttributes entries.
+   */
+  noConnect?: readonly PinLabel[] | PinLabel[];
   connections?: Connections<PinLabel>;
 }
 ```

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1097,6 +1097,7 @@ export interface ChipPropsSU<
   noSchematicRepresentation?: boolean
   internallyConnectedPins?: (string | number)[][]
   externallyConnectedPins?: string[][]
+  noConnect?: readonly PinLabel[] | PinLabel[]
   connections?: Connections<PinLabel>
 }
 /**
@@ -1137,6 +1138,7 @@ export const chipProps = commonComponentProps.extend({
   schWidth: distance.optional(),
   schHeight: distance.optional(),
   noSchematicRepresentation: z.boolean().optional(),
+  noConnect: noConnectProp.optional(),
   connections: connectionsProp.optional(),
 })
 ```

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -400,6 +400,11 @@ export interface ChipPropsSU<
   noSchematicRepresentation?: boolean
   internallyConnectedPins?: (string | number)[][]
   externallyConnectedPins?: string[][]
+  /**
+   * Pins intentionally left unconnected. This is a shorthand for marking
+   * those pins as do-not-connect without repeating pinAttributes entries.
+   */
+  noConnect?: readonly PinLabel[] | PinLabel[]
   connections?: Connections<PinLabel>
 }
 

--- a/lib/components/chip.ts
+++ b/lib/components/chip.ts
@@ -60,6 +60,11 @@ export interface ChipPropsSU<
   noSchematicRepresentation?: boolean
   internallyConnectedPins?: (string | number)[][]
   externallyConnectedPins?: string[][]
+  /**
+   * Pins intentionally left unconnected. This is a shorthand for marking
+   * those pins as do-not-connect without repeating pinAttributes entries.
+   */
+  noConnect?: readonly PinLabel[] | PinLabel[]
   connections?: Connections<PinLabel>
 }
 
@@ -115,6 +120,11 @@ const connectionTarget = z
   .or(z.array(z.string()).readonly())
   .or(z.array(z.string()))
 
+const noConnectProp = z
+  .array(schematicPinLabel)
+  .readonly()
+  .or(z.array(schematicPinLabel))
+
 const connectionsProp = z
   .custom<Connections>()
   .pipe(z.record(z.string(), connectionTarget))
@@ -150,6 +160,7 @@ export const chipProps = commonComponentProps.extend({
   schWidth: distance.optional(),
   schHeight: distance.optional(),
   noSchematicRepresentation: z.boolean().optional(),
+  noConnect: noConnectProp.optional(),
   connections: connectionsProp.optional(),
 })
 

--- a/tests/chip1-basic.test.ts
+++ b/tests/chip1-basic.test.ts
@@ -92,6 +92,18 @@ test("should parse chip props with mixed string and array connections", () => {
   })
 })
 
+test("should parse chip props with noConnect pins", () => {
+  const rawProps: ChipProps = {
+    name: "chip",
+    manufacturerPartNumber: "1234",
+    noConnect: ["GPIO5", "pin2"],
+  }
+
+  const parsedProps = chipProps.parse(rawProps)
+
+  expect(parsedProps.noConnect).toEqual(["GPIO5", "pin2"])
+})
+
 test("should parse chip props with connections and other properties", () => {
   const rawProps: ChipProps = {
     name: "chip",
@@ -161,6 +173,7 @@ test("should work with generic type parameter for pin labels", () => {
       pin3: "SIG1",
       pin4: "SIG2",
     },
+    noConnect: ["SIG2"],
     connections: {
       VCC: "net.VCC",
       GND: "net.GND",
@@ -176,4 +189,5 @@ test("should work with generic type parameter for pin labels", () => {
     SIG1: ".R1 > .pin1",
     SIG2: [".LED1 > .anode", ".C1 > .pin1"],
   })
+  expect(parsedProps.noConnect).toEqual(["SIG2"])
 })

--- a/tests/chip3-type-tests.test.tsx
+++ b/tests/chip3-type-tests.test.tsx
@@ -197,3 +197,31 @@ test("[typetest] connections can reference pin numbers", () => {
   void byNumber
   void invalid
 })
+
+test("[typetest] noConnect matches chip pin labels", () => {
+  const myPinLabels = {
+    pin1: "A",
+    pin2: "B",
+  } as const
+
+  const MyChip = (props: ChipProps<typeof myPinLabels>) => <chip {...props} />
+
+  const byLabel = <MyChip name="U1" pinLabels={myPinLabels} noConnect={["A"]} />
+  const byNumber = (
+    <MyChip name="U1" pinLabels={myPinLabels} noConnect={["pin2"]} />
+  )
+  const invalid = (
+    <MyChip
+      name="U1"
+      pinLabels={myPinLabels}
+      noConnect={[
+        // @ts-expect-error
+        "INVALID_PIN",
+      ]}
+    />
+  )
+
+  void byLabel
+  void byNumber
+  void invalid
+})


### PR DESCRIPTION
## Summary
- Add a shared `noConnect` prop to `ChipPropsSU` and the `chipProps` zod schema.
- Type it against chip pin labels so callers can mark intentionally unconnected pins directly.
- Update generated README and prop docs to reflect the new API.

## Testing
- `bun test tests/chip1-basic.test.ts tests/chip3-type-tests.test.tsx`
- `bunx tsc --noEmit`
- Ran the required generation scripts for component types, manual-edits docs, README docs, and props overview