### PR TITLE
fix(crystal): accept pin3 and pin4 connections for four-pin variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,7 +718,11 @@ export type FabricationNoteRectProps = z.input<typeof fabricationNoteRectProps>;
 export interface FabricationNoteTextProps extends PcbLayoutProps {
   text: string;
   anchorAlignment?:
-    "center" | "top_left" | "top_right" | "bottom_left" | "bottom_right";
+    | "center"
+    | "top_left"
+    | "top_right"
+    | "bottom_left"
+    | "bottom_right";
   font?: "tscircuit2024";
   fontSize?: string | number;
   color?: string;
@@ -1284,7 +1288,11 @@ export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
 export interface PcbNoteTextProps extends PcbLayoutProps {
   text: string;
   anchorAlignment?:
-    "center" | "top_left" | "top_right" | "bottom_left" | "bottom_right";
+    | "center"
+    | "top_left"
+    | "top_right"
+    | "bottom_left"
+    | "bottom_right";
   font?: "tscircuit2024";
   fontSize?: string | number;
   color?: string;
@@ -2118,6 +2126,7 @@ export interface PlatformConfig {
 ```
 
 [Source](https://github.com/tscircuit/props/blob/main/lib/platformConfig.ts)
+
 <!-- PLATFORM_CONFIG_END -->
 
 <!-- PROJECT_CONFIG_START -->
@@ -2141,4 +2150,5 @@ export interface ProjectConfig extends Pick<
 ```
 
 [Source](https://github.com/tscircuit/props/blob/main/lib/projectConfig.ts)
+
 <!-- PROJECT_CONFIG_END -->

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1455,6 +1455,14 @@ export const courtyardRectProps = pcbLayoutProps.extend({
 ### crystal
 
 ```typescript
+export const crystalPins = [
+  "pin1",
+  "left",
+  "pin2",
+  "right",
+  "pin3",
+  "pin4",
+] as const
 export interface CrystalProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   frequency: number | string

--- a/lib/components/crystal.ts
+++ b/lib/components/crystal.ts
@@ -3,7 +3,6 @@ import { createConnectionsProp } from "lib/common/connectionsProp"
 import {
   type CommonComponentProps,
   commonComponentProps,
-  lrPins,
 } from "lib/common/layout"
 import {
   type SchematicOrientation,
@@ -15,7 +14,14 @@ import { z } from "zod"
 
 export type PinVariant = "two_pin" | "four_pin"
 
-export const crystalPins = lrPins
+export const crystalPins = [
+  "pin1",
+  "left",
+  "pin2",
+  "right",
+  "pin3",
+  "pin4",
+] as const
 export type CrystalPinLabels = (typeof crystalPins)[number]
 
 export interface CrystalProps<PinLabel extends string = string>

--- a/tests/crystal.test.ts
+++ b/tests/crystal.test.ts
@@ -82,3 +82,26 @@ test("should parse crystal props with connections", () => {
     right: "net.CLK_OUT",
   })
 })
+
+test("should parse four-pin crystal props with numbered connections", () => {
+  const rawProps: CrystalProps = {
+    name: "crystal",
+    frequency: "16MHz",
+    loadCapacitance: "20pF",
+    pinVariant: "four_pin",
+    connections: {
+      pin1: "U1.XIN",
+      pin2: "net.GND",
+      pin3: "U1.XOUT",
+      pin4: "net.GND",
+    },
+  }
+
+  const parsedProps = crystalProps.parse(rawProps)
+  expect(parsedProps.connections).toEqual({
+    pin1: "U1.XIN",
+    pin2: "net.GND",
+    pin3: "U1.XOUT",
+    pin4: "net.GND",
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the crystal connection schema so four-pin crystal variants accept all four numbered pins: `pin1`, `pin2`, `pin3`, and `pin4`.

Previously, `pinVariant="four_pin"` created four runtime ports, but the props schema reused the two-terminal `lrPins` definition. As a result, valid `pin3` and `pin4` connections were rejected during type checking and runtime validation.

## Changes

- Add `pin3` and `pin4` to the supported crystal connection labels
- Preserve the existing `left` and `right` aliases for two-pin crystals
- Add a regression test that parses a four-pin crystal with connections on all four numbered pins
- Regenerate the component type documentation

## Example

```tsx
<crystal
  name="X1"
  frequency="16MHz"
  loadCapacitance="20pF"
  pinVariant="four_pin"
  connections={{
    pin1: "U1.XIN",
    pin2: "net.GND",
    pin3: "U1.XOUT",
    pin4: "net.GND",
  }}
/>
```

## Validation

- All 357 tests pass
- TypeScript typecheck passes
- Biome formatting check passes
- Generated documentation is up to date
