### PR TITLE
Allow 10-layer boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ export interface BoardProps extends Omit<
   title?: string;
   material?: "fr4" | "fr1" | "flex";
   /** Number of layers for the PCB */
-  layers?: 1 | 2 | 4 | 6 | 8;
+  layers?: 1 | 2 | 4 | 6 | 8 | 10;
   borderRadius?: Distance;
   thickness?: Distance;
   boardAnchorPosition?: Point;
@@ -718,11 +718,7 @@ export type FabricationNoteRectProps = z.input<typeof fabricationNoteRectProps>;
 export interface FabricationNoteTextProps extends PcbLayoutProps {
   text: string;
   anchorAlignment?:
-    | "center"
-    | "top_left"
-    | "top_right"
-    | "bottom_left"
-    | "bottom_right";
+    "center" | "top_left" | "top_right" | "bottom_left" | "bottom_right";
   font?: "tscircuit2024";
   fontSize?: string | number;
   color?: string;
@@ -1288,11 +1284,7 @@ export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
 export interface PcbNoteTextProps extends PcbLayoutProps {
   text: string;
   anchorAlignment?:
-    | "center"
-    | "top_left"
-    | "top_right"
-    | "bottom_left"
-    | "bottom_right";
+    "center" | "top_left" | "top_right" | "bottom_left" | "bottom_right";
   font?: "tscircuit2024";
   fontSize?: string | number;
   color?: string;
@@ -2126,7 +2118,6 @@ export interface PlatformConfig {
 ```
 
 [Source](https://github.com/tscircuit/props/blob/main/lib/platformConfig.ts)
-
 <!-- PLATFORM_CONFIG_END -->
 
 <!-- PROJECT_CONFIG_START -->
@@ -2150,5 +2141,4 @@ export interface ProjectConfig extends Pick<
 ```
 
 [Source](https://github.com/tscircuit/props/blob/main/lib/projectConfig.ts)
-
 <!-- PROJECT_CONFIG_END -->

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1030,7 +1030,7 @@ export interface BoardProps
   extends Omit<SubcircuitGroupProps, "subcircuit" | "connections"> {
   title?: string
   material?: "fr4" | "fr1" | "flex"
-  layers?: 1 | 2 | 4 | 6 | 8
+  layers?: 1 | 2 | 4 | 6 | 8 | 10
   borderRadius?: Distance
   thickness?: Distance
   boardAnchorPosition?: Point
@@ -1057,6 +1057,7 @@ export const boardProps = subcircuitGroupProps
         z.literal(4),
         z.literal(6),
         z.literal(8),
+        z.literal(10),
       ])
       .default(2),
     borderRadius: distance.optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -260,7 +260,7 @@ export interface BoardProps
   title?: string
   material?: "fr4" | "fr1" | "flex"
   /** Number of layers for the PCB */
-  layers?: 1 | 2 | 4 | 6 | 8
+  layers?: 1 | 2 | 4 | 6 | 8 | 10
   borderRadius?: Distance
   thickness?: Distance
   boardAnchorPosition?: Point

--- a/lib/components/board.ts
+++ b/lib/components/board.ts
@@ -28,7 +28,7 @@ export interface BoardProps
   title?: string
   material?: "fr4" | "fr1" | "flex"
   /** Number of layers for the PCB */
-  layers?: 1 | 2 | 4 | 6 | 8
+  layers?: 1 | 2 | 4 | 6 | 8 | 10
   borderRadius?: Distance
   thickness?: Distance
   boardAnchorPosition?: Point
@@ -63,6 +63,7 @@ export const boardProps = subcircuitGroupProps
         z.literal(4),
         z.literal(6),
         z.literal(8),
+        z.literal(10),
       ])
       .default(2),
     borderRadius: distance.optional(),

--- a/tests/board.test.ts
+++ b/tests/board.test.ts
@@ -28,12 +28,14 @@ test("should allow single-layer boards", () => {
   expect(parsed.layers).toBe(1)
 })
 
-test("should allow 6 and 8 layer boards", () => {
+test("should allow 6, 8, and 10 layer boards", () => {
   const sixLayer: BoardProps = { name: "board", layers: 6 }
   const eightLayer: BoardProps = { name: "board", layers: 8 }
+  const tenLayer: BoardProps = { name: "board", layers: 10 }
 
   expect(boardProps.parse(sixLayer).layers).toBe(6)
   expect(boardProps.parse(eightLayer).layers).toBe(8)
+  expect(boardProps.parse(tenLayer).layers).toBe(10)
 })
 
 test("should parse flex board material", () => {


### PR DESCRIPTION
## Summary

- allow layers=10 in BoardProps and its runtime schema
- add parser coverage for 6-, 8-, and 10-layer boards
- regenerate the required component type and props documentation

## Testing

- bun test tests/board.test.ts
- bun run typecheck
- bun run build

Companion to tscircuit/tscircuit-autorouter#1648.