### PR TITLE
Add region and reroute support to <autoroutingphase />

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,13 @@ export interface AutoroutingPhaseProps {
   key?: any;
   autorouter?: AutorouterProp;
   phaseIndex?: number;
+  region?: {
+    minX: number;
+    maxX: number;
+    minY: number;
+    maxY: number;
+  };
+  reroute?: boolean;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -884,11 +884,35 @@ export interface AutoroutingPhaseProps {
   key?: any
   autorouter?: AutorouterProp
   phaseIndex?: number
+  region?: {
+    minX: number
+    maxX: number
+    minY: number
+    maxY: number
+  }
+  reroute?: boolean
 }
 export const autoroutingPhaseProps = z.object({
   key: z.any().optional(),
   autorouter: autorouterProp.optional(),
   phaseIndex: z.number().optional(),
+  region: z
+    .object({
+      minX: z.number(),
+      maxX: z.number(),
+      minY: z.number(),
+      maxY: z.number(),
+    })
+    .optional(),
+  reroute: z.boolean().optional(),
+}).superRefine((value, ctx) => {
+  if (value.reroute !== undefined && value.region === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "region is required when reroute is provided",
+      path: ["region"],
+    })
+  }
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -75,6 +75,13 @@ export interface AutoroutingPhaseProps {
   key?: any
   autorouter?: AutorouterProp
   phaseIndex?: number
+  region?: {
+    minX: number
+    maxX: number
+    minY: number
+    maxY: number
+  }
+  reroute?: boolean
 }
 
 

--- a/lib/components/autoroutingphase.ts
+++ b/lib/components/autoroutingphase.ts
@@ -6,13 +6,39 @@ export interface AutoroutingPhaseProps {
   key?: any
   autorouter?: AutorouterProp
   phaseIndex?: number
+  region?: {
+    minX: number
+    maxX: number
+    minY: number
+    maxY: number
+  }
+  reroute?: boolean
 }
 
-export const autoroutingPhaseProps = z.object({
-  key: z.any().optional(),
-  autorouter: autorouterProp.optional(),
-  phaseIndex: z.number().optional(),
-})
+export const autoroutingPhaseProps = z
+  .object({
+    key: z.any().optional(),
+    autorouter: autorouterProp.optional(),
+    phaseIndex: z.number().optional(),
+    region: z
+      .object({
+        minX: z.number(),
+        maxX: z.number(),
+        minY: z.number(),
+        maxY: z.number(),
+      })
+      .optional(),
+    reroute: z.boolean().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.reroute !== undefined && value.region === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "region is required when reroute is provided",
+        path: ["region"],
+      })
+    }
+  })
 
 type InferredAutoroutingPhaseProps = z.input<typeof autoroutingPhaseProps>
 expectTypesMatch<AutoroutingPhaseProps, InferredAutoroutingPhaseProps>(true)

--- a/tests/autoroutingphase.test.ts
+++ b/tests/autoroutingphase.test.ts
@@ -34,3 +34,33 @@ test("autorouting phase accepts autorouter config", () => {
     traceClearance: 0.2,
   })
 })
+
+test("autorouting phase accepts region with reroute", () => {
+  const raw: AutoroutingPhaseProps = {
+    phaseIndex: 2,
+    reroute: true,
+    region: {
+      minX: 1,
+      maxX: 10,
+      minY: 2,
+      maxY: 12,
+    },
+  }
+
+  const parsed = autoroutingPhaseProps.parse(raw)
+  expect(parsed.reroute).toBe(true)
+  expect(parsed.region).toEqual({
+    minX: 1,
+    maxX: 10,
+    minY: 2,
+    maxY: 12,
+  })
+})
+
+test("autorouting phase requires region when reroute is provided", () => {
+  expect(() =>
+    autoroutingPhaseProps.parse({
+      reroute: false,
+    }),
+  ).toThrow("region is required when reroute is provided")
+})


### PR DESCRIPTION
### Motivation
- Allow specifying a rectangular `region` and an optional `reroute` flag on `<autoroutingphase />` so a section of the PCB can be targeted for rerouting. 
- Enforce a clear invariant that if `reroute` is provided then a `region` must also be supplied to avoid ambiguous or incomplete reroute requests.

### Description
- Added `region?: { minX: number; maxX: number; minY: number; maxY: number }` and `reroute?: boolean` to `AutoroutingPhaseProps` in `lib/components/autoroutingphase.ts`.
- Updated the Zod schema `autoroutingPhaseProps` to validate `region` and `reroute` and added a `.superRefine()` rule that errors with `"region is required when reroute is provided"` when `reroute` is present but `region` is missing.
- Added tests in `tests/autoroutingphase.test.ts` to cover valid `region + reroute` parsing and the invalid case where `reroute` is supplied without `region`.
- Regenerated documentation and type artifacts so `README.md`, `generated/COMPONENT_TYPES.md`, and `generated/PROPS_OVERVIEW.md` reflect the new props.

### Testing
- Ran generation scripts: `bun scripts/generate-component-types.ts`, `bun scripts/generate-manual-edits-docs.ts`, `bun scripts/generate-readme-docs.ts`, and `bun scripts/generate-props-overview.ts`, and they completed successfully. 
- Ran unit tests with `bun test tests/autoroutingphase.test.ts` which reported `4 pass, 0 fail` for the updated tests. 
- Type-checked with `bunx tsc --noEmit` which completed successfully. 
- Ran formatting with `bun run format` which formatted project files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f936228748832e8767326f9fbf2275)