### PR TITLE
Add assembly device props

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,11 +718,7 @@ export type FabricationNoteRectProps = z.input<typeof fabricationNoteRectProps>;
 export interface FabricationNoteTextProps extends PcbLayoutProps {
   text: string;
   anchorAlignment?:
-    | "center"
-    | "top_left"
-    | "top_right"
-    | "bottom_left"
-    | "bottom_right";
+    "center" | "top_left" | "top_right" | "bottom_left" | "bottom_right";
   font?: "tscircuit2024";
   fontSize?: string | number;
   color?: string;
@@ -1288,11 +1284,7 @@ export interface PcbNoteRectProps extends Omit<PcbLayoutProps, "pcbRotation"> {
 export interface PcbNoteTextProps extends PcbLayoutProps {
   text: string;
   anchorAlignment?:
-    | "center"
-    | "top_left"
-    | "top_right"
-    | "bottom_left"
-    | "bottom_right";
+    "center" | "top_left" | "top_right" | "bottom_left" | "bottom_right";
   font?: "tscircuit2024";
   fontSize?: string | number;
   color?: string;
@@ -2126,7 +2118,6 @@ export interface PlatformConfig {
 ```
 
 [Source](https://github.com/tscircuit/props/blob/main/lib/platformConfig.ts)
-
 <!-- PLATFORM_CONFIG_END -->
 
 <!-- PROJECT_CONFIG_START -->
@@ -2150,5 +2141,4 @@ export interface ProjectConfig extends Pick<
 ```
 
 [Source](https://github.com/tscircuit/props/blob/main/lib/projectConfig.ts)
-
 <!-- PROJECT_CONFIG_END -->

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -41,6 +41,12 @@ export interface AnalogSimulationProps {
 }
 
 
+export interface AssemblyDeviceProps {
+  /** Product-level assembly identity. */
+  name?: string
+}
+
+
 export interface AutorouterConfig {
   serverUrl?: string
   inputFormat?: "simplified" | "circuit-json"

--- a/lib/assembly/device.ts
+++ b/lib/assembly/device.ts
@@ -1,0 +1,15 @@
+import { expectTypesMatch } from "lib/typecheck"
+import { z } from "zod"
+
+export interface AssemblyDeviceProps {
+  /** Product-level assembly identity. */
+  name?: string
+}
+
+export const assemblyDeviceProps = z.object({
+  name: z.string().optional(),
+})
+
+export type AssemblyDevicePropsInput = z.input<typeof assemblyDeviceProps>
+
+expectTypesMatch<AssemblyDeviceProps, AssemblyDevicePropsInput>(true)

--- a/lib/assembly/index.ts
+++ b/lib/assembly/index.ts
@@ -1,0 +1,7 @@
+import { assemblyDeviceProps } from "./device"
+
+export * from "./device"
+
+export const assemblyProps = {
+  device: assemblyDeviceProps,
+} as const

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,6 @@
 export * from "./common/direction"
 export * from "./common/commonShape"
+export * from "./assembly"
 export * from "./enclosure"
 export * from "./common/portHints"
 export * from "./common/layout"

--- a/tests/assembly-device.test.ts
+++ b/tests/assembly-device.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import {
+  type AssemblyDevicePropsInput,
+  assemblyDeviceProps,
+  assemblyProps,
+} from "lib/assembly"
+
+test("parses assembly.device props", () => {
+  const input: AssemblyDevicePropsInput = { name: "controller" }
+
+  expect(assemblyDeviceProps.parse(input)).toEqual({ name: "controller" })
+})
+
+test("exposes device props through the assembly namespace", () => {
+  expect(assemblyProps.device).toBe(assemblyDeviceProps)
+})


### PR DESCRIPTION
## Summary

- add the `AssemblyDeviceProps` and `AssemblyDevicePropsInput` authoring contracts
- expose the validator as both `assemblyDeviceProps` and `assemblyProps.device`
- export the assembly namespace from the package root
- add focused parsing and namespace tests
- regenerate the checked-in props documentation

## Why

The imported `<assembly.device>` wrapper used by the parametric enclosure integration needs a React-independent props schema from `@tscircuit/props`, matching the existing `enclosureProps.fdm.box` and `enclosureProps.cutoutaperture` contracts. Without this export, the enclosure package cannot import or register the assembly root parser.

## Developer impact

Packages implementing the runtime wrapper can now import `assemblyDeviceProps` and `AssemblyDevicePropsInput`, or access the schema through `assemblyProps.device`. The initial contract carries an optional product-level `name`.

## Validation

- `bun test tests/assembly-device.test.ts` (2 passing)
- `bun test` (368 passing)
- `bun run typecheck`
- `bun run build`
- `bun run check-circular-deps`
- `bun run format:check`
- all required documentation generation scripts

The reference `pcb-enclosure` consumer also resolves the new props exports successfully. Its end-to-end build proceeds to its separate unreleased `@tscircuit/core` external-element/postprocessor dependency.
