### PR TITLE
remove unsupported cornerRadius property from PcbNoteRectProps and related components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1212,7 +1212,6 @@ export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   hasStroke?: boolean;
   isStrokeDashed?: boolean;
   color?: string;
-  cornerRadius?: string | number;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1649,7 +1649,6 @@ export const fabricationNoteRectProps = pcbLayoutProps
     hasStroke: z.boolean().optional(),
     isStrokeDashed: z.boolean().optional(),
     color: z.string().optional(),
-    cornerRadius: distance.optional(),
   })
 ```
 
@@ -2797,7 +2796,6 @@ export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   hasStroke?: boolean
   isStrokeDashed?: boolean
   color?: string
-  cornerRadius?: string | number
 }
 export const pcbNoteRectProps = pcbLayoutProps
   .omit({ pcbRotation: true })
@@ -2809,7 +2807,6 @@ export const pcbNoteRectProps = pcbLayoutProps
     hasStroke: z.boolean().optional(),
     isStrokeDashed: z.boolean().optional(),
     color: z.string().optional(),
-    cornerRadius: distance.optional(),
   })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1379,7 +1379,6 @@ export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   hasStroke?: boolean
   isStrokeDashed?: boolean
   color?: string
-  cornerRadius?: string | number
 }
 
 

--- a/lib/components/fabrication-note-rect.ts
+++ b/lib/components/fabrication-note-rect.ts
@@ -12,6 +12,5 @@ export const fabricationNoteRectProps = pcbLayoutProps
     hasStroke: z.boolean().optional(),
     isStrokeDashed: z.boolean().optional(),
     color: z.string().optional(),
-    cornerRadius: distance.optional(),
   })
 export type FabricationNoteRectProps = z.input<typeof fabricationNoteRectProps>

--- a/lib/components/pcb-note-rect.ts
+++ b/lib/components/pcb-note-rect.ts
@@ -11,7 +11,6 @@ export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   hasStroke?: boolean
   isStrokeDashed?: boolean
   color?: string
-  cornerRadius?: string | number
 }
 
 export const pcbNoteRectProps = pcbLayoutProps
@@ -24,7 +23,6 @@ export const pcbNoteRectProps = pcbLayoutProps
     hasStroke: z.boolean().optional(),
     isStrokeDashed: z.boolean().optional(),
     color: z.string().optional(),
-    cornerRadius: distance.optional(),
   })
 
 expectTypesMatch<PcbNoteRectProps, z.input<typeof pcbNoteRectProps>>(true)


### PR DESCRIPTION
This pull request removes the `cornerRadius` property from the `PcbNoteRectProps` and `FabricationNoteRectProps` interfaces and their associated schemas. This means rectangular note components no longer support specifying a corner radius.

**Removal of `cornerRadius` support:**

* Removed the `cornerRadius` property from the `PcbNoteRectProps` interface in both `README.md` and `lib/components/pcb-note-rect.ts`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1215) [[2]](diffhunk://#diff-36c4ac05b7b8962fe929f32031646e35feb3f055159bdb7006f8869ef96a4973L14)
* Removed the `cornerRadius` property from the Zod schemas in `pcb-note-rect.ts` and `fabrication-note-rect.ts`, as well as from the `FabricationNoteRectProps` type. [[1]](diffhunk://#diff-36c4ac05b7b8962fe929f32031646e35feb3f055159bdb7006f8869ef96a4973L27) [[2]](diffhunk://#diff-b53634423c13fe30e4e1a587a47742db8217229b077ad8226223c2c19afd853bL15)