### PR TITLE
Set transistor pin aliases to collector base emitter

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -4144,9 +4144,9 @@ export const transistorPins = [
   "pin1",
   "emitter",
   "pin2",
-  "collector",
-  "pin3",
   "base",
+  "pin3",
+  "collector",
 ] as const
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -4142,11 +4142,11 @@ export const transistorProps = commonComponentProps.extend({
 })
 export const transistorPins = [
   "pin1",
-  "emitter",
+  "collector",
   "pin2",
   "base",
   "pin3",
-  "collector",
+  "emitter",
 ] as const
 ```
 

--- a/lib/components/transistor.ts
+++ b/lib/components/transistor.ts
@@ -33,11 +33,11 @@ export const transistorProps = commonComponentProps.extend({
 
 export const transistorPins = [
   "pin1",
-  "emitter",
+  "collector",
   "pin2",
   "base",
   "pin3",
-  "collector",
+  "emitter",
 ] as const
 export type TransistorPinLabels = (typeof transistorPins)[number]
 

--- a/lib/components/transistor.ts
+++ b/lib/components/transistor.ts
@@ -35,9 +35,9 @@ export const transistorPins = [
   "pin1",
   "emitter",
   "pin2",
-  "collector",
-  "pin3",
   "base",
+  "pin3",
+  "collector",
 ] as const
 export type TransistorPinLabels = (typeof transistorPins)[number]
 

--- a/tests/transistor.test.ts
+++ b/tests/transistor.test.ts
@@ -44,13 +44,13 @@ test("should enforce correct types for transistor props", () => {
   expectTypeOf(rawProps).toMatchTypeOf<TransistorProps>()
 })
 
-test("should map transistor pin aliases to emitter base collector", () => {
+test("should map transistor pin aliases to collector base emitter", () => {
   expect(transistorPins).toEqual([
     "pin1",
-    "emitter",
+    "collector",
     "pin2",
     "base",
     "pin3",
-    "collector",
+    "emitter",
   ])
 })

--- a/tests/transistor.test.ts
+++ b/tests/transistor.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
 import {
+  transistorPins,
   transistorProps,
   type TransistorProps,
 } from "../lib/components/transistor"
@@ -41,4 +42,15 @@ test("should enforce correct types for transistor props", () => {
   }
 
   expectTypeOf(rawProps).toMatchTypeOf<TransistorProps>()
+})
+
+test("should map transistor pin aliases to emitter base collector", () => {
+  expect(transistorPins).toEqual([
+    "pin1",
+    "emitter",
+    "pin2",
+    "base",
+    "pin3",
+    "collector",
+  ])
 })


### PR DESCRIPTION
## Summary

Updates the transistor pin alias mapping in the props model.

After this change:
- `pin1` resolves to `collector`
- `pin2` resolves to `base`
- `pin3` resolves to `emitter`

<img width="724" height="424" alt="image" src="https://github.com/user-attachments/assets/48badbf9-465c-4d3b-92d8-e8b086571012" />

## Why this matters

This keeps transistor pin aliasing explicit and consistent for component connectivity and downstream consumers that rely on the props pin definitions.

## What changed

- Updated the transistor pin alias order in `lib/components/transistor.ts`
- Updated the regression test covering the expected collector/base/emitter mapping
- Regenerated generated docs to keep published artifacts in sync

## Verification

- Ran: `bun test tests/transistor.test.ts`
- Regenerated:
  - `bun scripts/generate-component-types.ts`
  - `bun scripts/generate-manual-edits-docs.ts`
  - `bun scripts/generate-readme-docs.ts`
  - `bun scripts/generate-props-overview.ts`