### PR TITLE
add oval hole interface and corresponding tests

### DIFF
--- a/lib/components/hole.ts
+++ b/lib/components/hole.ts
@@ -21,6 +21,15 @@ export interface PillHoleProps extends PcbLayoutProps {
   coveredWithSolderMask?: boolean
 }
 
+export interface OvalHoleProps extends PcbLayoutProps {
+  name?: string
+  shape: "oval"
+  width: Distance
+  height: Distance
+  solderMaskMargin?: Distance
+  coveredWithSolderMask?: boolean
+}
+
 export interface RectHoleProps extends PcbLayoutProps {
   name?: string
   shape: "rect"
@@ -30,7 +39,11 @@ export interface RectHoleProps extends PcbLayoutProps {
   coveredWithSolderMask?: boolean
 }
 
-export type HoleProps = CircleHoleProps | PillHoleProps | RectHoleProps
+export type HoleProps =
+  | CircleHoleProps
+  | PillHoleProps
+  | OvalHoleProps
+  | RectHoleProps
 
 const circleHoleProps = pcbLayoutProps
   .extend({
@@ -56,6 +69,15 @@ const pillHoleProps = pcbLayoutProps.extend({
   coveredWithSolderMask: z.boolean().optional(),
 })
 
+const ovalHoleProps = pcbLayoutProps.extend({
+  name: z.string().optional(),
+  shape: z.literal("oval"),
+  width: distance,
+  height: distance,
+  solderMaskMargin: distance.optional(),
+  coveredWithSolderMask: z.boolean().optional(),
+})
+
 const rectHoleProps = pcbLayoutProps.extend({
   name: z.string().optional(),
   shape: z.literal("rect"),
@@ -68,6 +90,7 @@ const rectHoleProps = pcbLayoutProps.extend({
 export const holeProps = z.union([
   circleHoleProps,
   pillHoleProps,
+  ovalHoleProps,
   rectHoleProps,
 ])
 

--- a/tests/hole.test.ts
+++ b/tests/hole.test.ts
@@ -43,6 +43,27 @@ test("pill holes require width and height", () => {
   }
 })
 
+test("oval holes require width and height", () => {
+  const raw: HoleProps = {
+    shape: "oval",
+    width: "4mm",
+    height: "1.5mm",
+    name: "slot",
+  }
+
+  expectTypeOf(raw).toMatchTypeOf<z.input<typeof holeProps>>()
+
+  const parsed = holeProps.parse(raw)
+
+  if (parsed.shape === "oval") {
+    expect(parsed.width).toBe(4)
+    expect(parsed.height).toBe(1.5)
+    expect(parsed.name).toBe("slot")
+  } else {
+    throw new Error("Expected oval hole props")
+  }
+})
+
 test("pill holes without required dimensions throw", () => {
   const raw = {
     shape: "pill",


### PR DESCRIPTION
This pull request adds support for a new "oval" hole type to the PCB layout components. The main changes involve defining the new `OvalHoleProps` interface, updating type unions and validation schemas, and adding tests to ensure correct behavior.

<img width="842" height="743" alt="image" src="https://github.com/user-attachments/assets/fe53aa3c-8e7b-4786-a8b3-e6ef3c75df87" />

already supported in 3d viewer and circuit-json

**Support for Oval Hole Type:**

* Added a new `OvalHoleProps` interface, including properties such as `name`, `shape`, `width`, `height`, `solderMaskMargin`, and `coveredWithSolderMask` to `hole.ts`.
* Updated the `HoleProps` union type to include `OvalHoleProps`, allowing oval holes to be used wherever holes are accepted.
* Created a new Zod validation schema `ovalHoleProps` for oval holes and included it in the overall `holeProps` union schema. [[1]](diffhunk://#diff-593282b1e603b489c377e9f4f2a22b99d3a40db60a341bcc9a36110afc1a22a4R72-R80) [[2]](diffhunk://#diff-593282b1e603b489c377e9f4f2a22b99d3a40db60a341bcc9a36110afc1a22a4R93)

**Testing:**

* Added a test to verify that oval holes require `width` and `height`, and that the properties are parsed and typed correctly.