### PR TITLE
Add krt autorouter preset

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2016,6 +2016,7 @@ export interface AutorouterConfig {
     | "auto_cloud"
     | "auto_jumper"
     | "tscircuit_beta"
+    | "krt"
     | "freerouting"
     | "laser_prefab" // Prefabricated PCB with laser copper ablation
     | /** @deprecated Use "auto_jumper" */ "auto-jumper"
@@ -2059,6 +2060,7 @@ export const autorouterConfig = z.object({
       "auto_cloud",
       "auto_jumper",
       "tscircuit_beta",
+      "krt",
       "freerouting",
       "laser_prefab",
       "auto-jumper",

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -48,6 +48,7 @@ export interface AutorouterConfig {
     | "auto_cloud"
     | "auto_jumper"
     | "tscircuit_beta"
+    | "krt"
     | "freerouting"
     | "laser_prefab" // Prefabricated PCB with laser copper ablation
     | /** @deprecated Use "auto_jumper" */ "auto-jumper"

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -344,6 +344,7 @@ export interface AutorouterConfig {
     | "auto_cloud"
     | "auto_jumper"
     | "tscircuit_beta"
+    | "krt"
     | "freerouting"
     | "laser_prefab" // Prefabricated PCB with laser copper ablation
     | /** @deprecated Use "auto_jumper" */ "auto-jumper"
@@ -360,6 +361,7 @@ export type AutorouterPreset =
   | "auto_cloud"
   | "auto_jumper"
   | "tscircuit_beta"
+  | "krt"
   | "freerouting"
   | "laser_prefab"
   | "auto-jumper"
@@ -412,6 +414,7 @@ export const autorouterConfig = z.object({
       "auto_cloud",
       "auto_jumper",
       "tscircuit_beta",
+      "krt",
       "freerouting",
       "laser_prefab",
       "auto-jumper",
@@ -431,6 +434,7 @@ export const autorouterPreset = z.union([
   z.literal("auto_cloud"),
   z.literal("auto_jumper"),
   z.literal("tscircuit_beta"),
+  z.literal("krt"),
   z.literal("freerouting"),
   z.literal("laser_prefab"), // Prefabricated PCB with laser copper ablation
   z.literal("auto-jumper"),

--- a/tests/autorouter.test.ts
+++ b/tests/autorouter.test.ts
@@ -31,6 +31,11 @@ test("supports tscircuit beta preset", () => {
   expect(result).toBe("tscircuit_beta")
 })
 
+test("supports krt preset", () => {
+  const result = autorouterProp.parse("krt")
+  expect(result).toBe("krt")
+})
+
 test("still supports deprecated kebab-case presets", () => {
   const result = autorouterProp.parse("auto-cloud")
   expect(result).toBe("auto-cloud")


### PR DESCRIPTION
### Motivation
- Expose a new autorouter preset named `krt` so it can be selected in group autorouter configurations.
- Keep generated documentation and type/schema artifacts in sync with the new preset.

### Description
- Add `"krt"` to the `preset` union on `AutorouterConfig` and to the `AutorouterPreset` type in `lib/components/group.ts`.
- Add `z.enum` / `z.literal` entries for `krt` in the runtime `autorouterConfig` schema and `autorouterPreset` union.
- Update generated artifacts `generated/COMPONENT_TYPES.md` and `generated/PROPS_OVERVIEW.md` to include the new preset.
- Add a unit test in `tests/autorouter.test.ts` asserting `autorouterProp.parse("krt")` returns `"krt"`.

### Testing
- Ran the generation scripts `bun scripts/generate-component-types.ts`, `bun scripts/generate-manual-edits-docs.ts`, `bun scripts/generate-readme-docs.ts`, and `bun scripts/generate-props-overview.ts` which completed successfully.
- Ran `bun test tests/autorouter.test.ts` and all tests passed (10 passed, 0 failed).
- Ran the typechecker with `bunx tsc --noEmit` which completed without errors.
- Ran `biome format .` / `bun run format:check` which reported no formatting fixes required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc2984bafc83278ed2719cb0f3b3af)