### PR TITLE
Fix differential pair max length skew validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ export interface BatteryProps<
   voltage?: number | string;
   standard?: "AA" | "AAA" | "9V" | "CR2032" | "18650" | "C";
   schOrientation?: SchematicOrientation;
+  connections?: Connections<BatteryPinLabels>;
 }
 ```
 
@@ -624,7 +625,7 @@ export interface DifferentialPairProps {
   positiveConnection: string;
   /** Name of the trace or pin carrying the negative signal. */
   negativeConnection: string;
-  /** Maximum permitted routed-length skew, expressed as a ratio from 0 to 1. */
+  /** Maximum permitted routed-length skew in millimeters. */
   maxLengthSkew?: number;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -278,7 +278,6 @@ export interface BatteryProps<
   voltage?: number | string;
   standard?: "AA" | "AAA" | "9V" | "CR2032" | "18650" | "C";
   schOrientation?: SchematicOrientation;
-  connections?: Connections<BatteryPinLabels>;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1007,20 +1007,19 @@ export const autoroutingPhaseProps = z
 ### battery
 
 ```typescript
+/** @deprecated use battery_capacity from circuit-json when circuit-json is updated */
 export interface BatteryProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   capacity?: number | string
   voltage?: number | string
   standard?: "AA" | "AAA" | "9V" | "CR2032" | "18650" | "C"
   schOrientation?: SchematicOrientation
-  connections?: Connections<BatteryPinLabels>
 }
 export const batteryProps = commonComponentProps.extend({
   capacity: capacity.optional(),
   voltage: voltage.optional(),
   standard: z.enum(["AA", "AAA", "9V", "CR2032", "18650", "C"]).optional(),
   schOrientation: schematicOrientation.optional(),
-  connections: createConnectionsProp(batteryPins).optional(),
 })
 ```
 
@@ -4371,4 +4370,3 @@ export const voltageSourceProps = commonComponentProps.extend({
   connections: createConnectionsProp(voltageSourcePinLabels).optional(),
 })
 ```
-

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1007,19 +1007,20 @@ export const autoroutingPhaseProps = z
 ### battery
 
 ```typescript
-/** @deprecated use battery_capacity from circuit-json when circuit-json is updated */
 export interface BatteryProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   capacity?: number | string
   voltage?: number | string
   standard?: "AA" | "AAA" | "9V" | "CR2032" | "18650" | "C"
   schOrientation?: SchematicOrientation
+  connections?: Connections<BatteryPinLabels>
 }
 export const batteryProps = commonComponentProps.extend({
   capacity: capacity.optional(),
   voltage: voltage.optional(),
   standard: z.enum(["AA", "AAA", "9V", "CR2032", "18650", "C"]).optional(),
   schOrientation: schematicOrientation.optional(),
+  connections: createConnectionsProp(batteryPins).optional(),
 })
 ```
 
@@ -1615,12 +1616,12 @@ export interface DifferentialPairProps {
   negativeConnection: string
   maxLengthSkew?: number
 }
-/** Maximum permitted routed-length skew, expressed as a ratio from 0 to 1. */
+/** Maximum permitted routed-length skew in millimeters. */
 export const differentialPairProps = z.object({
   name: z.string().optional(),
   positiveConnection: z.string(),
   negativeConnection: z.string(),
-  maxLengthSkew: z.number().min(0).max(1).optional(),
+  maxLengthSkew: z.number().min(0).finite().optional(),
 })
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -4370,3 +4370,4 @@ export const voltageSourceProps = commonComponentProps.extend({
   connections: createConnectionsProp(voltageSourcePinLabels).optional(),
 })
 ```
+

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -258,6 +258,7 @@ export interface BatteryProps<PinLabel extends string = string>
   voltage?: number | string
   standard?: "AA" | "AAA" | "9V" | "CR2032" | "18650" | "C"
   schOrientation?: SchematicOrientation
+  connections?: Connections<BatteryPinLabels>
 }
 
 
@@ -732,7 +733,7 @@ export interface DifferentialPairProps {
   positiveConnection: string
   /** Name of the trace or pin carrying the negative signal. */
   negativeConnection: string
-  /** Maximum permitted routed-length skew, expressed as a ratio from 0 to 1. */
+  /** Maximum permitted routed-length skew in millimeters. */
   maxLengthSkew?: number
 }
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -258,7 +258,6 @@ export interface BatteryProps<PinLabel extends string = string>
   voltage?: number | string
   standard?: "AA" | "AAA" | "9V" | "CR2032" | "18650" | "C"
   schOrientation?: SchematicOrientation
-  connections?: Connections<BatteryPinLabels>
 }
 
 

--- a/lib/components/differentialpair.ts
+++ b/lib/components/differentialpair.ts
@@ -11,7 +11,7 @@ export interface DifferentialPairProps {
   positiveConnection: string
   /** Name of the trace or pin carrying the negative signal. */
   negativeConnection: string
-  /** Maximum permitted routed-length skew, expressed as a ratio from 0 to 1. */
+  /** Maximum permitted routed-length skew in millimeters. */
   maxLengthSkew?: number
 }
 
@@ -19,7 +19,7 @@ export const differentialPairProps = z.object({
   name: z.string().optional(),
   positiveConnection: z.string(),
   negativeConnection: z.string(),
-  maxLengthSkew: z.number().min(0).max(1).optional(),
+  maxLengthSkew: z.number().min(0).finite().optional(),
 })
 
 type InferredDifferentialPairProps = z.input<typeof differentialPairProps>

--- a/tests/differentialpair1.test.ts
+++ b/tests/differentialpair1.test.ts
@@ -9,7 +9,7 @@ test("parses a differential pair with maximum length skew", () => {
     name: "data",
     positiveConnection: "data-positive",
     negativeConnection: "data-negative",
-    maxLengthSkew: 0.1,
+    maxLengthSkew: 2.5,
   }
 
   const parsed = differentialPairProps.parse(raw)

--- a/tests/differentialpair3.test.ts
+++ b/tests/differentialpair3.test.ts
@@ -1,12 +1,22 @@
 import { expect, test } from "bun:test"
 import { differentialPairProps } from "lib/components/differentialpair"
 
-test("requires maximum length skew to be a ratio from zero through one", () => {
+test("requires maximum length skew to be non-negative", () => {
   expect(() =>
     differentialPairProps.parse({
       positiveConnection: "data-positive",
       negativeConnection: "data-negative",
-      maxLengthSkew: 1.1,
+      maxLengthSkew: -0.1,
+    }),
+  ).toThrow()
+})
+
+test("requires maximum length skew to be finite", () => {
+  expect(() =>
+    differentialPairProps.parse({
+      positiveConnection: "data-positive",
+      negativeConnection: "data-negative",
+      maxLengthSkew: Number.POSITIVE_INFINITY,
     }),
   ).toThrow()
 })

--- a/tests/differentialpair4.test.ts
+++ b/tests/differentialpair4.test.ts
@@ -1,12 +1,12 @@
 import { expect, test } from "bun:test"
 import { differentialPairProps } from "lib/components/differentialpair"
 
-test("requires maximum length skew to be non-negative", () => {
+test("requires maximum length skew to be finite", () => {
   expect(() =>
     differentialPairProps.parse({
       positiveConnection: "data-positive",
       negativeConnection: "data-negative",
-      maxLengthSkew: -0.1,
+      maxLengthSkew: Number.POSITIVE_INFINITY,
     }),
   ).toThrow()
 })


### PR DESCRIPTION
This was an mistake in API definition because of my ambiguity

## Summary

- allow maxLengthSkew to accept any finite, non-negative millimeter value
- add regression coverage and refresh the corresponding generated documentation

## Validation

- bun test (372 passed)
- bun run format:check
- bun run build
- required documentation generation scripts
- bun run typecheck (currently blocked by pre-existing via tests using inner7/inner8 while circuit-json 0.0.450 types stop at inner6)