### PR TITLE
Add `kicad_routing_tools` autorouter preset

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1955,6 +1955,7 @@ export interface AutorouterConfig {
     | "auto_local"
     | "auto_cloud"
     | "auto_jumper"
+    | "kicad_routing_tools"
     | "tscircuit_beta"
     | "freerouting"
     | "laser_prefab" // Prefabricated PCB with laser copper ablation
@@ -1987,6 +1988,7 @@ export const autorouterConfig = z.object({
       "auto_local",
       "auto_cloud",
       "auto_jumper",
+      "kicad_routing_tools",
       "tscircuit_beta",
       "freerouting",
       "laser_prefab",
@@ -3975,3 +3977,4 @@ export const voltageSourceProps = commonComponentProps.extend({
   connections: createConnectionsProp(voltageSourcePinLabels).optional(),
 })
 ```
+

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -47,6 +47,7 @@ export interface AutorouterConfig {
     | "auto_local"
     | "auto_cloud"
     | "auto_jumper"
+    | "kicad_routing_tools"
     | "tscircuit_beta"
     | "freerouting"
     | "laser_prefab" // Prefabricated PCB with laser copper ablation

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -330,6 +330,7 @@ export interface AutorouterConfig {
     | "auto_local"
     | "auto_cloud"
     | "auto_jumper"
+    | "kicad_routing_tools"
     | "tscircuit_beta"
     | "freerouting"
     | "laser_prefab" // Prefabricated PCB with laser copper ablation
@@ -346,6 +347,7 @@ export type AutorouterPreset =
   | "auto_local"
   | "auto_cloud"
   | "auto_jumper"
+  | "kicad_routing_tools"
   | "tscircuit_beta"
   | "freerouting"
   | "laser_prefab"
@@ -386,6 +388,7 @@ export const autorouterConfig = z.object({
       "auto_local",
       "auto_cloud",
       "auto_jumper",
+      "kicad_routing_tools",
       "tscircuit_beta",
       "freerouting",
       "laser_prefab",
@@ -405,6 +408,7 @@ export const autorouterPreset = z.union([
   z.literal("auto_local"),
   z.literal("auto_cloud"),
   z.literal("auto_jumper"),
+  z.literal("kicad_routing_tools"),
   z.literal("tscircuit_beta"),
   z.literal("freerouting"),
   z.literal("laser_prefab"), // Prefabricated PCB with laser copper ablation

--- a/tests/autorouter.test.ts
+++ b/tests/autorouter.test.ts
@@ -19,6 +19,11 @@ test("supports auto jumper preset", () => {
   expect(result).toBe("auto_jumper")
 })
 
+test("supports kicad routing tools preset", () => {
+  const result = autorouterProp.parse("kicad_routing_tools")
+  expect(result).toBe("kicad_routing_tools")
+})
+
 test("supports laser prefab preset", () => {
   const result = autorouterProp.parse("laser_prefab")
   expect(result).toBe("laser_prefab")


### PR DESCRIPTION
### Motivation
- Expose a new autorouter preset `kicad_routing_tools` so configs and props can explicitly request KiCad routing tools as an autorouter backend and be validated by the type system and runtime zod validators.

### Description
- Added `"kicad_routing_tools"` to the `preset` union on `AutorouterConfig`, the `AutorouterPreset` type, and the zod `preset` enum and `autorouterPreset` literal list in `lib/components/group.ts`.
- Added a unit test `supports kicad routing tools preset` to `tests/autorouter.test.ts` that verifies `autorouterProp.parse("kicad_routing_tools")` succeeds.
- Regenerated documentation artifacts (`generated/COMPONENT_TYPES.md`, `generated/PROPS_OVERVIEW.md`) and ran formatting to keep generated files in sync.

### Testing
- Ran `bun test tests/autorouter.test.ts` and all tests passed (9 passed, 0 failed).
- Ran `bunx tsc --noEmit` and the TypeScript typecheck completed successfully.
- Ran the generation scripts `bun scripts/generate-component-types.ts`, `bun scripts/generate-manual-edits-docs.ts`, `bun scripts/generate-readme-docs.ts`, and `bun scripts/generate-props-overview.ts` which completed without error.
- Ran `bun run format` to apply formatting to the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e41beca544832eaec9e0b911bee285)