### PR TITLE
Add schSheetName to schematic box props

### DIFF
--- a/README.md
+++ b/README.md
@@ -1547,6 +1547,7 @@ export interface SchematicBoxProps {
   schPinArrangement?: SchematicPinArrangement;
   schX?: Distance;
   schY?: Distance;
+  schSheetName?: string;
   width?: Distance;
   height?: Distance;
   overlay?: string[];

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -3500,6 +3500,7 @@ export const schematicBoxProps = z
 
     schX: distance.optional(),
     schY: distance.optional(),
+    schSheetName: z.string().optional(),
     width: distance.optional(),
     height: distance.optional(),
     overlay: z.array(z.string()).optional(),
@@ -3524,6 +3525,7 @@ export interface SchematicBoxProps {
   schPinArrangement?: SchematicPinArrangement
   schX?: Distance
   schY?: Distance
+  schSheetName?: string
   width?: Distance
   height?: Distance
   overlay?: string[]

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1975,6 +1975,7 @@ export interface SchematicBoxProps {
   schPinArrangement?: SchematicPinArrangement
   schX?: Distance
   schY?: Distance
+  schSheetName?: string
   width?: Distance
   height?: Distance
   overlay?: string[]

--- a/lib/components/schematic-box.ts
+++ b/lib/components/schematic-box.ts
@@ -18,6 +18,7 @@ export const schematicBoxProps = z
 
     schX: distance.optional(),
     schY: distance.optional(),
+    schSheetName: z.string().optional(),
     width: distance.optional(),
     height: distance.optional(),
     overlay: z.array(z.string()).optional(),
@@ -65,6 +66,7 @@ export interface SchematicBoxProps {
   schPinArrangement?: SchematicPinArrangement
   schX?: Distance
   schY?: Distance
+  schSheetName?: string
   width?: Distance
   height?: Distance
   overlay?: string[]

--- a/tests/schematic-box.test.ts
+++ b/tests/schematic-box.test.ts
@@ -24,6 +24,7 @@ test("should parse schematic box chip reference props", () => {
   const raw: SchematicBoxProps = {
     name: "U1A",
     chipRef: "U1",
+    schSheetName: "Power Sheet",
     width: 2.245,
     height: 1,
     pinLabels: {
@@ -40,6 +41,7 @@ test("should parse schematic box chip reference props", () => {
 
   expect(parsed.name).toBe("U1A")
   expect(parsed.chipRef).toBe("U1")
+  expect(parsed.schSheetName).toBe("Power Sheet")
   expect(parsed.pinLabels).toEqual({ pin1: "VCC", pin2: "GND" })
   expect(parsed.schPinArrangement).toEqual({
     leftSide: {


### PR DESCRIPTION
## Summary

- add `schSheetName` to the `schematicBoxProps` validator
- expose `schSheetName` on `SchematicBoxProps`
- cover parsing the prop in the schematic box test
- regenerate the props documentation

## Why

A schematic box can inherit a schematic sheet from a parent, but TSX authors cannot currently assign a board-level sibling `<schematicbox />` directly to a `<schematicsheet />`. Core already resolves `schSheetName` when rendering schematic primitives; the props schema and public interface were the missing boundary.

This enables flat multi-sheet layouts such as `<schematicbox schSheetName="Power Sheet" />` without requiring a wrapper group.

## Validation

- `bun test tests/schematic-box.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run build`
- all required documentation generators from `AGENTS.md`