### PR TITLE
Add schematic section title font size prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1584,6 +1584,7 @@ export interface SchematicRowProps {
 export interface SchematicSectionProps {
   displayName?: string;
   name: string;
+  sectionTitleFontSize?: number | string;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -3498,10 +3498,12 @@ export interface SchematicRowProps {
 export interface SchematicSectionProps {
   displayName?: string
   name: string
+  sectionTitleFontSize?: number | string
 }
 export const schematicSectionProps = z.object({
   displayName: z.string().optional(),
   name: z.string(),
+  sectionTitleFontSize: distance.optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1951,6 +1951,7 @@ export interface SchematicRowProps {
 export interface SchematicSectionProps {
   displayName?: string
   name: string
+  sectionTitleFontSize?: number | string
 }
 
 

--- a/lib/components/schematic-section.ts
+++ b/lib/components/schematic-section.ts
@@ -1,14 +1,17 @@
+import { distance } from "circuit-json"
 import { z } from "zod"
 import { expectTypesMatch } from "lib/typecheck"
 
 export interface SchematicSectionProps {
   displayName?: string
   name: string
+  sectionTitleFontSize?: number | string
 }
 
 export const schematicSectionProps = z.object({
   displayName: z.string().optional(),
   name: z.string(),
+  sectionTitleFontSize: distance.optional(),
 })
 
 export type InferredSchematicSectionProps = z.input<


### PR DESCRIPTION
## Summary

Adds an optional `sectionTitleFontSize` prop to `<schematicsection />`, allowing callers to configure schematic section title sizing.

## Changes

- Added `sectionTitleFontSize?: number | string` to `SchematicSectionProps`
- Added `sectionTitleFontSize: distance.optional()` to `schematicSectionProps`
- Regenerated component type and props documentation

## Validation

- `bun scripts/generate-component-types.ts`
- `bun scripts/generate-manual-edits-docs.ts`
- `bun scripts/generate-readme-docs.ts`
- `bun scripts/generate-props-overview.ts`
- `bunx tsc --noEmit`
- `bun run format:check`