### PR TITLE
Rename subcircuit spacing props to clearance and add board edge clearance

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2010,7 +2010,15 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
   routingDisabled?: boolean
   bomDisabled?: boolean
   defaultTraceWidth?: Distance
+
   minTraceWidth?: Distance
+  minViaToViaClearance?: Distance
+  minTraceToPadClearance?: Distance
+  minPadToPadClearance?: Distance
+  minBoardEdgeClearance?: Distance
+  minViaHoleDiameter?: Distance
+  minViaPadDiameter?: Distance
+
   nominalTraceWidth?: Distance
   pcbRouteCache?: PcbRouteCache
 
@@ -2151,6 +2159,12 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   bomDisabled: z.boolean().optional(),
   defaultTraceWidth: length.optional(),
   minTraceWidth: length.optional(),
+  minViaToViaClearance: length.optional(),
+  minTraceToPadClearance: length.optional(),
+  minPadToPadClearance: length.optional(),
+  minBoardEdgeClearance: length.optional(),
+  minViaHoleDiameter: length.optional(),
+  minViaPadDiameter: length.optional(),
   nominalTraceWidth: length.optional(),
   partsEngine: partsEngine.optional(),
   _subcircuitCachingEnabled: z.boolean().optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1939,7 +1939,15 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
   routingDisabled?: boolean
   bomDisabled?: boolean
   defaultTraceWidth?: Distance
+
   minTraceWidth?: Distance
+  minViaToViaClearance?: Distance
+  minTraceToPadClearance?: Distance
+  minPadToPadClearance?: Distance
+  minBoardEdgeClearance?: Distance
+  minViaHoleDiameter?: Distance
+  minViaPadDiameter?: Distance
+
   nominalTraceWidth?: Distance
   pcbRouteCache?: PcbRouteCache
 

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -433,9 +433,10 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
   defaultTraceWidth?: Distance
 
   minTraceWidth?: Distance
-  minViaToViaSpacing?: Distance
-  minTraceToPadSpacing?: Distance
-  minPadToPadSpacing?: Distance
+  minViaToViaClearance?: Distance
+  minTraceToPadClearance?: Distance
+  minPadToPadClearance?: Distance
+  minBoardEdgeClearance?: Distance
   minViaHoleDiameter?: Distance
   minViaPadDiameter?: Distance
 
@@ -601,9 +602,10 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   bomDisabled: z.boolean().optional(),
   defaultTraceWidth: length.optional(),
   minTraceWidth: length.optional(),
-  minViaToViaSpacing: length.optional(),
-  minTraceToPadSpacing: length.optional(),
-  minPadToPadSpacing: length.optional(),
+  minViaToViaClearance: length.optional(),
+  minTraceToPadClearance: length.optional(),
+  minPadToPadClearance: length.optional(),
+  minBoardEdgeClearance: length.optional(),
   minViaHoleDiameter: length.optional(),
   minViaPadDiameter: length.optional(),
   nominalTraceWidth: length.optional(),


### PR DESCRIPTION
### Motivation
- Clarify naming for PCB spacing-related properties by using `*Clearance` instead of `*Spacing` and allow explicit control of clearance to board edge.

### Description
- Renamed props on `SubcircuitGroupProps` in `lib/components/group.ts`: `minViaToViaSpacing` -> `minViaToViaClearance`, `minTraceToPadSpacing` -> `minTraceToPadClearance`, and `minPadToPadSpacing` -> `minPadToPadClearance`.
- Added new prop `minBoardEdgeClearance` to the `SubcircuitGroupProps` TypeScript interface and to the `subcircuitGroupProps` Zod schema.
- Regenerated documentation/type artifacts so the changes are reflected in `generated/COMPONENT_TYPES.md` and `generated/PROPS_OVERVIEW.md`.

### Testing
- Ran the repository generation scripts successfully: `bun scripts/generate-component-types.ts`, `bun scripts/generate-manual-edits-docs.ts`, `bun scripts/generate-readme-docs.ts`, and `bun scripts/generate-props-overview.ts` (all succeeded).
- Verified updated artifacts are present and committed (`lib/components/group.ts`, `generated/COMPONENT_TYPES.md`, `generated/PROPS_OVERVIEW.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e7bb90283c832788b62e962c2912d1)