### PR TITLE
Add start/end aliases for trace endpoints

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -3862,7 +3862,7 @@ export const traceHintProps = z.object({
 ```typescript
 export const portRef = z.union([
   z.string(),
-  z.custom<{ getPortSelector: () => string }>((v) =>
+  z.custom<{ getPortSelector: () => string }>(
 .extend({
     via: z.boolean().optional(),
     fromLayer: layer_ref.optional(),
@@ -3874,6 +3874,10 @@ baseTraceProps.extend({
 baseTraceProps.extend({
     from: portRef,
     to: portRef,
+  }),
+baseTraceProps.extend({
+    start: portRef,
+    end: portRef,
   }),
 ```
 
@@ -3975,3 +3979,4 @@ export const voltageSourceProps = commonComponentProps.extend({
   connections: createConnectionsProp(voltageSourcePinLabels).optional(),
 })
 ```
+

--- a/lib/components/trace.ts
+++ b/lib/components/trace.ts
@@ -4,8 +4,12 @@ import { point } from "../common/point"
 
 export const portRef = z.union([
   z.string(),
-  z.custom<{ getPortSelector: () => string }>((v) =>
-    Boolean(v.getPortSelector),
+  z.custom<{ getPortSelector: () => string }>(
+    (v) =>
+      typeof v === "object" &&
+      v !== null &&
+      "getPortSelector" in v &&
+      typeof v.getPortSelector === "function",
   ),
 ])
 
@@ -63,6 +67,10 @@ export const traceProps = z.union([
   baseTraceProps.extend({
     from: portRef,
     to: portRef,
+  }),
+  baseTraceProps.extend({
+    start: portRef,
+    end: portRef,
   }),
 ])
 

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -88,3 +88,17 @@ test("supports pcbStraightLine flag", () => {
 
   expect(parsed.pcbStraightLine).toBe(true)
 })
+
+test("accepts start/end aliases for trace endpoints", () => {
+  const raw: TraceProps = {
+    start: "A",
+    end: "B",
+  }
+
+  const parsed = traceProps.parse(raw)
+
+  expect(parsed).toMatchObject({
+    start: "A",
+    end: "B",
+  })
+})


### PR DESCRIPTION
### Motivation
- Allow `start`/`end` as ergonomic aliases for trace endpoints in addition to existing `from`/`to` forms so callers can use either naming style.
- Prevent a runtime error when validating `portRef` values that are non-object by making the custom validator robust to non-object inputs.
- Keep generated docs in sync with source schema changes.

### Description
- Add a third variant to `traceProps` that accepts `start: portRef` and `end: portRef` alongside the existing `path` and `from`/`to` variants in `lib/components/trace.ts`.
- Harden the `portRef` `z.custom(...)` validator to check that the value is a non-null object and that `getPortSelector` is a function before accepting it.
- Add a unit test `tests/trace.test.ts` that verifies parsing of `start`/`end` aliases.
- Regenerate component type documentation (`generated/COMPONENT_TYPES.md`) and run code formatting to keep generated artifacts up to date.

### Testing
- Ran `bun test tests/trace.test.ts` and all tests passed.
- Ran `bunx tsc --noEmit` for type checking and it succeeded.
- Ran generation scripts `bun scripts/generate-component-types.ts`, `bun scripts/generate-manual-edits-docs.ts`, `bun scripts/generate-readme-docs.ts`, and `bun scripts/generate-props-overview.ts` and they completed successfully.
- Ran `bun run format` to format files successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e41b97a0c0832e9628f804d6d5aa2e)