### PR TITLE
Add schSectionName to schematic box props

### DIFF
--- a/README.md
+++ b/README.md
@@ -1547,6 +1547,7 @@ export interface SchematicBoxProps {
   schPinArrangement?: SchematicPinArrangement;
   schX?: Distance;
   schY?: Distance;
+  schSectionName?: string;
   schSheetName?: string;
   width?: Distance;
   height?: Distance;

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -3500,6 +3500,7 @@ export const schematicBoxProps = z
 
     schX: distance.optional(),
     schY: distance.optional(),
+    schSectionName: z.string().optional(),
     schSheetName: z.string().optional(),
     width: distance.optional(),
     height: distance.optional(),
@@ -3525,6 +3526,7 @@ export interface SchematicBoxProps {
   schPinArrangement?: SchematicPinArrangement
   schX?: Distance
   schY?: Distance
+  schSectionName?: string
   schSheetName?: string
   width?: Distance
   height?: Distance

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1975,6 +1975,7 @@ export interface SchematicBoxProps {
   schPinArrangement?: SchematicPinArrangement
   schX?: Distance
   schY?: Distance
+  schSectionName?: string
   schSheetName?: string
   width?: Distance
   height?: Distance

--- a/lib/components/schematic-box.ts
+++ b/lib/components/schematic-box.ts
@@ -18,6 +18,7 @@ export const schematicBoxProps = z
 
     schX: distance.optional(),
     schY: distance.optional(),
+    schSectionName: z.string().optional(),
     schSheetName: z.string().optional(),
     width: distance.optional(),
     height: distance.optional(),
@@ -66,6 +67,7 @@ export interface SchematicBoxProps {
   schPinArrangement?: SchematicPinArrangement
   schX?: Distance
   schY?: Distance
+  schSectionName?: string
   schSheetName?: string
   width?: Distance
   height?: Distance

--- a/tests/schematic-box.test.ts
+++ b/tests/schematic-box.test.ts
@@ -24,6 +24,7 @@ test("should parse schematic box chip reference props", () => {
   const raw: SchematicBoxProps = {
     name: "U1A",
     chipRef: "U1",
+    schSectionName: "Power Input",
     schSheetName: "Power Sheet",
     width: 2.245,
     height: 1,
@@ -41,6 +42,7 @@ test("should parse schematic box chip reference props", () => {
 
   expect(parsed.name).toBe("U1A")
   expect(parsed.chipRef).toBe("U1")
+  expect(parsed.schSectionName).toBe("Power Input")
   expect(parsed.schSheetName).toBe("Power Sheet")
   expect(parsed.pinLabels).toEqual({ pin1: "VCC", pin2: "GND" })
   expect(parsed.schPinArrangement).toEqual({


### PR DESCRIPTION
## Summary

- add optional `schSectionName` support to `schematicBoxProps` and `SchematicBoxProps`
- extend the schematic box parser test to cover section and sheet names together
- regenerate the component type and props documentation

`schSheetName` was already present, so this PR leaves its existing implementation unchanged.

## Why

Schematic boxes should be able to target a named section within a schematic sheet using the same `schSectionName` convention exposed by shared schematic layout props.

## Impact

TSX authors can now pass `schSectionName` to `<schematicbox />`. The accepted and parsed value is an optional string; there are no defaults, aliases, conflicts, or migration requirements.

## Validation

- `bun test` (374 passing)
- `bun run typecheck`
- `bun run build`
- `bun run format:check`
- `git diff --check`
- all four repository-required documentation generators