### PR TITLE
Add namespaced enclosure props

### DIFF
--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -790,9 +790,9 @@ export interface EditTraceHintEvent extends BaseManualEditEvent {
 export interface EnclosureFdmBoxProps {
   /** The name or selector of the board enclosed by this box. */
   boardRef: string
-  width: Distance
-  height: Distance
-  depth: Distance
+  width?: Distance
+  height?: Distance
+  depth?: Distance
   wallThickness?: Distance
 }
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -787,6 +787,16 @@ export interface EditTraceHintEvent extends BaseManualEditEvent {
 }
 
 
+export interface EnclosureFdmBoxProps {
+  /** The name or selector of the board enclosed by this box. */
+  boardRef: string
+  width: Distance
+  height: Distance
+  depth: Distance
+  wallThickness?: Distance
+}
+
+
 export interface FabricationNoteDimensionProps
   extends Omit<
     PcbLayoutProps,

--- a/lib/enclosure/fdm/box.ts
+++ b/lib/enclosure/fdm/box.ts
@@ -5,17 +5,17 @@ import { z } from "zod"
 export interface EnclosureFdmBoxProps {
   /** The name or selector of the board enclosed by this box. */
   boardRef: string
-  width: Distance
-  height: Distance
-  depth: Distance
+  width?: Distance
+  height?: Distance
+  depth?: Distance
   wallThickness?: Distance
 }
 
 export const enclosureFdmBoxProps = z.object({
   boardRef: z.string().min(1),
-  width: distance,
-  height: distance,
-  depth: distance,
+  width: distance.optional(),
+  height: distance.optional(),
+  depth: distance.optional(),
   wallThickness: distance.default("2mm"),
 })
 

--- a/lib/enclosure/fdm/box.ts
+++ b/lib/enclosure/fdm/box.ts
@@ -1,0 +1,24 @@
+import { type Distance, distance } from "lib/common/distance"
+import { expectTypesMatch } from "lib/typecheck"
+import { z } from "zod"
+
+export interface EnclosureFdmBoxProps {
+  /** The name or selector of the board enclosed by this box. */
+  boardRef: string
+  width: Distance
+  height: Distance
+  depth: Distance
+  wallThickness?: Distance
+}
+
+export const enclosureFdmBoxProps = z.object({
+  boardRef: z.string().min(1),
+  width: distance,
+  height: distance,
+  depth: distance,
+  wallThickness: distance.default("2mm"),
+})
+
+export type EnclosureFdmBoxPropsInput = z.input<typeof enclosureFdmBoxProps>
+
+expectTypesMatch<EnclosureFdmBoxProps, EnclosureFdmBoxPropsInput>(true)

--- a/lib/enclosure/fdm/index.ts
+++ b/lib/enclosure/fdm/index.ts
@@ -1,0 +1,1 @@
+export * from "./box"

--- a/lib/enclosure/index.ts
+++ b/lib/enclosure/index.ts
@@ -1,0 +1,9 @@
+import { enclosureFdmBoxProps } from "./fdm/box"
+
+export * from "./fdm"
+
+export const enclosureProps = {
+  fdm: {
+    Box: enclosureFdmBoxProps,
+  },
+} as const

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,5 @@
 export * from "./common/direction"
+export * from "./enclosure"
 export * from "./common/portHints"
 export * from "./common/layout"
 export * from "./common/pinAttributeMap"

--- a/tests/enclosure-fdm-box.test.ts
+++ b/tests/enclosure-fdm-box.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import {
+  type EnclosureFdmBoxPropsInput,
+  enclosureFdmBoxProps,
+  enclosureProps,
+} from "lib/enclosure"
+
+test("parses enclosure.fdm.Box props with a boardRef", () => {
+  const input: EnclosureFdmBoxPropsInput = {
+    boardRef: ".main-board",
+    width: "45mm",
+    height: "35mm",
+    depth: "15mm",
+    wallThickness: "2.4mm",
+  }
+
+  expect(enclosureFdmBoxProps.parse(input)).toEqual({
+    boardRef: ".main-board",
+    width: 45,
+    height: 35,
+    depth: 15,
+    wallThickness: 2.4,
+  })
+})
+
+test("exposes the box schema through the enclosure namespace", () => {
+  expect(enclosureProps.fdm.Box).toBe(enclosureFdmBoxProps)
+})
+
+test("requires a non-empty boardRef", () => {
+  expect(() =>
+    enclosureFdmBoxProps.parse({
+      boardRef: "",
+      width: 45,
+      height: 35,
+      depth: 15,
+    }),
+  ).toThrow()
+})
+
+test("defaults wallThickness to 2mm", () => {
+  expect(
+    enclosureFdmBoxProps.parse({
+      boardRef: ".main-board",
+      width: 45,
+      height: 35,
+      depth: 15,
+    }).wallThickness,
+  ).toBe(2)
+})

--- a/tests/enclosure-fdm-box.test.ts
+++ b/tests/enclosure-fdm-box.test.ts
@@ -27,6 +27,17 @@ test("exposes the box schema through the enclosure namespace", () => {
   expect(enclosureProps.fdm.Box).toBe(enclosureFdmBoxProps)
 })
 
+test("allows dimensions to be inferred from boardRef", () => {
+  expect(
+    enclosureFdmBoxProps.parse({
+      boardRef: ".main-board",
+    }),
+  ).toEqual({
+    boardRef: ".main-board",
+    wallThickness: 2,
+  })
+})
+
 test("requires a non-empty boardRef", () => {
   expect(() =>
     enclosureFdmBoxProps.parse({


### PR DESCRIPTION
## Summary

- add the initial `enclosure.fdm.Box` props schema and TypeScript interface
- require a non-empty `boardRef`, allowing box dimensions to be inferred from the referenced board
- support optional unit-aware `width`, `height`, and `depth` overrides
- expose the schema through `enclosureProps.fdm.Box`
- document the generated props interface and add parsing, inference, and default tests

## Why

This establishes the props-side contract for namespaced JSX elements such as `<enclosure.fdm.Box />`. The schema remains React-independent so core can provide the runtime namespace wrapper separately.

## Developer impact

Consumers can import `EnclosureFdmBoxProps`, `enclosureFdmBoxProps`, or access the schema through `enclosureProps.fdm.Box`. `boardRef` is the only required sizing input; `width`, `height`, and `depth` are optional overrides. `wallThickness` defaults to 2 mm.

## Validation

- `bun test tests/enclosure-fdm-box.test.ts` (5 passing)
- `bunx tsc --noEmit`
- full props test suite previously run: 358 passing
- generated documentation scripts run