### PR TITLE
Add dash length and gap props for schematic line and path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1527,6 +1527,8 @@ export interface SchematicLineProps {
   strokeWidth?: Distance;
   color?: string;
   isDashed?: boolean;
+  dashLength?: Distance;
+  dashGap?: Distance;
 }
 ```
 
@@ -1540,6 +1542,8 @@ export interface SchematicPathProps {
   svgPath?: string;
   strokeWidth?: Distance;
   strokeColor?: string;
+  dashLength?: Distance;
+  dashGap?: Distance;
   isFilled?: boolean;
   fillColor?: string;
 }

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -3415,6 +3415,8 @@ export const schematicLineProps = z.object({
   strokeWidth: distance.optional(),
   color: z.string().optional(),
   isDashed: z.boolean().optional().default(false),
+  dashLength: distance.optional(),
+  dashGap: distance.optional(),
 })
 export interface SchematicLineProps {
   x1: Distance
@@ -3424,6 +3426,8 @@ export interface SchematicLineProps {
   strokeWidth?: Distance
   color?: string
   isDashed?: boolean
+  dashLength?: Distance
+  dashGap?: Distance
 }
 ```
 
@@ -3435,6 +3439,8 @@ export const schematicPathProps = z.object({
   svgPath: z.string().optional(),
   strokeWidth: distance.optional(),
   strokeColor: z.string().optional(),
+  dashLength: distance.optional(),
+  dashGap: distance.optional(),
   isFilled: z.boolean().optional().default(false),
   fillColor: z.string().optional(),
 })
@@ -3443,6 +3449,8 @@ export interface SchematicPathProps {
   svgPath?: string
   strokeWidth?: Distance
   strokeColor?: string
+  dashLength?: Distance
+  dashGap?: Distance
   isFilled?: boolean
   fillColor?: string
 }

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1890,6 +1890,8 @@ export interface SchematicLineProps {
   strokeWidth?: Distance
   color?: string
   isDashed?: boolean
+  dashLength?: Distance
+  dashGap?: Distance
 }
 
 
@@ -1898,6 +1900,8 @@ export interface SchematicPathProps {
   svgPath?: string
   strokeWidth?: Distance
   strokeColor?: string
+  dashLength?: Distance
+  dashGap?: Distance
   isFilled?: boolean
   fillColor?: string
 }

--- a/lib/components/schematic-line.ts
+++ b/lib/components/schematic-line.ts
@@ -11,6 +11,8 @@ export const schematicLineProps = z.object({
   strokeWidth: distance.optional(),
   color: z.string().optional(),
   isDashed: z.boolean().optional().default(false),
+  dashLength: distance.optional(),
+  dashGap: distance.optional(),
 })
 
 export interface SchematicLineProps {
@@ -21,6 +23,8 @@ export interface SchematicLineProps {
   strokeWidth?: Distance
   color?: string
   isDashed?: boolean
+  dashLength?: Distance
+  dashGap?: Distance
 }
 
 export type InferredSchematicLineProps = z.input<typeof schematicLineProps>

--- a/lib/components/schematic-path.ts
+++ b/lib/components/schematic-path.ts
@@ -9,6 +9,8 @@ export const schematicPathProps = z.object({
   svgPath: z.string().optional(),
   strokeWidth: distance.optional(),
   strokeColor: z.string().optional(),
+  dashLength: distance.optional(),
+  dashGap: distance.optional(),
   isFilled: z.boolean().optional().default(false),
   fillColor: z.string().optional(),
 })
@@ -18,6 +20,8 @@ export interface SchematicPathProps {
   svgPath?: string
   strokeWidth?: Distance
   strokeColor?: string
+  dashLength?: Distance
+  dashGap?: Distance
   isFilled?: boolean
   fillColor?: string
 }

--- a/tests/schematic-line.test.ts
+++ b/tests/schematic-line.test.ts
@@ -28,9 +28,13 @@ test("schematic line accepts style overrides", () => {
     strokeWidth: "0.05in",
     color: "#123456",
     isDashed: true,
+    dashLength: "2mm",
+    dashGap: "1mm",
   })
 
   expect(parsed.strokeWidth).toBeGreaterThan(0)
   expect(parsed.color).toBe("#123456")
   expect(parsed.isDashed).toBe(true)
+  expect(parsed.dashLength).toBe(2)
+  expect(parsed.dashGap).toBe(1)
 })

--- a/tests/schematic-path.test.ts
+++ b/tests/schematic-path.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test"
+import {
+  schematicPathProps,
+  type SchematicPathProps,
+} from "lib/components/schematic-path"
+
+test("schematic path accepts dash distance parameters", () => {
+  const parsed = schematicPathProps.parse({
+    points: [
+      { x: 0, y: 0 },
+      { x: 5, y: 5 },
+    ],
+    strokeWidth: "0.1mm",
+    strokeColor: "#123456",
+    dashLength: "2mm",
+    dashGap: "1mm",
+  } satisfies SchematicPathProps)
+
+  expect(parsed.strokeWidth).toBeCloseTo(0.1)
+  expect(parsed.strokeColor).toBe("#123456")
+  expect(parsed.dashLength).toBe(2)
+  expect(parsed.dashGap).toBe(1)
+  expect(parsed.isFilled).toBe(false)
+})


### PR DESCRIPTION
## What changed

Adds `dashLength` and `dashGap` support to `<schematicline />` and `<schematicpath />`, matching the existing `dash_length` and `dash_gap` fields in `circuit-json`.

## Why

`circuit-json` already models dash length and gap for schematic lines and paths, but `@tscircuit/props` did not expose corresponding JSX props. This lets consumers configure schematic dash patterns through props instead of being limited to the default dashed behavior.

## Validation

- `bun test tests/schematic-line.test.ts tests/schematic-path.test.ts`
- `bunx tsc --noEmit`
- `bun scripts/generate-component-types.ts`
- `bun scripts/generate-manual-edits-docs.ts`
- `bun scripts/generate-readme-docs.ts`
- `bun scripts/generate-props-overview.ts`
- `bun run format:check lib/components/schematic-line.ts lib/components/schematic-path.ts tests/schematic-line.test.ts tests/schematic-path.test.ts`