### PR TITLE
swap transistor base and collector pin mapping

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -4144,9 +4144,9 @@ export const transistorPins = [
   "pin1",
   "emitter",
   "pin2",
-  "collector",
-  "pin3",
   "base",
+  "pin3",
+  "collector",
 ] as const
 ```
 

--- a/lib/components/transistor.ts
+++ b/lib/components/transistor.ts
@@ -35,9 +35,9 @@ export const transistorPins = [
   "pin1",
   "emitter",
   "pin2",
-  "collector",
-  "pin3",
   "base",
+  "pin3",
+  "collector",
 ] as const
 export type TransistorPinLabels = (typeof transistorPins)[number]
 


### PR DESCRIPTION

  ## Summary

  Fix the built-in transistor pin mapping so the generic numbered pins match the intended BJT ordering:

  - `pin1` -> `emitter`
  - `pin2` -> `base`
  - `pin3` -> `collector`

  This updates the source definition in `lib/components/transistor.ts` and regenerates the derived component type documentation in `generated/COMPONENT_TYPES.md`.

  ## Why

  The previous mapping assigned:

  - `pin2` -> `collector`
  - `pin3` -> `base`

  That caused numbered transistor connections to resolve to the wrong semantic pins, which can lead to incorrect schematic intent and mismatched downstream behavior when users rely on `pin1`/`pin2`/
  `pin3` instead of named pins.

  ## Impact

  - Corrects transistor data modeling for numbered pin usage
  - Makes numbered transistor connections align with the intended BJT pin semantics
  - Keeps generated component type docs in sync with the source definition