### PR TITLE
Make Via layer refs optional and add `layers` array; update schema and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1843,8 +1843,9 @@ export interface TransistorProps<
 ```ts
 export interface ViaProps extends CommonLayoutProps {
   name?: string;
-  fromLayer: LayerRefInput;
-  toLayer: LayerRefInput;
+  fromLayer?: LayerRefInput;
+  toLayer?: LayerRefInput;
+  layers?: LayerRefInput[];
   holeDiameter?: number | string;
   outerDiameter?: number | string;
   connectsTo?: string | string[];

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -4012,8 +4012,9 @@ export const transistorPins = [
 ```typescript
 export interface ViaProps extends CommonLayoutProps {
   name?: string
-  fromLayer: LayerRefInput
-  toLayer: LayerRefInput
+  fromLayer?: LayerRefInput
+  toLayer?: LayerRefInput
+  layers?: LayerRefInput[]
   holeDiameter?: number | string
   outerDiameter?: number | string
   connectsTo?: string | string[]
@@ -4021,10 +4022,11 @@ export interface ViaProps extends CommonLayoutProps {
 }
 export const viaProps = commonLayoutProps.extend({
   name: z.string().optional(),
-  fromLayer: layer_ref,
-  toLayer: layer_ref,
+  fromLayer: layer_ref.optional(),
+  toLayer: layer_ref.optional(),
   holeDiameter: distance.optional(),
   outerDiameter: distance.optional(),
+  layers: z.array(layer_ref).optional(),
   connectsTo: z.string().or(z.array(z.string())).optional(),
   netIsAssignable: z.boolean().optional(),
 })

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -2119,8 +2119,9 @@ export interface TransistorProps<PinLabel extends string = string>
 
 export interface ViaProps extends CommonLayoutProps {
   name?: string
-  fromLayer: LayerRefInput
-  toLayer: LayerRefInput
+  fromLayer?: LayerRefInput
+  toLayer?: LayerRefInput
+  layers?: LayerRefInput[]
   holeDiameter?: number | string
   outerDiameter?: number | string
   connectsTo?: string | string[]

--- a/lib/components/via.ts
+++ b/lib/components/via.ts
@@ -5,8 +5,9 @@ import { z } from "zod"
 
 export interface ViaProps extends CommonLayoutProps {
   name?: string
-  fromLayer: LayerRefInput
-  toLayer: LayerRefInput
+  fromLayer?: LayerRefInput
+  toLayer?: LayerRefInput
+  layers?: LayerRefInput[]
   holeDiameter?: number | string
   outerDiameter?: number | string
   connectsTo?: string | string[]
@@ -15,10 +16,11 @@ export interface ViaProps extends CommonLayoutProps {
 
 export const viaProps = commonLayoutProps.extend({
   name: z.string().optional(),
-  fromLayer: layer_ref,
-  toLayer: layer_ref,
+  fromLayer: layer_ref.optional(),
+  toLayer: layer_ref.optional(),
   holeDiameter: distance.optional(),
   outerDiameter: distance.optional(),
+  layers: z.array(layer_ref).optional(),
   connectsTo: z.string().or(z.array(z.string())).optional(),
   netIsAssignable: z.boolean().optional(),
 })

--- a/tests/via.test.ts
+++ b/tests/via.test.ts
@@ -20,3 +20,21 @@ test("should parse ViaProps with name and connectsTo", () => {
   expect(parsed.connectsTo).toEqual(["net1", "net2"])
   expect(parsed.outerDiameter).toBe(0.8)
 })
+
+test("should parse ViaProps with layers and net assignability flag", () => {
+  const raw: ViaProps = {
+    name: "v2",
+    layers: ["top", "bottom"],
+    holeDiameter: "0.25mm",
+    outerDiameter: "0.6mm",
+    netIsAssignable: true,
+  }
+
+  expectTypeOf(raw).toMatchTypeOf<z.input<typeof viaProps>>()
+
+  const parsed = viaProps.parse(raw)
+  expect(parsed.layers).toEqual(["top", "bottom"])
+  expect(parsed.holeDiameter).toBe(0.25)
+  expect(parsed.outerDiameter).toBe(0.6)
+  expect(parsed.netIsAssignable).toBe(true)
+})


### PR DESCRIPTION
### Motivation

- Allow vias to be specified with an explicit `layers` array or omit explicit `fromLayer`/`toLayer` to support more flexible layer declarations and maintain backwards compatibility.

### Description

- Change `ViaProps` to make `fromLayer` and `toLayer` optional and add an optional `layers?: LayerRefInput[]` property in `lib/components/via.ts`.
- Update the Zod schema `viaProps` to mark `fromLayer`/`toLayer` as optional and add `layers: z.array(layer_ref).optional()` for runtime validation.
- Regenerate documentation files `README.md`, `generated/COMPONENT_TYPES.md`, and `generated/PROPS_OVERVIEW.md` to reflect the updated `ViaProps` shape.
- Add a new test in `tests/via.test.ts` to validate parsing of `layers` and `netIsAssignable`, and keep the existing test for `fromLayer`/`toLayer`.

### Testing

- Ran the test suite with `bun test` and the updated `tests/via.test.ts` executed successfully.
- Type-level checks using `expectTypeOf` against `z.input<typeof viaProps>` passed in the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69febc328b7c832e9e345fd54cb380d4)