### PR TITLE
Use 10-layer Circuit JSON schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/node": "^20.12.11",
     "@types/react": "^18.3.2",
     "ava": "^6.1.3",
-    "circuit-json": "^0.0.449",
+    "circuit-json": "^0.0.450",
     "expect-type": "^1.3.0",
     "glob": "^11.0.0",
     "madge": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/node": "^20.12.11",
     "@types/react": "^18.3.2",
     "ava": "^6.1.3",
-    "circuit-json": "^0.0.433",
+    "circuit-json": "^0.0.449",
     "expect-type": "^1.3.0",
     "glob": "^11.0.0",
     "madge": "^8.0.0",

--- a/tests/via.test.ts
+++ b/tests/via.test.ts
@@ -24,7 +24,9 @@ test("should parse ViaProps with name and connectsTo", () => {
 test("should parse ViaProps with layers and net assignability flag", () => {
   const raw: ViaProps = {
     name: "v2",
-    layers: ["top", "bottom"],
+    fromLayer: "inner7",
+    toLayer: "inner8",
+    layers: ["inner7", "inner8"],
     holeDiameter: "0.25mm",
     outerDiameter: "0.6mm",
     netIsAssignable: true,
@@ -33,7 +35,9 @@ test("should parse ViaProps with layers and net assignability flag", () => {
   expectTypeOf(raw).toMatchTypeOf<z.input<typeof viaProps>>()
 
   const parsed = viaProps.parse(raw)
-  expect(parsed.layers).toEqual(["top", "bottom"])
+  expect(parsed.fromLayer).toBe("inner7")
+  expect(parsed.toLayer).toBe("inner8")
+  expect(parsed.layers).toEqual(["inner7", "inner8"])
   expect(parsed.holeDiameter).toBe(0.25)
   expect(parsed.outerDiameter).toBe(0.6)
   expect(parsed.netIsAssignable).toBe(true)


### PR DESCRIPTION
## Summary

- update the Circuit JSON build dependency to 0.0.449
- verify via props accept inner7 and inner8 at both the type and runtime-schema boundaries

This is required for tscircuit/core#2690: the merged board-layer-count change accepts layers=10, but the older bundled layer_ref schema still stops before inner7/inner8.

## Testing

- bun test tests/via.test.ts tests/board.test.ts
- bun run typecheck
- bun run format:check
- bun run build