### PR TITLE
Add force_directed option to schLayout.packPlacementStrategy

### DIFF
--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -80,7 +80,7 @@ export const layoutConfig = z.object({
     ])
     .optional(),
   packPlacementStrategy: z
-    .enum(["shortest_connection_along_outline"])
+    .enum(["shortest_connection_along_outline", "force_directed"])
     .optional(),
 
   padding: length.optional(),
@@ -132,7 +132,7 @@ export interface LayoutConfig {
     | "largest_to_smallest"
     | "first_to_last"
     | "highest_to_lowest_pin_count"
-  packPlacementStrategy?: "shortest_connection_along_outline"
+  packPlacementStrategy?: "shortest_connection_along_outline" | "force_directed"
 
   padding?: Distance
   paddingLeft?: Distance


### PR DESCRIPTION
## Summary

Adds `"force_directed"` to the `schLayout.packPlacementStrategy` enum (both the zod schema and the `LayoutConfig` type). This lets a board or group opt into the analytical force-directed schematic packer, which fixes the O(n³) greedy slowdown behind tscircuit/tscircuit#3208.

Type-only and additive. The existing `"shortest_connection_along_outline"` value and the default behavior are unchanged.

Part of tscircuit/tscircuit#3208. The `core` PR reads this prop and passes it to matchpack; the packer itself lives in the `matchpack` and `calculate-packing` PRs.
