### PR TITLE
Add simplify autorouter preset

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2090,6 +2090,7 @@ export interface AutorouterConfig {
     | "tscircuit_beta"
     | "krt"
     | "freerouting"
+    | "simplify"
     | "laser_prefab" // Prefabricated PCB with laser copper ablation
     | /** @deprecated Use "auto_jumper" */ "auto-jumper"
     | /** @deprecated Use "sequential_trace" */ "sequential-trace"
@@ -2135,6 +2136,7 @@ export const autorouterConfig = z.object({
       "tscircuit_beta",
       "krt",
       "freerouting",
+      "simplify",
       "laser_prefab",
       "auto-jumper",
       "sequential-trace",

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -66,6 +66,7 @@ export interface AutorouterConfig {
     | "tscircuit_beta"
     | "krt"
     | "freerouting"
+    | "simplify"
     | "laser_prefab" // Prefabricated PCB with laser copper ablation
     | /** @deprecated Use "auto_jumper" */ "auto-jumper"
     | /** @deprecated Use "sequential_trace" */ "sequential-trace"

--- a/lib/components/autoroutingphase.ts
+++ b/lib/components/autoroutingphase.ts
@@ -45,6 +45,17 @@ export const autoroutingPhaseProps = z
     reroute: z.boolean().optional(),
   })
   .superRefine((value, ctx) => {
+    const isSimplifyAutorouter =
+      value.autorouter === "simplify" ||
+      (typeof value.autorouter === "object" &&
+        value.autorouter?.preset === "simplify")
+
+    if (isSimplifyAutorouter && value.reroute !== true) {
+      console.warn(
+        'The "simplify" autorouter preset should only be used with reroute=true',
+      )
+    }
+
     if (
       value.reroute !== undefined &&
       value.region === undefined &&

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -352,6 +352,7 @@ export interface AutorouterConfig {
     | "tscircuit_beta"
     | "krt"
     | "freerouting"
+    | "simplify"
     | "laser_prefab" // Prefabricated PCB with laser copper ablation
     | /** @deprecated Use "auto_jumper" */ "auto-jumper"
     | /** @deprecated Use "sequential_trace" */ "sequential-trace"
@@ -370,6 +371,7 @@ export type AutorouterPreset =
   | "tscircuit_beta"
   | "krt"
   | "freerouting"
+  | "simplify"
   | "laser_prefab"
   | "auto-jumper"
   | "sequential-trace"
@@ -424,6 +426,7 @@ export const autorouterConfig = z.object({
       "tscircuit_beta",
       "krt",
       "freerouting",
+      "simplify",
       "laser_prefab",
       "auto-jumper",
       "sequential-trace",
@@ -445,6 +448,7 @@ export const autorouterPreset = z.union([
   z.literal("tscircuit_beta"),
   z.literal("krt"),
   z.literal("freerouting"),
+  z.literal("simplify"),
   z.literal("laser_prefab"), // Prefabricated PCB with laser copper ablation
   z.literal("auto-jumper"),
   z.literal("sequential-trace"),

--- a/tests/autorouter.test.ts
+++ b/tests/autorouter.test.ts
@@ -11,6 +11,14 @@ test("supports freerouting preset", () => {
   expect(result).toBe("freerouting")
 })
 
+test("supports simplify preset", () => {
+  const result = autorouterProp.parse("simplify")
+  expect(result).toBe("simplify")
+
+  const configResult = autorouterProp.parse({ preset: "simplify" })
+  expect(configResult).toMatchObject({ preset: "simplify" })
+})
+
 test("supports snake_case presets", () => {
   const result = autorouterProp.parse("auto_cloud")
   expect(result).toBe("auto_cloud")

--- a/tests/autoroutingphase.test.ts
+++ b/tests/autoroutingphase.test.ts
@@ -1,10 +1,14 @@
-import { expect, test } from "bun:test"
+import { afterEach, expect, mock, spyOn, test } from "bun:test"
 import { expectTypeOf } from "expect-type"
 import {
   type AutoroutingPhaseProps,
   autoroutingPhaseProps,
 } from "lib/components/autoroutingphase"
 import type { z } from "zod"
+
+afterEach(() => {
+  mock.restore()
+})
 
 test("autorouting phase accepts a name", () => {
   const raw: AutoroutingPhaseProps = {
@@ -83,6 +87,30 @@ test("autorouting phase accepts autorouter config", () => {
     preset: "auto_local",
     traceClearance: 0.2,
   })
+})
+
+test("autorouting phase warns when simplify is used without reroute", () => {
+  const warn = spyOn(console, "warn").mockImplementation(() => {})
+
+  autoroutingPhaseProps.parse({ autorouter: "simplify" })
+  autoroutingPhaseProps.parse({ autorouter: { preset: "simplify" } })
+
+  expect(warn).toHaveBeenCalledTimes(2)
+  expect(warn).toHaveBeenCalledWith(
+    'The "simplify" autorouter preset should only be used with reroute=true',
+  )
+})
+
+test("autorouting phase does not warn when simplify reroutes", () => {
+  const warn = spyOn(console, "warn").mockImplementation(() => {})
+
+  autoroutingPhaseProps.parse({
+    autorouter: "simplify",
+    reroute: true,
+    connection: "U1.pin1",
+  })
+
+  expect(warn).not.toHaveBeenCalled()
 })
 
 test("autorouting phase accepts routing tolerances", () => {


### PR DESCRIPTION
## Summary

- add `simplify` as a supported autorouter preset in both string and config forms
- warn when an autorouting phase uses `simplify` without `reroute=true`
- regenerate checked-in props documentation

## Why

The simplify routing mode operates on existing routes, so using it without rerouting enabled is likely a configuration mistake. The warning keeps the input parseable while making that mismatch visible to developers.

## Validation

- `bun test` (350 tests passed)
- `bun run typecheck`
- `bun run build`
- `bun run format:check`
- `bun run check-circular-deps`
- required documentation generation scripts
- `git diff --check`