### PR TITLE
Deprecate schPinSpacing in favor of schPinStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
 
   /**
    * Spacing between pins when rendered as a schematic box
+   * @deprecated Use schPinStyle instead.
    */
   schPinSpacing?: Distance;
 
@@ -906,6 +907,7 @@ export interface JumperProps extends CommonComponentProps {
     SchematicPinLabel | SchematicPinLabel[]
   >;
   schPinStyle?: SchematicPinStyle;
+  /** @deprecated Use schPinStyle instead. */
   schPinSpacing?: number | string;
   schWidth?: number | string;
   schHeight?: number | string;
@@ -1286,6 +1288,7 @@ export interface PinHeaderProps extends CommonComponentProps {
 
   /**
    * Schematic pin spacing
+   * @deprecated Use schPinStyle instead.
    */
   schPinSpacing?: number | string;
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -100,6 +100,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
 
   /**
    * Spacing between pins when rendered as a schematic box
+   * @deprecated Use schPinStyle instead.
    */
   schPinSpacing?: Distance
 
@@ -853,6 +854,7 @@ export interface JumperProps extends CommonComponentProps {
     SchematicPinLabel | SchematicPinLabel[]
   >
   schPinStyle?: SchematicPinStyle
+  /** @deprecated Use schPinStyle instead. */
   schPinSpacing?: number | string
   schWidth?: number | string
   schHeight?: number | string
@@ -1553,6 +1555,7 @@ export interface PinHeaderProps extends CommonComponentProps {
 
   /**
    * Schematic pin spacing
+   * @deprecated Use schPinStyle instead.
    */
   schPinSpacing?: number | string
 

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -192,6 +192,7 @@ export interface BaseGroupProps extends CommonLayoutProps, LayoutConfig {
 
   /**
    * Spacing between pins when rendered as a schematic box
+   * @deprecated Use schPinStyle instead.
    */
   schPinSpacing?: Distance
 

--- a/lib/components/jumper.ts
+++ b/lib/components/jumper.ts
@@ -28,6 +28,7 @@ export interface JumperProps extends CommonComponentProps {
     SchematicPinLabel | SchematicPinLabel[]
   >
   schPinStyle?: SchematicPinStyle
+  /** @deprecated Use schPinStyle instead. */
   schPinSpacing?: number | string
   schWidth?: number | string
   schHeight?: number | string

--- a/lib/components/pin-header.ts
+++ b/lib/components/pin-header.ts
@@ -107,6 +107,7 @@ export interface PinHeaderProps extends CommonComponentProps {
 
   /**
    * Schematic pin spacing
+   * @deprecated Use schPinStyle instead.
    */
   schPinSpacing?: number | string
 


### PR DESCRIPTION
### Motivation
- `schPinSpacing` is being deprecated in favor of the richer `schPinStyle` configuration to steer users toward the preferred API for schematic pin layout.

### Description
- Added a JSDoc deprecation note `@deprecated Use schPinStyle instead.` to `schPinSpacing` on `PinHeaderProps` (`lib/components/pin-header.ts`), `JumperProps` (`lib/components/jumper.ts`), and `BaseGroupProps` (`lib/components/group.ts`).
- Regenerated documentation and type artifacts by running the repository generation scripts which updated `README.md` and `generated/PROPS_OVERVIEW.md` to surface the deprecation.
- This change is purely a documentation annotation and does not alter runtime validation or types beyond the added comments.

### Testing
- Ran the generation scripts `bun scripts/generate-component-types.ts`, `bun scripts/generate-manual-edits-docs.ts`, `bun scripts/generate-readme-docs.ts`, and `bun scripts/generate-props-overview.ts`, and they completed successfully.
- Executed unit tests `bun test tests/chip1-basic.test.ts`, `bun test tests/chip2-schematic-port-arrangement.test.ts`, `bun test tests/pin-header.test.ts`, and `bun test tests/group.test.ts`, and all tests passed.
- Performed typecheck `bunx tsc --noEmit` and formatting `bun run format`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f67caf8cf4832e890503569074045b)