### PR TITLE
Add MOSFET symbol port side props

### DIFF
--- a/README.md
+++ b/README.md
@@ -1033,6 +1033,12 @@ export interface MosfetProps<
 > extends CommonComponentProps<PinLabel> {
   channelType: "n" | "p";
   mosfetMode: "enhancement" | "depletion";
+  /** The side of the schematic symbol where the drain port is placed. */
+  symbolDrainSide?: "left" | "right" | "top" | "bottom";
+  /** The side of the schematic symbol where the source port is placed. */
+  symbolSourceSide?: "left" | "right" | "top" | "bottom";
+  /** The side of the schematic symbol where the gate port is placed. */
+  symbolGateSide?: "left" | "right" | "top" | "bottom";
   connections?: Connections<MosfetPinLabels>;
 }
 ```

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2526,11 +2526,18 @@ export interface MosfetProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   channelType: "n" | "p"
   mosfetMode: "enhancement" | "depletion"
+  symbolDrainSide?: "left" | "right" | "top" | "bottom"
+  symbolSourceSide?: "left" | "right" | "top" | "bottom"
+  symbolGateSide?: "left" | "right" | "top" | "bottom"
   connections?: Connections<MosfetPinLabels>
 }
+/** The side of the schematic symbol where the gate port is placed. */
 export const mosfetProps = commonComponentProps.extend({
   channelType: z.enum(["n", "p"]),
   mosfetMode: z.enum(["enhancement", "depletion"]),
+  symbolDrainSide: z.enum(["left", "right", "top", "bottom"]).optional(),
+  symbolSourceSide: z.enum(["left", "right", "top", "bottom"]).optional(),
+  symbolGateSide: z.enum(["left", "right", "top", "bottom"]).optional(),
   connections: createConnectionsProp(mosfetPins).optional(),
 })
 ```

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1190,6 +1190,12 @@ export interface MosfetProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   channelType: "n" | "p"
   mosfetMode: "enhancement" | "depletion"
+  /** The side of the schematic symbol where the drain port is placed. */
+  symbolDrainSide?: "left" | "right" | "top" | "bottom"
+  /** The side of the schematic symbol where the source port is placed. */
+  symbolSourceSide?: "left" | "right" | "top" | "bottom"
+  /** The side of the schematic symbol where the gate port is placed. */
+  symbolGateSide?: "left" | "right" | "top" | "bottom"
   connections?: Connections<MosfetPinLabels>
 }
 

--- a/lib/components/mosfet.ts
+++ b/lib/components/mosfet.ts
@@ -21,12 +21,21 @@ export interface MosfetProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   channelType: "n" | "p"
   mosfetMode: "enhancement" | "depletion"
+  /** The side of the schematic symbol where the drain port is placed. */
+  symbolDrainSide?: "left" | "right" | "top" | "bottom"
+  /** The side of the schematic symbol where the source port is placed. */
+  symbolSourceSide?: "left" | "right" | "top" | "bottom"
+  /** The side of the schematic symbol where the gate port is placed. */
+  symbolGateSide?: "left" | "right" | "top" | "bottom"
   connections?: Connections<MosfetPinLabels>
 }
 
 export const mosfetProps = commonComponentProps.extend({
   channelType: z.enum(["n", "p"]),
   mosfetMode: z.enum(["enhancement", "depletion"]),
+  symbolDrainSide: z.enum(["left", "right", "top", "bottom"]).optional(),
+  symbolSourceSide: z.enum(["left", "right", "top", "bottom"]).optional(),
+  symbolGateSide: z.enum(["left", "right", "top", "bottom"]).optional(),
   connections: createConnectionsProp(mosfetPins).optional(),
 })
 

--- a/tests/mosfet.test.ts
+++ b/tests/mosfet.test.ts
@@ -95,3 +95,31 @@ test("should allow optional mosfet connections", () => {
 
   expect(parsedProps.connections).toBeUndefined()
 })
+
+test("should parse mosfet schematic symbol port sides", () => {
+  const rawProps: MosfetProps = {
+    name: "M1",
+    channelType: "n",
+    mosfetMode: "enhancement",
+    symbolDrainSide: "bottom",
+    symbolSourceSide: "top",
+    symbolGateSide: "right",
+  }
+
+  const parsedProps = mosfetProps.parse(rawProps)
+
+  expect(parsedProps.symbolDrainSide).toBe("bottom")
+  expect(parsedProps.symbolSourceSide).toBe("top")
+  expect(parsedProps.symbolGateSide).toBe("right")
+})
+
+test("should reject invalid mosfet schematic symbol port sides", () => {
+  expect(() =>
+    mosfetProps.parse({
+      name: "M1",
+      channelType: "n",
+      mosfetMode: "enhancement",
+      symbolGateSide: "center",
+    }),
+  ).toThrow(z.ZodError)
+})


### PR DESCRIPTION
## Summary

- add optional `symbolDrainSide`, `symbolSourceSide`, and `symbolGateSide` MOSFET props
- accept `left`, `right`, `top`, or `bottom` for each schematic port position
- update generated prop documentation

## Why

MOSFET schematic rendering needs explicit port-side intent so later renderer changes can support alternative symbol layouts without relying only on whole-symbol rotation.

The props are optional, so existing MOSFET schematics retain their current behavior.

## Validation

- `bun test` (350 tests passed)
- `bun run typecheck`
- `bun run build`
- `bunx biome format lib/components/mosfet.ts tests/mosfet.test.ts --write`
- all four repository-required documentation generators
