### PR TITLE
feat: add topola autorouter preset

### DIFF
--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -352,6 +352,7 @@ export interface AutorouterConfig {
     | "tscircuit_beta"
     | "krt"
     | "freerouting"
+    | "topola"
     | "laser_prefab" // Prefabricated PCB with laser copper ablation
     | /** @deprecated Use "auto_jumper" */ "auto-jumper"
     | /** @deprecated Use "sequential_trace" */ "sequential-trace"
@@ -370,6 +371,7 @@ export type AutorouterPreset =
   | "tscircuit_beta"
   | "krt"
   | "freerouting"
+  | "topola"
   | "laser_prefab"
   | "auto-jumper"
   | "sequential-trace"
@@ -424,6 +426,7 @@ export const autorouterConfig = z.object({
       "tscircuit_beta",
       "krt",
       "freerouting",
+      "topola",
       "laser_prefab",
       "auto-jumper",
       "sequential-trace",
@@ -445,6 +448,7 @@ export const autorouterPreset = z.union([
   z.literal("tscircuit_beta"),
   z.literal("krt"),
   z.literal("freerouting"),
+  z.literal("topola"),
   z.literal("laser_prefab"), // Prefabricated PCB with laser copper ablation
   z.literal("auto-jumper"),
   z.literal("sequential-trace"),


### PR DESCRIPTION
## Summary
- Add `"topola"` to `AutorouterPreset` / zod schemas so `autorouter="topola"` is a first-class preset name (alongside `krt` / `freerouting`).

## Context
https://github.com/tscircuit/tscircuit/issues/4078

Companion PRs:
- core: wire preset → local solve-endpoint
- docs: document Topola adapter usage

Reference adapter: https://github.com/djmango/lightbar-dock/tree/master/packages/topola-autorouter

## Test plan
- [ ] Types / zod still accept existing presets
- [ ] `"topola"` is a valid `AutorouterProp` string