### PR TITLE
feat: add schPinLength prop to chip component props

### DIFF
--- a/lib/components/chip.ts
+++ b/lib/components/chip.ts
@@ -55,6 +55,7 @@ export interface ChipPropsSU<
   pinCompatibleVariants?: PinCompatibleVariant[]
   schPinStyle?: SchematicPinStyle
   schPinSpacing?: Distance
+  schPinLength?: Distance
   schWidth?: Distance
   schHeight?: Distance
   noSchematicRepresentation?: boolean
@@ -157,6 +158,7 @@ export const chipProps = commonComponentProps.extend({
   pinCompatibleVariants: z.array(pinCompatibleVariant).optional(),
   schPinStyle: schematicPinStyle.optional(),
   schPinSpacing: distance.optional(),
+  schPinLength: distance.optional(),
   schWidth: distance.optional(),
   schHeight: distance.optional(),
   noSchematicRepresentation: z.boolean().optional(),


### PR DESCRIPTION
Adds schPinLength optional number prop to ChipProps for controlling schematic pin stem length. Companion to tscircuit/core#2199.