### PR TITLE
Support children in schematic sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1672,6 +1672,7 @@ export interface SchematicSectionProps {
   displayName?: string;
   name: string;
   sectionTitleFontSize?: number | string;
+  children?: any;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -3692,11 +3692,13 @@ export interface SchematicSectionProps {
   displayName?: string
   name: string
   sectionTitleFontSize?: number | string
+  children?: any
 }
 export const schematicSectionProps = z.object({
   displayName: z.string().optional(),
   name: z.string(),
   sectionTitleFontSize: distance.optional(),
+  children: z.any().optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -2089,6 +2089,7 @@ export interface SchematicSectionProps {
   displayName?: string
   name: string
   sectionTitleFontSize?: number | string
+  children?: any
 }
 
 

--- a/lib/components/schematic-section.ts
+++ b/lib/components/schematic-section.ts
@@ -6,12 +6,14 @@ export interface SchematicSectionProps {
   displayName?: string
   name: string
   sectionTitleFontSize?: number | string
+  children?: any
 }
 
 export const schematicSectionProps = z.object({
   displayName: z.string().optional(),
   name: z.string(),
   sectionTitleFontSize: distance.optional(),
+  children: z.any().optional(),
 })
 
 export type InferredSchematicSectionProps = z.input<

--- a/tests/schematic-section.test.ts
+++ b/tests/schematic-section.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import {
+  schematicSectionProps,
+  type SchematicSectionProps,
+} from "lib/components/schematic-section"
+import { expectTypeOf } from "expect-type"
+
+test("should parse schematic section children", () => {
+  const raw: SchematicSectionProps = {
+    name: "power",
+    displayName: "Power",
+    children: [{ type: "resistor", props: { name: "R1" } }],
+  }
+
+  expectTypeOf(raw).toMatchTypeOf<SchematicSectionProps>()
+  const parsed = schematicSectionProps.parse(raw)
+  expect(parsed.children).toEqual([{ type: "resistor", props: { name: "R1" } }])
+})


### PR DESCRIPTION
## Summary

- add optional `children` support to `SchematicSectionProps` and its Zod schema
- regenerate the public props documentation
- add coverage for parsing nested schematic section children

## Why

`<schematicsection>` is intended to work as a container, similar to `<schematicsheet>`, but its public prop type and parser did not accept `children`. This prevented users from expressing section membership by nesting JSX inside the section element.

## Impact

Users can type and parse nested children in `<schematicsection>` elements. The corresponding Core change makes those descendants inherit section membership and participate in section-aware layout.

## Validation

- `bun test` (375 tests passed)
- `bun run typecheck`
- `bun run format:check`
- `bun run build`
- all required documentation generators