### PR TITLE
Add schematic box chip reference props

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ export interface BatteryProps<
   voltage?: number | string;
   standard?: "AA" | "AAA" | "9V" | "CR2032" | "18650" | "C";
   schOrientation?: SchematicOrientation;
+  connections?: Connections<BatteryPinLabels>;
 }
 ```
 
@@ -441,6 +442,12 @@ export interface ChipPropsSU<
   schWidth?: Distance;
   schHeight?: Distance;
   noSchematicRepresentation?: boolean;
+  /**
+   * Whether to show the components from `internalCircuit` in the schematic.
+   * When false, the chip's schematic box is shown instead.
+   * @default false
+   */
+  schShowInternalCircuit?: boolean;
   internallyConnectedPins?: (string | number)[][];
   externallyConnectedPins?: string[][];
   /**
@@ -1534,6 +1541,10 @@ export interface SchematicArcProps {
 
 ```ts
 export interface SchematicBoxProps {
+  name?: string;
+  chipRef?: string;
+  pinLabels?: PinLabelsProp;
+  schPinArrangement?: SchematicPinArrangement;
   schX?: Distance;
   schY?: Distance;
   width?: Distance;

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1007,19 +1007,20 @@ export const autoroutingPhaseProps = z
 ### battery
 
 ```typescript
-/** @deprecated use battery_capacity from circuit-json when circuit-json is updated */
 export interface BatteryProps<PinLabel extends string = string>
   extends CommonComponentProps<PinLabel> {
   capacity?: number | string
   voltage?: number | string
   standard?: "AA" | "AAA" | "9V" | "CR2032" | "18650" | "C"
   schOrientation?: SchematicOrientation
+  connections?: Connections<BatteryPinLabels>
 }
 export const batteryProps = commonComponentProps.extend({
   capacity: capacity.optional(),
   voltage: voltage.optional(),
   standard: z.enum(["AA", "AAA", "9V", "CR2032", "18650", "C"]).optional(),
   schOrientation: schematicOrientation.optional(),
+  connections: createConnectionsProp(batteryPins).optional(),
 })
 ```
 
@@ -1223,6 +1224,7 @@ export interface ChipPropsSU<
   schWidth?: Distance
   schHeight?: Distance
   noSchematicRepresentation?: boolean
+  schShowInternalCircuit?: boolean
   internallyConnectedPins?: (string | number)[][]
   externallyConnectedPins?: string[][]
   noConnect?: readonly PinLabel[] | PinLabel[]
@@ -1268,6 +1270,7 @@ export const chipProps = commonComponentProps.extend({
   schWidth: distance.optional(),
   schHeight: distance.optional(),
   noSchematicRepresentation: z.boolean().optional(),
+  schShowInternalCircuit: z.boolean().optional().default(false),
   noConnect: noConnectProp.optional(),
   connections: connectionsProp.optional(),
   spiceModel: spicemodelElement.optional(),
@@ -3490,6 +3493,11 @@ export interface SchematicArcProps {
 ```typescript
 export const schematicBoxProps = z
   .object({
+    name: z.string().optional(),
+    chipRef: z.string().optional(),
+    pinLabels: pinLabelsProp.optional(),
+    schPinArrangement: schematicPinArrangement.optional(),
+
     schX: distance.optional(),
     schY: distance.optional(),
     width: distance.optional(),
@@ -3510,6 +3518,10 @@ export const schematicBoxProps = z
     strokeStyle: z.enum(["solid", "dashed"]).default("solid"),
   })
 export interface SchematicBoxProps {
+  name?: string
+  chipRef?: string
+  pinLabels?: PinLabelsProp
+  schPinArrangement?: SchematicPinArrangement
   schX?: Distance
   schY?: Distance
   width?: Distance

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -258,6 +258,7 @@ export interface BatteryProps<PinLabel extends string = string>
   voltage?: number | string
   standard?: "AA" | "AAA" | "9V" | "CR2032" | "18650" | "C"
   schOrientation?: SchematicOrientation
+  connections?: Connections<BatteryPinLabels>
 }
 
 
@@ -446,6 +447,12 @@ export interface ChipPropsSU<
   schWidth?: Distance
   schHeight?: Distance
   noSchematicRepresentation?: boolean
+  /**
+   * Whether to show the components from `internalCircuit` in the schematic.
+   * When false, the chip's schematic box is shown instead.
+   * @default false
+   */
+  schShowInternalCircuit?: boolean
   internallyConnectedPins?: (string | number)[][]
   externallyConnectedPins?: string[][]
   /**
@@ -1962,6 +1969,10 @@ export interface SchematicArcProps {
 
 
 export interface SchematicBoxProps {
+  name?: string
+  chipRef?: string
+  pinLabels?: PinLabelsProp
+  schPinArrangement?: SchematicPinArrangement
   schX?: Distance
   schY?: Distance
   width?: Distance

--- a/lib/components/schematic-box.ts
+++ b/lib/components/schematic-box.ts
@@ -1,11 +1,21 @@
 import { distance } from "circuit-json"
-import { z } from "zod"
 import { ninePointAnchor } from "lib/common/ninePointAnchor"
+import {
+  type SchematicPinArrangement,
+  schematicPinArrangement,
+} from "lib/common/schematicPinDefinitions"
+import { type PinLabelsProp, pinLabelsProp } from "lib/components/chip"
 import { expectTypesMatch } from "lib/typecheck"
 import type { Distance } from "lib/common/distance"
+import { z } from "zod"
 
 export const schematicBoxProps = z
   .object({
+    name: z.string().optional(),
+    chipRef: z.string().optional(),
+    pinLabels: pinLabelsProp.optional(),
+    schPinArrangement: schematicPinArrangement.optional(),
+
     schX: distance.optional(),
     schY: distance.optional(),
     width: distance.optional(),
@@ -49,6 +59,10 @@ export const schematicBoxProps = z
   )
 
 export interface SchematicBoxProps {
+  name?: string
+  chipRef?: string
+  pinLabels?: PinLabelsProp
+  schPinArrangement?: SchematicPinArrangement
   schX?: Distance
   schY?: Distance
   width?: Distance

--- a/tests/schematic-box.test.ts
+++ b/tests/schematic-box.test.ts
@@ -20,6 +20,39 @@ test("should parse schematic box with schX and schY", () => {
   expect(parsed.height).toBe(30)
 })
 
+test("should parse schematic box chip reference props", () => {
+  const raw: SchematicBoxProps = {
+    name: "U1A",
+    chipRef: "U1",
+    width: 2.245,
+    height: 1,
+    pinLabels: {
+      pin1: "VCC",
+      pin2: "GND",
+    },
+    schPinArrangement: {
+      leftSide: ["pin1", "pin2"],
+      rightSide: [],
+    },
+  }
+
+  const parsed = schematicBoxProps.parse(raw)
+
+  expect(parsed.name).toBe("U1A")
+  expect(parsed.chipRef).toBe("U1")
+  expect(parsed.pinLabels).toEqual({ pin1: "VCC", pin2: "GND" })
+  expect(parsed.schPinArrangement).toEqual({
+    leftSide: {
+      pins: ["pin1", "pin2"],
+      direction: "top-to-bottom",
+    },
+    rightSide: {
+      pins: [],
+      direction: "top-to-bottom",
+    },
+  })
+})
+
 test("should parse schematic box with only overlay", () => {
   const raw: SchematicBoxProps = {
     overlay: ["custom"],


### PR DESCRIPTION
## Summary

- add `name`, `chipRef`, `pinLabels`, and `schPinArrangement` to `schematicBoxProps` and `SchematicBoxProps`
- reuse the shared chip pin-label and schematic pin-arrangement validators
- add a regression test based on the multi-sheet chip example in tscircuit/core#2750
- regenerate the props documentation

## Why

[tscircuit/core#2750](https://github.com/tscircuit/core/pull/2750) uses multiple `<schematicbox />` elements to represent one chip across schematic sheets. The runtime schema and TypeScript interface did not declare the identity, chip linkage, pin-label, or pin-arrangement fields, so those props were rejected by TypeScript and stripped during parsing.

This change makes those fields part of the canonical schematic-box props API and preserves the shared pin-arrangement normalization behavior.

## Validation

- `bun test` (373 passing)
- `bun run typecheck`
- `bun run build`
- `bun run format:check`
- `bun run check-circular-deps`