### PR TITLE
Add disabled flags to project config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2164,6 +2164,8 @@ export interface ProjectConfig extends Pick<
   | "includeBoardFiles"
   | "snapshotsDir"
   | "defaultSpiceEngine"
+  | "pcbDisabled"
+  | "schematicDisabled"
 > {}
 ```
 

--- a/lib/projectConfig.ts
+++ b/lib/projectConfig.ts
@@ -13,6 +13,8 @@ export interface ProjectConfig
     | "includeBoardFiles"
     | "snapshotsDir"
     | "defaultSpiceEngine"
+    | "pcbDisabled"
+    | "schematicDisabled"
   > {}
 
 const platformConfigObject = platformConfig as z.ZodObject<any>
@@ -26,6 +28,8 @@ export const projectConfig = platformConfigObject.pick({
   includeBoardFiles: true,
   snapshotsDir: true,
   defaultSpiceEngine: true,
+  pcbDisabled: true,
+  schematicDisabled: true,
 }) as z.ZodType<ProjectConfig>
 
 expectTypesMatch<ProjectConfig, z.infer<typeof projectConfig>>(true)

--- a/tests/projectConfig.test.ts
+++ b/tests/projectConfig.test.ts
@@ -26,6 +26,20 @@ test("projectConfig only includes project-specific fields", () => {
     includeBoardFiles: ["boards/main.circuit.tsx"],
     snapshotsDir: "custom/snapshots",
     defaultSpiceEngine: "spicey",
+    pcbDisabled: true,
+    schematicDisabled: true,
+  })
+})
+
+test("projectConfig includes disabled rendering flags when provided", () => {
+  const config = projectConfig.parse({
+    pcbDisabled: true,
+    schematicDisabled: false,
+  })
+
+  expect(config).toEqual({
+    pcbDisabled: true,
+    schematicDisabled: false,
   })
 })
 


### PR DESCRIPTION
## Summary

- add `pcbDisabled` and `schematicDisabled` to the exported `ProjectConfig` type
- include both flags in the `projectConfig` Zod schema
- add parser coverage for true and false values
- regenerate the checked-in README documentation

## Why

Consumers that load `tscircuit.config.json` currently need to redeclare these fields locally even though both already exist on `PlatformConfig`. Exposing them through `ProjectConfig` gives JSON project configuration a shared source of truth.

## Impact

Packages such as `@tscircuit/eval` can extend `ProjectConfig` and consume the rendering-disable flags without duplicating their definitions.

## Validation

- `bun test tests` (374 passing)
- `bun run typecheck`
- `bun run format:check`
- `bun run build`
- all repository-required generation scripts