### PR TITLE
Add pcbComb trace prop

### DIFF
--- a/lib/components/trace.ts
+++ b/lib/components/trace.ts
@@ -55,6 +55,12 @@ const baseTraceProps = z.object({
     .boolean()
     .optional()
     .describe("Draw a straight pcb trace between the connected points"),
+  pcbComb: z
+    .enum(["columnToColumn", "rowToColumn", "columnToRow", "rowToRow"])
+    .optional()
+    .describe(
+      "Draw a fixed straight → 45° → straight comb trace between the connected pads; the value is <sourceLine>To<targetLine> (a COLUMN of pads escapes perpendicular in x, a ROW in y)",
+    ),
   schDisplayLabel: z.string().optional(),
   schStroke: z.string().optional(),
   highlightColor: z.string().optional(),


### PR DESCRIPTION
Adds a `pcbComb` field to `traceProps` — a sibling to `pcbStraightLine` / `pcbPath` for a *fixed, manually-shaped* trace between two lines of pads. The value is an orientation: `columnToColumn | rowToColumn | columnToRow | rowToRow`.

Schema only. The geometry — a perpendicular escape → 45° diagonal → perpendicular landing, so a bundle nests into an even comb — is implemented in the companion core PR **tscircuit/core#2567**, which carries the context, a worked visual example, and (honestly) our uncertainty about how common the case is.

Offered for your consideration.