### PR TITLE
Add operating-point simulation props

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,10 +232,11 @@ export interface AmmeterProps<
 ```ts
 export interface AnalogSimulationProps {
   name?: string;
-  simulationType?: "spice_transient_analysis";
+  simulationType?: "spice_dc_operating_point" | "spice_transient_analysis";
   duration?: number | string;
   startTime?: number | string;
   timePerStep?: number | string;
+  timeout?: number | string;
   spiceEngine?: AutocompleteString<"spicey" | "ngspice">;
   spiceOptions?: SpiceOptions;
   graphIndependentAxes?: boolean;
@@ -448,6 +449,12 @@ export interface ChipPropsSU<
    */
   noConnect?: readonly PinLabel[] | PinLabel[];
   connections?: Connections<PinLabel>;
+  /**
+   * Treat this chip as the intentional boundary of an analog simulation.
+   * Defaults to false, allowing an accidentally missing SPICE model to be
+   * reported instead of silently omitting the chip.
+   */
+  simulationBoundary?: boolean;
   spiceModel?: SpiceModelElement;
 }
 ```
@@ -718,11 +725,7 @@ export type FabricationNoteRectProps = z.input<typeof fabricationNoteRectProps>;
 export interface FabricationNoteTextProps extends PcbLayoutProps {
   text: string;
   anchorAlignment?:
-    | "center"
-    | "top_left"
-    | "top_right"
-    | "bottom_left"
-    | "bottom_right";
+    "center" | "top_left" | "top_right" | "bottom_left" | "bottom_right";
   font?: "tscircuit2024";
   fontSize?: string | number;
   color?: string;
@@ -1288,11 +1291,7 @@ export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
 export interface PcbNoteTextProps extends PcbLayoutProps {
   text: string;
   anchorAlignment?:
-    | "center"
-    | "top_left"
-    | "top_right"
-    | "bottom_left"
-    | "bottom_right";
+    "center" | "top_left" | "top_right" | "bottom_left" | "bottom_right";
   font?: "tscircuit2024";
   fontSize?: string | number;
   color?: string;
@@ -2126,7 +2125,6 @@ export interface PlatformConfig {
 ```
 
 [Source](https://github.com/tscircuit/props/blob/main/lib/platformConfig.ts)
-
 <!-- PLATFORM_CONFIG_END -->
 
 <!-- PROJECT_CONFIG_START -->
@@ -2150,5 +2148,4 @@ export interface ProjectConfig extends Pick<
 ```
 
 [Source](https://github.com/tscircuit/props/blob/main/lib/projectConfig.ts)
-
 <!-- PROJECT_CONFIG_END -->

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -902,10 +902,11 @@ export const ammeterProps = commonComponentProps.extend({
 ```typescript
 export interface AnalogSimulationProps {
   name?: string
-  simulationType?: "spice_transient_analysis"
+  simulationType?: "spice_dc_operating_point" | "spice_transient_analysis"
   duration?: number | string
   startTime?: number | string
   timePerStep?: number | string
+  timeout?: number | string
   spiceEngine?: AutocompleteString<"spicey" | "ngspice">
   spiceOptions?: SpiceOptions
   graphIndependentAxes?: boolean
@@ -919,11 +920,12 @@ export interface SpiceOptions {
 export const analogSimulationProps = z.object({
   name: z.string().optional(),
   simulationType: z
-    .literal("spice_transient_analysis")
+    .enum(["spice_dc_operating_point", "spice_transient_analysis"])
     .default("spice_transient_analysis"),
   duration: ms.optional(),
   startTime: ms.optional(),
   timePerStep: ms.optional(),
+  timeout: ms.optional(),
   spiceEngine: spiceEngine.optional(),
   spiceOptions: spiceOptions.optional(),
   graphIndependentAxes: z.boolean().optional(),
@@ -1193,6 +1195,7 @@ export interface ChipPropsSU<
   externallyConnectedPins?: string[][]
   noConnect?: readonly PinLabel[] | PinLabel[]
   connections?: Connections<PinLabel>
+  simulationBoundary?: boolean
   spiceModel?: SpiceModelElement
 }
 /**
@@ -1235,6 +1238,7 @@ export const chipProps = commonComponentProps.extend({
   noSchematicRepresentation: z.boolean().optional(),
   noConnect: noConnectProp.optional(),
   connections: connectionsProp.optional(),
+  simulationBoundary: z.boolean().default(false),
   spiceModel: spicemodelElement.optional(),
 })
 ```

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -31,10 +31,11 @@ export interface AmmeterProps<PinLabel extends string = string>
 
 export interface AnalogSimulationProps {
   name?: string
-  simulationType?: "spice_transient_analysis"
+  simulationType?: "spice_dc_operating_point" | "spice_transient_analysis"
   duration?: number | string
   startTime?: number | string
   timePerStep?: number | string
+  timeout?: number | string
   spiceEngine?: AutocompleteString<"spicey" | "ngspice">
   spiceOptions?: SpiceOptions
   graphIndependentAxes?: boolean
@@ -448,6 +449,12 @@ export interface ChipPropsSU<
    */
   noConnect?: readonly PinLabel[] | PinLabel[]
   connections?: Connections<PinLabel>
+  /**
+   * Treat this chip as the intentional boundary of an analog simulation.
+   * Defaults to false, allowing an accidentally missing SPICE model to be
+   * reported instead of silently omitting the chip.
+   */
+  simulationBoundary?: boolean
   spiceModel?: SpiceModelElement
 }
 
@@ -2123,7 +2130,15 @@ export interface SolderJumperProps extends JumperProps {
 
 
 export interface SpiceEngine {
-  simulate: (spiceString: string) => Promise<SpiceEngineSimulationResult>
+  simulate: (
+    spiceString: string,
+    options?: SpiceEngineSimulationOptions,
+  ) => Promise<SpiceEngineSimulationResult>
+}
+
+
+export interface SpiceEngineSimulationOptions {
+  timeoutMs?: number
 }
 
 

--- a/lib/components/analogsimulation.ts
+++ b/lib/components/analogsimulation.ts
@@ -5,10 +5,11 @@ import { z } from "zod"
 
 export interface AnalogSimulationProps {
   name?: string
-  simulationType?: "spice_transient_analysis"
+  simulationType?: "spice_dc_operating_point" | "spice_transient_analysis"
   duration?: number | string
   startTime?: number | string
   timePerStep?: number | string
+  timeout?: number | string
   spiceEngine?: AutocompleteString<"spicey" | "ngspice">
   spiceOptions?: SpiceOptions
   graphIndependentAxes?: boolean
@@ -35,11 +36,12 @@ const spiceOptions = z.object({
 export const analogSimulationProps = z.object({
   name: z.string().optional(),
   simulationType: z
-    .literal("spice_transient_analysis")
+    .enum(["spice_dc_operating_point", "spice_transient_analysis"])
     .default("spice_transient_analysis"),
   duration: ms.optional(),
   startTime: ms.optional(),
   timePerStep: ms.optional(),
+  timeout: ms.optional(),
   spiceEngine: spiceEngine.optional(),
   spiceOptions: spiceOptions.optional(),
   graphIndependentAxes: z.boolean().optional(),

--- a/lib/components/chip.ts
+++ b/lib/components/chip.ts
@@ -71,6 +71,12 @@ export interface ChipPropsSU<
    */
   noConnect?: readonly PinLabel[] | PinLabel[]
   connections?: Connections<PinLabel>
+  /**
+   * Treat this chip as the intentional boundary of an analog simulation.
+   * Defaults to false, allowing an accidentally missing SPICE model to be
+   * reported instead of silently omitting the chip.
+   */
+  simulationBoundary?: boolean
   spiceModel?: SpiceModelElement
 }
 
@@ -172,6 +178,7 @@ export const chipProps = commonComponentProps.extend({
   noSchematicRepresentation: z.boolean().optional(),
   noConnect: noConnectProp.optional(),
   connections: connectionsProp.optional(),
+  simulationBoundary: z.boolean().default(false),
   spiceModel: spicemodelElement.optional(),
 })
 

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -27,8 +27,15 @@ export interface SpiceEngineSimulationResult {
   simulationResultCircuitJson: CircuitJson
 }
 
+export interface SpiceEngineSimulationOptions {
+  timeoutMs?: number
+}
+
 export interface SpiceEngine {
-  simulate: (spiceString: string) => Promise<SpiceEngineSimulationResult>
+  simulate: (
+    spiceString: string,
+    options?: SpiceEngineSimulationOptions,
+  ) => Promise<SpiceEngineSimulationResult>
 }
 
 export type SimpleRouteJson = any

--- a/tests/analogsimulation.test.ts
+++ b/tests/analogsimulation.test.ts
@@ -41,6 +41,20 @@ test("analog simulation accepts time parameters", () => {
   expect(parsed.timePerStep).toBe(0.001)
 })
 
+test("analog simulation accepts DC operating-point analysis and timeout", () => {
+  const raw: AnalogSimulationProps = {
+    name: "bias",
+    simulationType: "spice_dc_operating_point",
+    timeout: "2s",
+  }
+
+  expectTypeOf(raw).toMatchTypeOf<z.input<typeof analogSimulationProps>>()
+
+  const parsed = analogSimulationProps.parse(raw)
+  expect(parsed.simulationType).toBe("spice_dc_operating_point")
+  expect(parsed.timeout).toBe(2000)
+})
+
 test("analog simulation accepts spice engine selection", () => {
   const raw: AnalogSimulationProps = {
     spiceEngine: "spicey",

--- a/tests/spicemodel.test.tsx
+++ b/tests/spicemodel.test.tsx
@@ -51,6 +51,16 @@ test("chip spiceModel accepts a spicemodel element", () => {
   expect(chipProps.parse(raw).spiceModel).toBe(raw.spiceModel)
 })
 
+test("chip accepts an explicit analog simulation boundary", () => {
+  const raw: ChipProps = {
+    name: "U1",
+    simulationBoundary: true,
+  }
+
+  expect(chipProps.parse(raw).simulationBoundary).toBe(true)
+  expect(chipProps.parse({ name: "U2" }).simulationBoundary).toBe(false)
+})
+
 test("chip spiceModel rejects plain model objects", () => {
   expect(() => {
     chipProps.parse({


### PR DESCRIPTION
## Summary

- allow `<analogsimulation>` to select DC operating-point or transient analysis
- add a parsed simulation timeout and pass it through the shared SPICE engine interface
- let chips explicitly opt into being an analog simulation boundary, so missing models can be diagnosed separately
- regenerate the public prop documentation

## Stack and merge order

1. Schema/result contract: https://github.com/tscircuit/circuit-json/pull/646
2. Public props (this PR): https://github.com/tscircuit/props/pull/730
3. `.op` netlist generation: https://github.com/tscircuit/circuit-json-to-spice/pull/50
4. ngspice execution/result conversion: https://github.com/tscircuit/ngspice-spice-engine/pull/25
5. SVG results and diagnostics: https://github.com/tscircuit/circuit-to-svg/pull/622
6. Core integration: https://github.com/tscircuit/core/pull/2682

## Validation

- `bun test` (359 passing)
- `bun run typecheck`
- `bun run build`
- `bun run check-circular-deps`
- `bun run format:check`
