### PR TITLE
Map supported resistor footprint shorthands in resistorProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,9 +234,8 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
 ### BatteryProps `<battery />`
 
 ```ts
-export interface BatteryProps<
-  PinLabel extends string = string,
-> extends CommonComponentProps<PinLabel> {
+export interface BatteryProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   capacity?: number | string;
   voltage?: number | string;
   standard?: "AA" | "AAA" | "9V" | "CR2032" | "18650" | "C";
@@ -249,10 +248,8 @@ export interface BatteryProps<
 ### BoardProps `<board />`
 
 ```ts
-export interface BoardProps extends Omit<
-  SubcircuitGroupProps,
-  "subcircuit" | "connections"
-> {
+export interface BoardProps
+  extends Omit<SubcircuitGroupProps, "subcircuit" | "connections"> {
   title?: string;
   material?: "fr4" | "fr1" | "flex";
   /** Number of layers for the PCB */
@@ -286,10 +283,8 @@ export interface BoardProps extends Omit<
 ### BreakoutProps `<breakout />`
 
 ```ts
-export interface BreakoutProps extends Omit<
-  SubcircuitGroupProps,
-  "subcircuit"
-> {
+export interface BreakoutProps
+  extends Omit<SubcircuitGroupProps, "subcircuit"> {
   padding?: Distance;
   paddingLeft?: Distance;
   paddingRight?: Distance;
@@ -303,10 +298,8 @@ export interface BreakoutProps extends Omit<
 ### BreakoutPointProps `<breakoutpoint />`
 
 ```ts
-export interface BreakoutPointProps extends Omit<
-  PcbLayoutProps,
-  "pcbRotation" | "layer"
-> {
+export interface BreakoutPointProps
+  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   connection: string;
 }
 ```
@@ -358,9 +351,8 @@ export interface CadModelProps extends CadModelBase {
 ### CapacitorProps `<capacitor />`
 
 ```ts
-export interface CapacitorProps<
-  PinLabel extends string = string,
-> extends CommonComponentProps<PinLabel> {
+export interface CapacitorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   capacitance: number | string;
   maxVoltageRating?: number | string;
   schShowRatings?: boolean;
@@ -521,9 +513,8 @@ export type CourtyardRectProps = z.input<typeof courtyardRectProps>;
 ### CrystalProps `<crystal />`
 
 ```ts
-export interface CrystalProps<
-  PinLabel extends string = string,
-> extends CommonComponentProps<PinLabel> {
+export interface CrystalProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   frequency: number | string;
   loadCapacitance: number | string;
   manufacturerPartNumber?: string;
@@ -539,9 +530,8 @@ export interface CrystalProps<
 ### CurrentSourceProps `<currentsource />`
 
 ```ts
-export interface CurrentSourceProps<
-  PinLabel extends string = string,
-> extends CommonComponentProps<PinLabel> {
+export interface CurrentSourceProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   current?: number | string;
   frequency?: number | string;
   peakToPeakCurrent?: number | string;
@@ -557,10 +547,8 @@ export interface CurrentSourceProps<
 ### RectCutoutProps `<cutout />`
 
 ```ts
-export interface RectCutoutProps extends Omit<
-  PcbLayoutProps,
-  "layer" | "pcbRotation"
-> {
+export interface RectCutoutProps
+  extends Omit<PcbLayoutProps, "layer" | "pcbRotation"> {
   name?: string;
   shape: "rect";
   width: Distance;
@@ -573,9 +561,8 @@ export interface RectCutoutProps extends Omit<
 ### DiodeProps `<diode />`
 
 ```ts
-export interface DiodeProps<
-  PinLabel extends string = string,
-> extends CommonComponentProps<PinLabel> {
+export interface DiodeProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   connections?: {
     anode?: string | string[] | readonly string[];
     cathode?: string | string[] | readonly string[];
@@ -600,18 +587,19 @@ export interface DiodeProps<
 ### FabricationNoteDimensionProps `<fabricationnotedimension />`
 
 ```ts
-export interface FabricationNoteDimensionProps extends Omit<
-  PcbLayoutProps,
-  | "pcbLeftEdgeX"
-  | "pcbRightEdgeX"
-  | "pcbTopEdgeY"
-  | "pcbBottomEdgeY"
-  | "pcbX"
-  | "pcbY"
-  | "pcbOffsetX"
-  | "pcbOffsetY"
-  | "pcbRotation"
-> {
+export interface FabricationNoteDimensionProps
+  extends Omit<
+    PcbLayoutProps,
+    | "pcbLeftEdgeX"
+    | "pcbRightEdgeX"
+    | "pcbTopEdgeY"
+    | "pcbBottomEdgeY"
+    | "pcbX"
+    | "pcbY"
+    | "pcbOffsetX"
+    | "pcbOffsetY"
+    | "pcbRotation"
+  > {
   from: string | Point;
   to: string | Point;
   text?: string;
@@ -712,9 +700,8 @@ export interface FootprintProps {
 ### FuseProps `<fuse />`
 
 ```ts
-export interface FuseProps<
-  PinLabel extends string = string,
-> extends CommonComponentProps<PinLabel> {
+export interface FuseProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   /**
    * Current rating of the fuse in amperes
    */
@@ -892,9 +879,8 @@ export interface CircleHoleProps extends PcbLayoutProps {
 ### InductorProps `<inductor />`
 
 ```ts
-export interface InductorProps<
-  PinLabel extends string = string,
-> extends CommonComponentProps<PinLabel> {
+export interface InductorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   inductance: number | string;
   maxCurrentRating?: number | string;
   schOrientation?: SchematicOrientation;
@@ -976,9 +962,8 @@ export type LedProps = z.input<typeof ledProps>;
 ### MosfetProps `<mosfet />`
 
 ```ts
-export interface MosfetProps<
-  PinLabel extends string = string,
-> extends CommonComponentProps<PinLabel> {
+export interface MosfetProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   channelType: "n" | "p";
   mosfetMode: "enhancement" | "depletion";
 }
@@ -990,7 +975,8 @@ export interface MosfetProps<
 
 ```ts
 export interface MountedBoardProps
-  extends SubcircuitGroupProps, MountedBoardChipProps {
+  extends SubcircuitGroupProps,
+    MountedBoardChipProps {
   boardToBoardDistance?: Distance;
   mountOrientation?: "faceDown" | "faceUp";
 }
@@ -1047,9 +1033,8 @@ export interface NetLabelProps {
 ### OpAmpProps `<opamp />`
 
 ```ts
-export interface OpAmpProps<
-  PinLabel extends string = string,
-> extends CommonComponentProps<PinLabel> {
+export interface OpAmpProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   connections?: Connections<OpAmpPinLabels>;
 }
 ```
@@ -1059,10 +1044,8 @@ export interface OpAmpProps<
 ### PanelProps `<panel />`
 
 ```ts
-export interface PanelProps extends Omit<
-  BaseGroupProps,
-  "height" | "layoutMode" | "width"
-> {
+export interface PanelProps
+  extends Omit<BaseGroupProps, "height" | "layoutMode" | "width"> {
   width?: Distance;
   height?: Distance;
   children?: BaseGroupProps["children"];
@@ -1105,18 +1088,19 @@ export type PcbKeepoutProps = z.input<typeof pcbKeepoutProps>;
 ### PcbNoteDimensionProps `<pcbnotedimension />`
 
 ```ts
-export interface PcbNoteDimensionProps extends Omit<
-  PcbLayoutProps,
-  | "pcbLeftEdgeX"
-  | "pcbRightEdgeX"
-  | "pcbTopEdgeY"
-  | "pcbBottomEdgeY"
-  | "pcbX"
-  | "pcbY"
-  | "pcbOffsetX"
-  | "pcbOffsetY"
-  | "pcbRotation"
-> {
+export interface PcbNoteDimensionProps
+  extends Omit<
+    PcbLayoutProps,
+    | "pcbLeftEdgeX"
+    | "pcbRightEdgeX"
+    | "pcbTopEdgeY"
+    | "pcbBottomEdgeY"
+    | "pcbX"
+    | "pcbY"
+    | "pcbOffsetX"
+    | "pcbOffsetY"
+    | "pcbRotation"
+  > {
   from: string | Point;
   to: string | Point;
   text?: string;
@@ -1137,18 +1121,19 @@ export interface PcbNoteDimensionProps extends Omit<
 ### PcbNoteLineProps `<pcbnoteline />`
 
 ```ts
-export interface PcbNoteLineProps extends Omit<
-  PcbLayoutProps,
-  | "pcbLeftEdgeX"
-  | "pcbRightEdgeX"
-  | "pcbTopEdgeY"
-  | "pcbBottomEdgeY"
-  | "pcbX"
-  | "pcbY"
-  | "pcbOffsetX"
-  | "pcbOffsetY"
-  | "pcbRotation"
-> {
+export interface PcbNoteLineProps
+  extends Omit<
+    PcbLayoutProps,
+    | "pcbLeftEdgeX"
+    | "pcbRightEdgeX"
+    | "pcbTopEdgeY"
+    | "pcbBottomEdgeY"
+    | "pcbX"
+    | "pcbY"
+    | "pcbOffsetX"
+    | "pcbOffsetY"
+    | "pcbRotation"
+  > {
   x1: string | number;
   y1: string | number;
   x2: string | number;
@@ -1164,18 +1149,19 @@ export interface PcbNoteLineProps extends Omit<
 ### PcbNotePathProps `<pcbnotepath />`
 
 ```ts
-export interface PcbNotePathProps extends Omit<
-  PcbLayoutProps,
-  | "pcbLeftEdgeX"
-  | "pcbRightEdgeX"
-  | "pcbTopEdgeY"
-  | "pcbBottomEdgeY"
-  | "pcbX"
-  | "pcbY"
-  | "pcbOffsetX"
-  | "pcbOffsetY"
-  | "pcbRotation"
-> {
+export interface PcbNotePathProps
+  extends Omit<
+    PcbLayoutProps,
+    | "pcbLeftEdgeX"
+    | "pcbRightEdgeX"
+    | "pcbTopEdgeY"
+    | "pcbBottomEdgeY"
+    | "pcbX"
+    | "pcbY"
+    | "pcbOffsetX"
+    | "pcbOffsetY"
+    | "pcbRotation"
+  > {
   route: RouteHintPointInput[];
   strokeWidth?: string | number;
   color?: string;
@@ -1335,10 +1321,8 @@ export interface PinHeaderProps extends CommonComponentProps {
 ### CirclePlatedHoleProps `<platedhole />`
 
 ```ts
-export interface CirclePlatedHoleProps extends Omit<
-  PcbLayoutProps,
-  "pcbRotation" | "layer"
-> {
+export interface CirclePlatedHoleProps
+  extends Omit<PcbLayoutProps, "pcbRotation" | "layer"> {
   name?: string;
   connectsTo?: string | string[];
   shape: "circle";
@@ -1364,9 +1348,8 @@ export type PortProps = z.input<typeof portProps>;
 ### PotentiometerProps `<potentiometer />`
 
 ```ts
-export interface PotentiometerProps<
-  PinLabel extends string = string,
-> extends CommonComponentProps<PinLabel> {
+export interface PotentiometerProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   maxResistance: number | string;
   pinVariant?: PotentiometerPinVariant;
   connections?: Connections<PotentiometerPinLabels>;
@@ -1395,9 +1378,8 @@ export type PushButtonProps<T extends PinLabelsProp | string = string> =
 ### ResistorProps `<resistor />`
 
 ```ts
-export interface ResistorProps<
-  PinLabel extends string = string,
-> extends CommonComponentProps<PinLabel> {
+export interface ResistorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   resistance: number | string;
   tolerance?: number | string;
   pullupFor?: string;
@@ -1686,10 +1668,8 @@ export interface SolderJumperProps extends JumperProps {
 ### RectSolderPasteProps `<solderpaste />`
 
 ```ts
-export interface RectSolderPasteProps extends Omit<
-  PcbLayoutProps,
-  "pcbRotation"
-> {
+export interface RectSolderPasteProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
   shape: "rect";
   width: Distance;
   height: Distance;
@@ -1828,9 +1808,8 @@ export type TraceHintProps = z.input<typeof traceHintProps>;
 ### TransistorProps `<transistor />`
 
 ```ts
-export interface TransistorProps<
-  PinLabel extends string = string,
-> extends CommonComponentProps<PinLabel> {
+export interface TransistorProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   type: "npn" | "pnp" | "bjt" | "jfet" | "mosfet" | "igbt";
   connections?: Connections<transistorPinsLabels>;
 }
@@ -1870,9 +1849,8 @@ export interface VoltageProbeProps extends Omit<CommonComponentProps, "name"> {
 ### VoltageSourceProps `<voltagesource />`
 
 ```ts
-export interface VoltageSourceProps<
-  PinLabel extends string = string,
-> extends CommonComponentProps<PinLabel> {
+export interface VoltageSourceProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
   voltage?: number | string;
   frequency?: number | string;
   peakToPeakVoltage?: number | string;
@@ -1967,17 +1945,18 @@ export interface PlatformConfig {
 ### ProjectConfig
 
 ```ts
-export interface ProjectConfig extends Pick<
-  PlatformConfig,
-  | "projectName"
-  | "projectBaseUrl"
-  | "version"
-  | "url"
-  | "printBoardInformationToSilkscreen"
-  | "includeBoardFiles"
-  | "snapshotsDir"
-  | "defaultSpiceEngine"
-> {}
+export interface ProjectConfig
+  extends Pick<
+    PlatformConfig,
+    | "projectName"
+    | "projectBaseUrl"
+    | "version"
+    | "url"
+    | "printBoardInformationToSilkscreen"
+    | "includeBoardFiles"
+    | "snapshotsDir"
+    | "defaultSpiceEngine"
+  > {}
 ```
 
 [Source](https://github.com/tscircuit/props/blob/main/lib/projectConfig.ts)

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -3214,38 +3214,38 @@ export interface ResistorProps<PinLabel extends string = string>
   schSize?: SchematicSymbolSize
   connections?: Connections<ResistorPinLabels>
 }
-export const resistorProps = commonComponentProps.extend({
-  resistance,
-  tolerance: z
-    .union([z.string(), z.number()])
-    .transform((val) => {
-      if (typeof val === "string") {
-        if (val.endsWith("%")) {
-          return parseFloat(val.slice(0, -1)) / 100
+.extend({
+    resistance,
+    tolerance: z
+      .union([z.string(), z.number()])
+      .transform((val) => {
+        if (typeof val === "string") {
+          if (val.endsWith("%")) {
+            return parseFloat(val.slice(0, -1)) / 100
+          }
+          return parseFloat(val)
         }
-        return parseFloat(val)
-      }
-      return val
-    })
-    .pipe(
-      z
-        .number()
-        .min(0, "Tolerance must be non-negative")
-        .max(1, "Tolerance cannot be greater than 100%"),
-    )
-    .optional(),
+        return val
+      })
+      .pipe(
+        z
+          .number()
+          .min(0, "Tolerance must be non-negative")
+          .max(1, "Tolerance cannot be greater than 100%"),
+      )
+      .optional(),
 
-  pullupFor: z.string().optional(),
-  pullupTo: z.string().optional(),
+    pullupFor: z.string().optional(),
+    pullupTo: z.string().optional(),
 
-  pulldownFor: z.string().optional(),
-  pulldownTo: z.string().optional(),
+    pulldownFor: z.string().optional(),
+    pulldownTo: z.string().optional(),
 
-  schOrientation: schematicOrientation.optional(),
-  schSize: schematicSymbolSize.optional(),
+    schOrientation: schematicOrientation.optional(),
+    schSize: schematicSymbolSize.optional(),
 
-  connections: createConnectionsProp(resistorPinLabels).optional(),
-})
+    connections: createConnectionsProp(resistorPinLabels).optional(),
+  })
 ```
 
 ### resonator

--- a/lib/components/resistor.ts
+++ b/lib/components/resistor.ts
@@ -32,7 +32,25 @@ export interface ResistorProps<PinLabel extends string = string>
   schSize?: SchematicSymbolSize
   connections?: Connections<ResistorPinLabels>
 }
+const resistorImperialFootprintNames = new Set([
+  "01005",
+  "0201",
+  "0402",
+  "0504",
+  "0603",
+  "0805",
+  "1206",
+  "1210",
+  "1812",
+  "2010",
+  "2512",
+])
 
+const normalizeResistorFootprint = (footprint: unknown) => {
+  if (typeof footprint !== "string") return footprint
+  if (!resistorImperialFootprintNames.has(footprint)) return footprint
+  return `res${footprint}`
+}
 export const resistorProps = commonComponentProps.extend({
   resistance,
   tolerance: z
@@ -63,8 +81,12 @@ export const resistorProps = commonComponentProps.extend({
   schOrientation: schematicOrientation.optional(),
   schSize: schematicSymbolSize.optional(),
 
-  connections: createConnectionsProp(resistorPinLabels).optional(),
-})
+    connections: createConnectionsProp(resistorPinLabels).optional(),
+  })
+  .transform((props) => ({
+    ...props,
+    footprint: normalizeResistorFootprint(props.footprint),
+  }))
 export const resistorPins = lrPins
 
 type InferredResistorProps = z.input<typeof resistorProps>

--- a/lib/components/resistor.ts
+++ b/lib/components/resistor.ts
@@ -51,35 +51,36 @@ const normalizeResistorFootprint = (footprint: unknown) => {
   if (!resistorImperialFootprintNames.has(footprint)) return footprint
   return `res${footprint}`
 }
-export const resistorProps = commonComponentProps.extend({
-  resistance,
-  tolerance: z
-    .union([z.string(), z.number()])
-    .transform((val) => {
-      if (typeof val === "string") {
-        if (val.endsWith("%")) {
-          return parseFloat(val.slice(0, -1)) / 100
+export const resistorProps = commonComponentProps
+  .extend({
+    resistance,
+    tolerance: z
+      .union([z.string(), z.number()])
+      .transform((val) => {
+        if (typeof val === "string") {
+          if (val.endsWith("%")) {
+            return parseFloat(val.slice(0, -1)) / 100
+          }
+          return parseFloat(val)
         }
-        return parseFloat(val)
-      }
-      return val
-    })
-    .pipe(
-      z
-        .number()
-        .min(0, "Tolerance must be non-negative")
-        .max(1, "Tolerance cannot be greater than 100%"),
-    )
-    .optional(),
+        return val
+      })
+      .pipe(
+        z
+          .number()
+          .min(0, "Tolerance must be non-negative")
+          .max(1, "Tolerance cannot be greater than 100%"),
+      )
+      .optional(),
 
-  pullupFor: z.string().optional(),
-  pullupTo: z.string().optional(),
+    pullupFor: z.string().optional(),
+    pullupTo: z.string().optional(),
 
-  pulldownFor: z.string().optional(),
-  pulldownTo: z.string().optional(),
+    pulldownFor: z.string().optional(),
+    pulldownTo: z.string().optional(),
 
-  schOrientation: schematicOrientation.optional(),
-  schSize: schematicSymbolSize.optional(),
+    schOrientation: schematicOrientation.optional(),
+    schSize: schematicSymbolSize.optional(),
 
     connections: createConnectionsProp(resistorPinLabels).optional(),
   })

--- a/lib/components/resistor.ts
+++ b/lib/components/resistor.ts
@@ -32,6 +32,9 @@ export interface ResistorProps<PinLabel extends string = string>
   schSize?: SchematicSymbolSize
   connections?: Connections<ResistorPinLabels>
 }
+
+type ResistorFootprint = CommonComponentProps["footprint"]
+
 const resistorImperialFootprintNames = new Set([
   "01005",
   "0201",
@@ -46,7 +49,9 @@ const resistorImperialFootprintNames = new Set([
   "2512",
 ])
 
-const normalizeResistorFootprint = (footprint: unknown) => {
+const mapResistorFootprint = (
+  footprint: ResistorFootprint,
+): ResistorFootprint => {
   if (typeof footprint !== "string") return footprint
   if (!resistorImperialFootprintNames.has(footprint)) return footprint
   return `res${footprint}`
@@ -86,7 +91,7 @@ export const resistorProps = commonComponentProps
   })
   .transform((props) => ({
     ...props,
-    footprint: normalizeResistorFootprint(props.footprint),
+    footprint: mapResistorFootprint(props.footprint),
   }))
 export const resistorPins = lrPins
 

--- a/tests/resistor.test.ts
+++ b/tests/resistor.test.ts
@@ -22,3 +22,29 @@ test("should parse tolerance percentage for resistor", () => {
   const parsed = resistorProps.parse(raw)
   expect(parsed.tolerance).toBeCloseTo(0.05)
 })
+
+test("should normalize supported resistor imperial footprints", () => {
+  const supportedFootprints = ["01005", "0402", "2512"] as const
+
+  for (const footprint of supportedFootprints) {
+    const raw: ResistorProps = {
+      name: `R_${footprint}`,
+      resistance: 4700,
+      footprint,
+    }
+
+    const parsed = resistorProps.parse(raw)
+    expect(parsed.footprint).toBe(`res${footprint}`)
+  }
+})
+
+test("should preserve non-generic resistor footprints", () => {
+  const raw: ResistorProps = {
+    name: "R4",
+    resistance: 10000,
+    footprint: "kicad:R_0402_1005Metric",
+  }
+
+  const parsed = resistorProps.parse(raw)
+  expect(parsed.footprint).toBe("kicad:R_0402_1005Metric")
+})

--- a/tests/resistor.test.ts
+++ b/tests/resistor.test.ts
@@ -23,7 +23,7 @@ test("should parse tolerance percentage for resistor", () => {
   expect(parsed.tolerance).toBeCloseTo(0.05)
 })
 
-test("should normalize supported resistor imperial footprints", () => {
+test("should map supported resistor imperial footprints", () => {
   const supportedFootprints = ["01005", "0402", "2512"] as const
 
   for (const footprint of supportedFootprints) {


### PR DESCRIPTION
## Summary
- move resistor footprint shorthand handling into `resistorProps`
- map supported resistor footprint shorthands like `01005`, `0402`, and `2512` to `res01005`, `res0402`, and `res2512`
- use an explicit allowlist of footprinter-supported resistor sizes instead of a generic numeric pattern
- keep this behavior resistor-specific so shared footprint shorthands for other components are unchanged
- preserve explicit footprints like `kicad:R_0402_1005Metric` without rewriting them
- add tests for both shorthand mapping and passthrough behavior
