### PR TITLE
Rename SubcircuitGroupProps manufacturing DRC fields to updated camelCase names

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2012,9 +2012,10 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
   defaultTraceWidth?: Distance
 
   minTraceWidth?: Distance
-  minViaToViaClearance?: Distance
-  minTraceToPadClearance?: Distance
-  minPadToPadClearance?: Distance
+  minViaHoleEdgeToViaHoleEdgeClearance?: Distance
+  minPlatedHoleDrillEdgeToDrillEdgeClearance?: Distance
+  minTraceToPadEdgeClearance?: Distance
+  minPadEdgeToPadEdgeClearance?: Distance
   minBoardEdgeClearance?: Distance
   minViaHoleDiameter?: Distance
   minViaPadDiameter?: Distance
@@ -2159,9 +2160,10 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   bomDisabled: z.boolean().optional(),
   defaultTraceWidth: length.optional(),
   minTraceWidth: length.optional(),
-  minViaToViaClearance: length.optional(),
-  minTraceToPadClearance: length.optional(),
-  minPadToPadClearance: length.optional(),
+  minViaHoleEdgeToViaHoleEdgeClearance: length.optional(),
+  minPlatedHoleDrillEdgeToDrillEdgeClearance: length.optional(),
+  minTraceToPadEdgeClearance: length.optional(),
+  minPadEdgeToPadEdgeClearance: length.optional(),
   minBoardEdgeClearance: length.optional(),
   minViaHoleDiameter: length.optional(),
   minViaPadDiameter: length.optional(),
@@ -2936,6 +2938,7 @@ export interface PillWithRectPadPlatedHoleProps
   portHints?: PortHints
   holeOffsetX?: number | string
   holeOffsetY?: number | string
+  rectBorderRadius?: number | string
   solderMaskMargin?: Distance
   coveredWithSolderMask?: boolean
 }
@@ -3075,6 +3078,7 @@ pcbLayoutProps.omit({ layer: true }).extend({
       holeHeight: distance,
       rectPadWidth: distance,
       rectPadHeight: distance,
+      rectBorderRadius: distance.optional(),
       portHints: portHints.optional(),
       holeOffsetX: distance.optional(),
       holeOffsetY: distance.optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1427,6 +1427,7 @@ export interface PillWithRectPadPlatedHoleProps
   portHints?: PortHints
   holeOffsetX?: number | string
   holeOffsetY?: number | string
+  rectBorderRadius?: number | string
   solderMaskMargin?: Distance
   coveredWithSolderMask?: boolean
 }
@@ -1941,9 +1942,10 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
   defaultTraceWidth?: Distance
 
   minTraceWidth?: Distance
-  minViaToViaClearance?: Distance
-  minTraceToPadClearance?: Distance
-  minPadToPadClearance?: Distance
+  minViaHoleEdgeToViaHoleEdgeClearance?: Distance
+  minPlatedHoleDrillEdgeToDrillEdgeClearance?: Distance
+  minTraceToPadEdgeClearance?: Distance
+  minPadEdgeToPadEdgeClearance?: Distance
   minBoardEdgeClearance?: Distance
   minViaHoleDiameter?: Distance
   minViaPadDiameter?: Distance

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -433,9 +433,10 @@ export interface SubcircuitGroupProps extends BaseGroupProps {
   defaultTraceWidth?: Distance
 
   minTraceWidth?: Distance
-  minViaToViaClearance?: Distance
-  minTraceToPadClearance?: Distance
-  minPadToPadClearance?: Distance
+  minViaHoleEdgeToViaHoleEdgeClearance?: Distance
+  minPlatedHoleDrillEdgeToDrillEdgeClearance?: Distance
+  minTraceToPadEdgeClearance?: Distance
+  minPadEdgeToPadEdgeClearance?: Distance
   minBoardEdgeClearance?: Distance
   minViaHoleDiameter?: Distance
   minViaPadDiameter?: Distance
@@ -602,9 +603,10 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   bomDisabled: z.boolean().optional(),
   defaultTraceWidth: length.optional(),
   minTraceWidth: length.optional(),
-  minViaToViaClearance: length.optional(),
-  minTraceToPadClearance: length.optional(),
-  minPadToPadClearance: length.optional(),
+  minViaHoleEdgeToViaHoleEdgeClearance: length.optional(),
+  minPlatedHoleDrillEdgeToDrillEdgeClearance: length.optional(),
+  minTraceToPadEdgeClearance: length.optional(),
+  minPadEdgeToPadEdgeClearance: length.optional(),
   minBoardEdgeClearance: length.optional(),
   minViaHoleDiameter: length.optional(),
   minViaPadDiameter: length.optional(),


### PR DESCRIPTION
### Motivation
- The manufacturing DRC-related prop names on `SubcircuitGroupProps` were updated and needed to be reflected in the codebase using consistent camelCase naming.
- Runtime validation and generated documentation must match the new property names to avoid consumer/CI breakage.

### Description
- Renamed the DRC-related props on the `SubcircuitGroupProps` TypeScript interface in `lib/components/group.ts` to `minViaHoleEdgeToViaHoleEdgeClearance`, `minPlatedHoleDrillEdgeToDrillEdgeClearance`, `minTraceToPadEdgeClearance`, and `minPadEdgeToPadEdgeClearance` while keeping other existing fields unchanged.
- Updated the `subcircuitGroupProps` Zod schema in `lib/components/group.ts` to use the same renamed keys for runtime validation.
- Regenerated the derived documentation files so generated artifacts reflect the change, updating `generated/COMPONENT_TYPES.md` and `generated/PROPS_OVERVIEW.md` accordingly.

### Testing
- Ran the required generation scripts: `bun scripts/generate-component-types.ts`, `bun scripts/generate-manual-edits-docs.ts`, `bun scripts/generate-readme-docs.ts`, and `bun scripts/generate-props-overview.ts`, which completed successfully.
- Ran the focused test suite `bun test tests/group.test.ts`, which passed (16 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea5442fb6883278a7bdece228bfa2e)