### PR TITLE
[codex] Sync package version with npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1992,4 +1992,3 @@ export interface ProjectConfig extends Pick<
 [Source](https://github.com/tscircuit/props/blob/main/lib/projectConfig.ts)
 
 <!-- PROJECT_CONFIG_END -->
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tscircuit/props",
-  "version": "0.0.536",
+  "version": "0.0.535",
   "description": "Props for tscircuit builtin component types",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

- Reset `package.json` from `0.0.536` to `0.0.535` so the repo matches the currently published npm version.
- Regenerated docs per repository workflow; this only removed a trailing blank line in `README.md`.

## Context

The publish workflow had pushed git tags `v0.0.536`, `v0.0.537`, and `v0.0.538` even though npm publish failed. Those bad upstream tags have been deleted, leaving upstream tags synced through `v0.0.535`, which matches npm latest.

## Validation

- `bun scripts/generate-component-types.ts`
- `bun scripts/generate-manual-edits-docs.ts`
- `bun scripts/generate-readme-docs.ts`
- `bun scripts/generate-props-overview.ts`