### PR TITLE
Add crystal maxTraceLength prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,8 @@ export interface CrystalProps<
 > extends CommonComponentProps<PinLabel> {
   frequency: number | string;
   loadCapacitance: number | string;
+  /** Maximum allowed PCB trace length between the crystal and its connected component */
+  maxTraceLength?: number | string;
   manufacturerPartNumber?: string;
   mpn?: string;
   pinVariant?: PinVariant;

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1459,15 +1459,18 @@ export interface CrystalProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   frequency: number | string
   loadCapacitance: number | string
+  maxTraceLength?: number | string
   manufacturerPartNumber?: string
   mpn?: string
   pinVariant?: PinVariant
   schOrientation?: SchematicOrientation
   connections?: Connections<CrystalPinLabels>
 }
+/** Maximum allowed PCB trace length between the crystal and its connected component */
 export const crystalProps = commonComponentProps.extend({
   frequency: frequency,
   loadCapacitance: capacitance,
+  maxTraceLength: distance.optional(),
   manufacturerPartNumber: z.string().optional(),
   mpn: z.string().optional(),
   pinVariant: z.enum(["two_pin", "four_pin"]).optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -655,6 +655,8 @@ export interface CrystalProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   frequency: number | string
   loadCapacitance: number | string
+  /** Maximum allowed PCB trace length between the crystal and its connected component */
+  maxTraceLength?: number | string
   manufacturerPartNumber?: string
   mpn?: string
   pinVariant?: PinVariant

--- a/lib/components/crystal.ts
+++ b/lib/components/crystal.ts
@@ -1,16 +1,16 @@
-import { frequency, capacitance } from "circuit-json"
+import { capacitance, distance, frequency } from "circuit-json"
+import { createConnectionsProp } from "lib/common/connectionsProp"
 import {
   type CommonComponentProps,
   commonComponentProps,
   lrPins,
 } from "lib/common/layout"
-import type { Connections } from "lib/utility-types/connections-and-selectors"
-import { createConnectionsProp } from "lib/common/connectionsProp"
 import {
-  schematicOrientation,
   type SchematicOrientation,
+  schematicOrientation,
 } from "lib/common/schematicOrientation"
 import { expectTypesMatch } from "lib/typecheck"
+import type { Connections } from "lib/utility-types/connections-and-selectors"
 import { z } from "zod"
 
 export type PinVariant = "two_pin" | "four_pin"
@@ -22,6 +22,8 @@ export interface CrystalProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   frequency: number | string
   loadCapacitance: number | string
+  /** Maximum allowed PCB trace length between the crystal and its connected component */
+  maxTraceLength?: number | string
   manufacturerPartNumber?: string
   mpn?: string
   pinVariant?: PinVariant
@@ -32,6 +34,7 @@ export interface CrystalProps<PinLabel extends string = string>
 export const crystalProps = commonComponentProps.extend({
   frequency: frequency,
   loadCapacitance: capacitance,
+  maxTraceLength: distance.optional(),
   manufacturerPartNumber: z.string().optional(),
   mpn: z.string().optional(),
   pinVariant: z.enum(["two_pin", "four_pin"]).optional(),

--- a/tests/crystal.test.ts
+++ b/tests/crystal.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test"
-import { crystalProps, type CrystalProps } from "../lib/components/crystal"
-import type { z } from "zod"
 import { expectTypeOf } from "expect-type"
+import type { z } from "zod"
+import { type CrystalProps, crystalProps } from "../lib/components/crystal"
 
 test("should parse crystal props with 2pin variant", () => {
   const rawProps: CrystalProps = {
@@ -28,6 +28,19 @@ test("should parse manufacturerPartNumber and mpn", () => {
 
   expect(parsedProps.manufacturerPartNumber).toBe("1234")
   expect(parsedProps.mpn).toBe("5678")
+})
+
+test("should parse maxTraceLength", () => {
+  const rawProps: CrystalProps = {
+    name: "crystal",
+    frequency: "16MHz",
+    loadCapacitance: "20pF",
+    maxTraceLength: "10mm",
+  }
+
+  const parsedProps = crystalProps.parse(rawProps)
+
+  expect(parsedProps.maxTraceLength).toBe(10)
 })
 
 test("should parse crystal props with 4pin variant", () => {


### PR DESCRIPTION
## Summary

- add an optional `maxTraceLength` property to `CrystalProps`
- parse the property as a unit-aware distance, normalizing values to millimeters
- add focused test coverage and regenerate the public API documentation

## Why

Crystal authors need a component-level constraint for the maximum PCB trace length between a crystal and its connected component.

## Impact

Users can now specify values such as `maxTraceLength="10mm"` or a numeric millimeter value on `<crystal />`.

## Validation

- `bun test` (348 passing)
- `bun run typecheck`
- `bun run build`
- `bun run format:check`
- generated documentation scripts required by `AGENTS.md`