### PR TITLE
Add MOSFET connections support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1031,6 +1031,7 @@ export interface MosfetProps<
 > extends CommonComponentProps<PinLabel> {
   channelType: "n" | "p";
   mosfetMode: "enhancement" | "depletion";
+  connections?: Connections<MosfetPinLabels>;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2511,15 +2511,6 @@ export const ledProps = commonComponentProps.extend({
 ### mosfet
 
 ```typescript
-export interface MosfetProps<PinLabel extends string = string>
-  extends CommonComponentProps<PinLabel> {
-  channelType: "n" | "p"
-  mosfetMode: "enhancement" | "depletion"
-}
-export const mosfetProps = commonComponentProps.extend({
-  channelType: z.enum(["n", "p"]),
-  mosfetMode: z.enum(["enhancement", "depletion"]),
-})
 export const mosfetPins = [
   "pin1",
   "drain",
@@ -2528,6 +2519,17 @@ export const mosfetPins = [
   "pin3",
   "gate",
 ] as const
+export interface MosfetProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
+  channelType: "n" | "p"
+  mosfetMode: "enhancement" | "depletion"
+  connections?: Connections<MosfetPinLabels>
+}
+export const mosfetProps = commonComponentProps.extend({
+  channelType: z.enum(["n", "p"]),
+  mosfetMode: z.enum(["enhancement", "depletion"]),
+  connections: createConnectionsProp(mosfetPins).optional(),
+})
 ```
 
 ### mountedboard

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1188,6 +1188,7 @@ export interface MosfetProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   channelType: "n" | "p"
   mosfetMode: "enhancement" | "depletion"
+  connections?: Connections<MosfetPinLabels>
 }
 
 

--- a/lib/components/mosfet.ts
+++ b/lib/components/mosfet.ts
@@ -2,19 +2,10 @@ import {
   type CommonComponentProps,
   commonComponentProps,
 } from "../common/layout"
+import { createConnectionsProp } from "../common/connectionsProp"
 import { expectTypesMatch } from "../typecheck"
+import type { Connections } from "../utility-types/connections-and-selectors"
 import { z } from "zod"
-
-export interface MosfetProps<PinLabel extends string = string>
-  extends CommonComponentProps<PinLabel> {
-  channelType: "n" | "p"
-  mosfetMode: "enhancement" | "depletion"
-}
-
-export const mosfetProps = commonComponentProps.extend({
-  channelType: z.enum(["n", "p"]),
-  mosfetMode: z.enum(["enhancement", "depletion"]),
-})
 
 export const mosfetPins = [
   "pin1",
@@ -25,6 +16,19 @@ export const mosfetPins = [
   "gate",
 ] as const
 export type MosfetPinLabels = (typeof mosfetPins)[number]
+
+export interface MosfetProps<PinLabel extends string = string>
+  extends CommonComponentProps<PinLabel> {
+  channelType: "n" | "p"
+  mosfetMode: "enhancement" | "depletion"
+  connections?: Connections<MosfetPinLabels>
+}
+
+export const mosfetProps = commonComponentProps.extend({
+  channelType: z.enum(["n", "p"]),
+  mosfetMode: z.enum(["enhancement", "depletion"]),
+  connections: createConnectionsProp(mosfetPins).optional(),
+})
 
 type InferredMosfetProps = z.input<typeof mosfetProps>
 expectTypesMatch<MosfetProps, InferredMosfetProps>(true)

--- a/tests/mosfet.test.ts
+++ b/tests/mosfet.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
 import { mosfetProps, type MosfetProps } from "../lib/components/mosfet"
+import { z } from "zod"
 
 test("should parse mosfet props for n channel type and enhancement mode", () => {
   const rawProps: MosfetProps = {
@@ -30,4 +31,67 @@ test("should fail to parse mosfet with invalid channelType", () => {
     mosfetMode: "N/A",
   }
   expect(() => mosfetProps.parse(rawProps)).toThrow()
+})
+
+test("should parse mosfet props with connections", () => {
+  const rawProps: MosfetProps = {
+    name: "M1",
+    channelType: "n",
+    mosfetMode: "enhancement",
+    connections: {
+      gate: "net.GATE",
+      drain: ["net.DRAIN", "net.SENSE"],
+      source: "net.GND",
+    },
+  }
+
+  const parsedProps = mosfetProps.parse(rawProps)
+
+  expect(parsedProps.connections).toEqual({
+    gate: "net.GATE",
+    drain: ["net.DRAIN", "net.SENSE"],
+    source: "net.GND",
+  })
+})
+
+test("should parse mosfet connections using pin aliases", () => {
+  const rawProps: MosfetProps = {
+    name: "M1",
+    channelType: "p",
+    mosfetMode: "depletion",
+    connections: {
+      pin1: "net.DRAIN",
+      pin2: "net.SOURCE",
+      pin3: "net.GATE",
+    },
+  }
+
+  const parsedProps = mosfetProps.parse(rawProps)
+
+  expect(parsedProps.connections).toEqual(rawProps.connections)
+})
+
+test("should reject mosfet connections with invalid keys", () => {
+  expect(() =>
+    mosfetProps.parse({
+      name: "M1",
+      channelType: "n",
+      mosfetMode: "enhancement",
+      connections: {
+        invalid: "net.INVALID",
+      },
+    }),
+  ).toThrow(z.ZodError)
+})
+
+test("should allow optional mosfet connections", () => {
+  const rawProps: MosfetProps = {
+    name: "M1",
+    channelType: "n",
+    mosfetMode: "enhancement",
+  }
+
+  const parsedProps = mosfetProps.parse(rawProps)
+
+  expect(parsedProps.connections).toBeUndefined()
 })


### PR DESCRIPTION
## Summary

- add typed `connections` support to `MosfetProps`
- validate drain, source, gate, and numbered pin aliases
- add tests and regenerate props documentation

## Testing

- `bun test`
- `bun run typecheck`
- `bun run build`
- `bun run format:check`