### PR TITLE
Require padDiameter on fiducial props

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ export interface FabricationNoteTextProps extends PcbLayoutProps {
 ```ts
 export interface FiducialProps extends CommonComponentProps {
   soldermaskPullback?: Distance;
-  padDiameter?: Distance;
+  padDiameter: Distance;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1725,11 +1725,11 @@ export const fabricationNoteTextProps = pcbLayoutProps.extend({
 ```typescript
 export interface FiducialProps extends CommonComponentProps {
   soldermaskPullback?: Distance
-  padDiameter?: Distance
+  padDiameter: Distance
 }
 export const fiducialProps = commonComponentProps.extend({
   soldermaskPullback: distance.optional(),
-  padDiameter: distance.optional(),
+  padDiameter: distance,
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -809,7 +809,7 @@ export interface FabricationNoteTextProps extends PcbLayoutProps {
 
 export interface FiducialProps extends CommonComponentProps {
   soldermaskPullback?: Distance
-  padDiameter?: Distance
+  padDiameter: Distance
 }
 
 

--- a/lib/components/fiducial.ts
+++ b/lib/components/fiducial.ts
@@ -8,12 +8,12 @@ import { z } from "zod"
 
 export interface FiducialProps extends CommonComponentProps {
   soldermaskPullback?: Distance
-  padDiameter?: Distance
+  padDiameter: Distance
 }
 
 export const fiducialProps = commonComponentProps.extend({
   soldermaskPullback: distance.optional(),
-  padDiameter: distance.optional(),
+  padDiameter: distance,
 })
 
 type InferredFiducialProps = z.input<typeof fiducialProps>


### PR DESCRIPTION
## Summary
Make `padDiameter` required for `fiducial` at both the TypeScript and runtime schema levels.

## Why
A fiducial without a pad diameter is incomplete, and the previous optional typing allowed invalid prop shapes to pass through.

## Impact
- Tightens the fiducial prop contract
- Prevents incomplete fiducial definitions at parse time
- Keeps the checked-in generated docs in sync with the source schema

## Validation
- Ran `bun scripts/generate-component-types.ts`
- Ran `bun scripts/generate-manual-edits-docs.ts`
- Ran `bun scripts/generate-readme-docs.ts`
- Ran `bun scripts/generate-props-overview.ts`
- Ran `bunx tsc --noEmit`
