### PR TITLE
Add minViaDiameter and minViaHole board props

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ export interface BoardProps extends Omit<
   layers?: 1 | 2 | 4 | 6 | 8;
   borderRadius?: Distance;
   thickness?: Distance;
+  minViaDiameter?: Distance;
+  minViaHole?: Distance;
   boardAnchorPosition?: Point;
   anchorAlignment?: z.infer<typeof ninePointAnchor>;
   boardAnchorAlignment?: z.infer<typeof ninePointAnchor>;

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -906,6 +906,8 @@ export interface BoardProps
   layers?: 1 | 2 | 4 | 6 | 8
   borderRadius?: Distance
   thickness?: Distance
+  minViaDiameter?: Distance
+  minViaHole?: Distance
   boardAnchorPosition?: Point
   anchorAlignment?: z.infer<typeof ninePointAnchor>
   boardAnchorAlignment?: z.infer<typeof ninePointAnchor>
@@ -934,6 +936,8 @@ export const boardProps = subcircuitGroupProps
       .default(2),
     borderRadius: distance.optional(),
     thickness: distance.optional(),
+    minViaDiameter: distance.optional(),
+    minViaHole: distance.optional(),
     boardAnchorPosition: point.optional(),
     anchorAlignment: ninePointAnchor.optional(),
     boardAnchorAlignment: ninePointAnchor
@@ -3975,3 +3979,4 @@ export const voltageSourceProps = commonComponentProps.extend({
   connections: createConnectionsProp(voltageSourcePinLabels).optional(),
 })
 ```
+

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -222,6 +222,8 @@ export interface BoardProps
   layers?: 1 | 2 | 4 | 6 | 8
   borderRadius?: Distance
   thickness?: Distance
+  minViaDiameter?: Distance
+  minViaHole?: Distance
   boardAnchorPosition?: Point
   anchorAlignment?: z.infer<typeof ninePointAnchor>
   boardAnchorAlignment?: z.infer<typeof ninePointAnchor>

--- a/lib/components/board.ts
+++ b/lib/components/board.ts
@@ -31,6 +31,8 @@ export interface BoardProps
   layers?: 1 | 2 | 4 | 6 | 8
   borderRadius?: Distance
   thickness?: Distance
+  minViaDiameter?: Distance
+  minViaHole?: Distance
   boardAnchorPosition?: Point
   anchorAlignment?: z.infer<typeof ninePointAnchor>
   boardAnchorAlignment?: z.infer<typeof ninePointAnchor>
@@ -67,6 +69,8 @@ export const boardProps = subcircuitGroupProps
       .default(2),
     borderRadius: distance.optional(),
     thickness: distance.optional(),
+    minViaDiameter: distance.optional(),
+    minViaHole: distance.optional(),
     boardAnchorPosition: point.optional(),
     anchorAlignment: ninePointAnchor.optional(),
     boardAnchorAlignment: ninePointAnchor

--- a/tests/board.test.ts
+++ b/tests/board.test.ts
@@ -42,6 +42,17 @@ test("should parse borderRadius prop", () => {
   expect(parsed.borderRadius).toBe(2)
 })
 
+test("should parse min via constraints", () => {
+  const raw: BoardProps = {
+    name: "board",
+    minViaDiameter: "0.6mm",
+    minViaHole: "0.3mm",
+  }
+  const parsed = boardProps.parse(raw)
+  expect(parsed.minViaDiameter).toBe(0.6)
+  expect(parsed.minViaHole).toBe(0.3)
+})
+
 test("should parse boardAnchorPosition prop", () => {
   const raw: BoardProps = {
     name: "board",


### PR DESCRIPTION
This change adds support for minViaDiameter and minViaHole on <board />, so board-level via constraints can be passed directly in props and parsed through the existing distance schema.
