### PR TITLE
Add "flex" as a supported board material

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ export interface BoardProps extends Omit<
   "subcircuit" | "connections"
 > {
   title?: string;
-  material?: "fr4" | "fr1";
+  material?: "fr4" | "fr1" | "flex";
   /** Number of layers for the PCB */
   layers?: 1 | 2 | 4 | 6 | 8;
   borderRadius?: Distance;
@@ -746,7 +746,6 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
   schPinArrangement?: SchematicPinArrangement;
 
   /**
-   * @deprecated Use schPinStyle instead.
    * Spacing between pins when rendered as a schematic box
    */
   schPinSpacing?: Distance;
@@ -907,7 +906,6 @@ export interface JumperProps extends CommonComponentProps {
     SchematicPinLabel | SchematicPinLabel[]
   >;
   schPinStyle?: SchematicPinStyle;
-  /** @deprecated Use schPinStyle instead. */
   schPinSpacing?: number | string;
   schWidth?: number | string;
   schHeight?: number | string;
@@ -1287,7 +1285,6 @@ export interface PinHeaderProps extends CommonComponentProps {
   schPinStyle?: SchematicPinStyle;
 
   /**
-   * @deprecated Use schPinStyle instead.
    * Schematic pin spacing
    */
   schPinSpacing?: number | string;

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -902,7 +902,7 @@ export const batteryProps = commonComponentProps.extend({
 export interface BoardProps
   extends Omit<SubcircuitGroupProps, "subcircuit" | "connections"> {
   title?: string
-  material?: "fr4" | "fr1"
+  material?: "fr4" | "fr1" | "flex"
   layers?: 1 | 2 | 4 | 6 | 8
   borderRadius?: Distance
   thickness?: Distance
@@ -922,7 +922,7 @@ export interface BoardProps
 export const boardProps = subcircuitGroupProps
   .omit({ connections: true })
   .extend({
-    material: z.enum(["fr4", "fr1"]).default("fr4"),
+    material: z.enum(["fr4", "fr1", "flex"]).default("fr4"),
     layers: z
       .union([
         z.literal(1),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -217,7 +217,7 @@ export interface BatteryProps<PinLabel extends string = string>
 export interface BoardProps
   extends Omit<SubcircuitGroupProps, "subcircuit" | "connections"> {
   title?: string
-  material?: "fr4" | "fr1"
+  material?: "fr4" | "fr1" | "flex"
   /** Number of layers for the PCB */
   layers?: 1 | 2 | 4 | 6 | 8
   borderRadius?: Distance
@@ -394,6 +394,7 @@ export interface ChipPropsSU<
   schPortArrangement?: SchematicPortArrangement
   pinCompatibleVariants?: PinCompatibleVariant[]
   schPinStyle?: SchematicPinStyle
+  /** @deprecated Use schPinStyle instead. */
   schPinSpacing?: Distance
   schWidth?: Distance
   schHeight?: Distance

--- a/lib/components/board.ts
+++ b/lib/components/board.ts
@@ -26,7 +26,7 @@ const boardColor = z.custom<BoardColor>((value) => typeof value === "string")
 export interface BoardProps
   extends Omit<SubcircuitGroupProps, "subcircuit" | "connections"> {
   title?: string
-  material?: "fr4" | "fr1"
+  material?: "fr4" | "fr1" | "flex"
   /** Number of layers for the PCB */
   layers?: 1 | 2 | 4 | 6 | 8
   borderRadius?: Distance
@@ -55,7 +55,7 @@ export interface BoardProps
 export const boardProps = subcircuitGroupProps
   .omit({ connections: true })
   .extend({
-    material: z.enum(["fr4", "fr1"]).default("fr4"),
+    material: z.enum(["fr4", "fr1", "flex"]).default("fr4"),
     layers: z
       .union([
         z.literal(1),

--- a/tests/board.test.ts
+++ b/tests/board.test.ts
@@ -36,6 +36,12 @@ test("should allow 6 and 8 layer boards", () => {
   expect(boardProps.parse(eightLayer).layers).toBe(8)
 })
 
+test("should parse flex board material", () => {
+  const raw: BoardProps = { name: "board", material: "flex" }
+  const parsed = boardProps.parse(raw)
+  expect(parsed.material).toBe("flex")
+})
+
 test("should parse borderRadius prop", () => {
   const raw: BoardProps = { name: "board", borderRadius: 2 }
   const parsed = boardProps.parse(raw)


### PR DESCRIPTION
### Motivation

- Add support for flexible PCBs by allowing "flex" as a board material option so consumers can specify flexible board types in props.

### Description

- Add `"flex"` to the `BoardProps.material` TypeScript type and to the `boardProps` Zod enum in `lib/components/board.ts` while keeping the default as `"fr4"`.
- Regenerate documentation artifacts so `generated/COMPONENT_TYPES.md`, `generated/PROPS_OVERVIEW.md`, and `README.md` reflect the new `"flex"` option.
- Add a unit test in `tests/board.test.ts` that validates parsing `material: "flex"` with `boardProps`.

### Testing

- Ran the generation scripts `bun scripts/generate-component-types.ts`, `bun scripts/generate-manual-edits-docs.ts`, `bun scripts/generate-readme-docs.ts`, and `bun scripts/generate-props-overview.ts`, each completed successfully.
- Ran unit tests with `bun test tests/board.test.ts`, which passed (12 tests, 0 failures).
- Ran type checking with `bunx tsc --noEmit` and formatting with `bun run format`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f67a90d358832e94b91f629455793f)