### PR TITLE
fix: align transistorPins order with schematic-symbols (pin1=collector, pin2=base, pin3=emitter)

### DIFF
--- a/lib/components/transistor.ts
+++ b/lib/components/transistor.ts
@@ -33,11 +33,11 @@ export const transistorProps = commonComponentProps.extend({
 
 export const transistorPins = [
   "pin1",
-  "emitter",
-  "pin2",
   "collector",
-  "pin3",
+  "pin2",
   "base",
+  "pin3",
+  "emitter",
 ] as const
 export type TransistorPinLabels = (typeof transistorPins)[number]
 


### PR DESCRIPTION
Part of the fix for tscircuit/tscircuit#3617 — companion to tscircuit/core#2740 (independent; safe to merge in either order).

## What

`transistorPins` paired the pins as `pin1=emitter, pin2=collector, pin3=base`, but the `schematic-symbols` package numbers BJT ports as **pin1=collector, pin2=base, pin3=emitter** — identically for `npn_bipolar_transistor` and `pnp_bipolar_transistor`, in both `_horz` and `_vert` orientations (verified against `schematic-symbols@0.0.232`):

```
["1","collector"]   ["2","base"]   ["3","emitter"]
```

This PR reorders the array to match. The exported `TransistorPinLabels` union type is unchanged (same members), so this is not a breaking type change.

Addressing the questions from the earlier stale-closed attempts (#698, #714):

- **PNP mapping** (@imrishabh18's question on #698): the PNP symbol uses the same numbering as NPN, so one order serves both — nothing gets "messed up".
- #698 proposed exactly this order (collector, base, emitter) and was correct; #714 proposed `pin2=emitter`, which contradicts the symbols package.

`bunx tsc --noEmit` clean; all 372 tests pass.

---
