### PR TITLE
Reject conflicting netlabel connection props

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2648,15 +2648,16 @@ export interface NetLabelProps {
   schRotation?: number | string
   anchorSide?: "left" | "top" | "right" | "bottom"
 }
-export const netLabelProps = z.object({
-  net: z.string().optional(),
-  connection: z.string().optional(),
-  connectsTo: z.string().or(z.array(z.string())).optional(),
-  schX: distance.optional(),
-  schY: distance.optional(),
-  schRotation: rotation.optional(),
-  anchorSide: z.enum(["left", "top", "right", "bottom"]).optional(),
-})
+export const netLabelProps = z
+  .object({
+    net: z.string().optional(),
+    connection: z.string().optional(),
+    connectsTo: z.string().or(z.array(z.string())).optional(),
+    schX: distance.optional(),
+    schY: distance.optional(),
+    schRotation: rotation.optional(),
+    anchorSide: z.enum(["left", "top", "right", "bottom"]).optional(),
+  })
 ```
 
 ### opamp

--- a/lib/components/netlabel.ts
+++ b/lib/components/netlabel.ts
@@ -13,15 +13,23 @@ export interface NetLabelProps {
   anchorSide?: "left" | "top" | "right" | "bottom"
 }
 
-export const netLabelProps = z.object({
-  net: z.string().optional(),
-  connection: z.string().optional(),
-  connectsTo: z.string().or(z.array(z.string())).optional(),
-  schX: distance.optional(),
-  schY: distance.optional(),
-  schRotation: rotation.optional(),
-  anchorSide: z.enum(["left", "top", "right", "bottom"]).optional(),
-})
+export const netLabelProps = z
+  .object({
+    net: z.string().optional(),
+    connection: z.string().optional(),
+    connectsTo: z.string().or(z.array(z.string())).optional(),
+    schX: distance.optional(),
+    schY: distance.optional(),
+    schRotation: rotation.optional(),
+    anchorSide: z.enum(["left", "top", "right", "bottom"]).optional(),
+  })
+  .refine(
+    (props) => props.net === undefined || props.connection === undefined,
+    {
+      message: "net and connection cannot be provided together",
+      path: ["connection"],
+    },
+  )
 
 type InferredNetLabelProps = z.input<typeof netLabelProps>
 expectTypesMatch<NetLabelProps, InferredNetLabelProps>(true)

--- a/tests/netlabel.test.ts
+++ b/tests/netlabel.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+import { netLabelProps, type NetLabelProps } from "lib/components/netlabel"
+import { z } from "zod"
+
+test("rejects net and connection provided together", () => {
+  const result = netLabelProps.safeParse({
+    net: "DC_IN",
+    connection: "net.A",
+  } satisfies NetLabelProps)
+
+  expect(result.success).toBe(false)
+  if (result.success) return
+
+  expect(result.error).toBeInstanceOf(z.ZodError)
+  expect(result.error.issues).toContainEqual({
+    code: "custom",
+    message: "net and connection cannot be provided together",
+    path: ["connection"],
+  })
+})
+
+test("accepts net with connectsTo", () => {
+  const parsed = netLabelProps.parse({
+    net: "DC_IN",
+    connectsTo: "U1.pin1",
+  } satisfies NetLabelProps)
+
+  expect(parsed).toEqual({
+    net: "DC_IN",
+    connectsTo: "U1.pin1",
+  })
+})
+
+test("continues to parse legacy connection when net is absent", () => {
+  const parsed = netLabelProps.parse({
+    connection: "U1.pin1",
+  } satisfies NetLabelProps)
+
+  expect(parsed).toEqual({
+    connection: "U1.pin1",
+  })
+})


### PR DESCRIPTION
## Summary

- reject `netlabel` props that provide both `net` and the legacy `connection` prop
- keep `net` with `connectsTo` valid for attaching a named net to ports
- keep `connection` parseable when `net` is absent for compatibility
- add schema tests and regenerate the component-types documentation

## Why

`net` and `connection` currently express conflicting ways to identify/connect a net label. Allowing both lets invalid input reach `@tscircuit/core`, where it can create a trace with an unresolved net selector and throw during rendering.

The shared props schema is the correct boundary for this rule. Consumers now receive a Zod issue on the `connection` path with the message `net and connection cannot be provided together`, allowing core to use its normal failed-component/error-placeholder path.

This supports the core regression tracked in [tscircuit/core#2663](https://github.com/tscircuit/core/pull/2663).

## Validation

- `bun test` (356 passed, 0 failed)
- `bun run typecheck`
- `bun run build`
- `bun run format:check`
- `bun run check-circular-deps`
- all required documentation/type generation scripts
- `git diff --check`
