### PR TITLE
fix: validate fuse connections against its pin labels (#754)

### DIFF
--- a/lib/components/fuse.ts
+++ b/lib/components/fuse.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import { createConnectionsProp } from "lib/common/connectionsProp"
 import {
   type CommonComponentProps,
   commonComponentProps,
@@ -8,6 +9,7 @@ import {
   type SchematicOrientation,
 } from "lib/common/schematicOrientation"
 import type { Connections } from "lib/utility-types/connections-and-selectors"
+import { expectTypesMatch } from "lib/typecheck"
 
 /**
  * Pin labels for fuse component
@@ -38,7 +40,7 @@ export interface FuseProps<PinLabel extends string = string>
   /**
    * Connections to other components
    */
-  connections?: Connections<PinLabel>
+  connections?: Connections<FusePinLabels>
 }
 
 /**
@@ -49,16 +51,9 @@ export const fuseProps = commonComponentProps.extend({
   voltageRating: z.union([z.number(), z.string()]).optional(),
   schShowRatings: z.boolean().optional(),
   schOrientation: schematicOrientation.optional(),
-  connections: z
-    .record(
-      z.string(),
-      z.union([
-        z.string(),
-        z.array(z.string()).readonly(),
-        z.array(z.string()),
-      ]),
-    )
-    .optional(),
+  connections: createConnectionsProp(fusePinLabels).optional(),
 })
 
 export type InferredFuseProps = z.input<typeof fuseProps>
+
+expectTypesMatch<FuseProps, InferredFuseProps>(true)

--- a/tests/fuse-connections.test.ts
+++ b/tests/fuse-connections.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import { capacitorProps } from "lib/components/capacitor"
+import { fuseProps } from "lib/components/fuse"
+
+const parseFuse = (connections: unknown) =>
+  fuseProps.safeParse({ name: "F1", currentRating: "1A", connections })
+
+test("fuse accepts its real pin labels in connections", () => {
+  expect(parseFuse({ pin1: ".R1 > .pin1" }).success).toBe(true)
+  expect(parseFuse({ pin2: ".R1 > .pin1" }).success).toBe(true)
+  expect(parseFuse({ pin1: ".R1 > .pin1", pin2: ".R2 > .pin1" }).success).toBe(
+    true,
+  )
+})
+
+test("fuse rejects a pin label it does not have", () => {
+  // Previously accepted: the schema used a bare z.record(z.string(), ...) so
+  // any key at all passed, including a typo'd pin that the fuse has no port for.
+  expect(parseFuse({ pin99: ".R1 > .pin1" }).success).toBe(false)
+  expect(parseFuse({ "not a pin at all": ".R1 > .pin1" }).success).toBe(false)
+  expect(parseFuse({ "": ".R1 > .pin1" }).success).toBe(false)
+})
+
+test("fuse validates connections the same way the other two-pin passives do", () => {
+  // Same typo, same shape of component — these must agree.
+  const typo = { pin99: ".R1 > .pin1" }
+
+  expect(parseFuse(typo).success).toBe(
+    capacitorProps.safeParse({
+      name: "C1",
+      capacitance: "1uF",
+      connections: typo,
+    }).success,
+  )
+})
+
+test("fuse still accepts array and readonly-array connection targets", () => {
+  expect(parseFuse({ pin1: [".R1 > .pin1", ".R2 > .pin1"] }).success).toBe(true)
+  expect(
+    parseFuse({ pin1: [".R1 > .pin1"] as readonly string[] }).success,
+  ).toBe(true)
+})
+
+test("connections stays optional on fuse", () => {
+  expect(fuseProps.safeParse({ name: "F1", currentRating: "1A" }).success).toBe(
+    true,
+  )
+})


### PR DESCRIPTION
Fixes #754.

### What was wrong

`fuseProps` accepted **any string** as a `connections` key. Same typo, same class of component, opposite result:

```ts
const typo = { pin99: ".R1 > .pin1" }

fuseProps.safeParse({ name: "F1", currentRating: "1A", connections: typo })      // success ❌
capacitorProps.safeParse({ name: "C1", capacitance: "1uF", connections: typo })  // fails   ✅
```

`{ "not a pin at all": ... }` and `{ "": ... }` got through too.

Two gaps caused it:

1. **The schema was hand-rolled.** Every other component does `createConnectionsProp(<its>PinLabels)`, which keys the record on `z.enum(labels)`. Fuse used a bare `z.record(z.string(), ...)`, so any key passed — even though the file already defines and exports `fusePinLabels = ["pin1", "pin2"]`.

2. **Nothing held the schema to the interface.** `FuseProps` declared `connections?: Connections<PinLabel>` while the schema produced `Record<string, ...>`. **Fuse is the only file in `lib/components/` that exports both an interface and an `Inferred*` type without calling `expectTypesMatch`** — I checked all 20 files that omit it, and the other 19 don't export both, so this was the single gap. Dropping the assertion into the file as-shipped fails to compile:

```
error TS2345: Argument of type 'true' is not assignable to parameter of
type '"property connections has mismatched types"'.
```

The types had silently drifted because the invariant was never applied here.

### The fix

Three lines of substance, all bringing fuse in line with the existing convention:

- `connections: createConnectionsProp(fusePinLabels).optional()` — the same helper and the same pin-label source everything else uses.
- `connections?: Connections<FusePinLabels>` on the interface, matching how `CapacitorProps` and `ResistorProps` pin theirs to concrete labels rather than the free `PinLabel` parameter.
- `expectTypesMatch<FuseProps, InferredFuseProps>(true)` at the bottom, so this can't drift again.

No new helper, no new convention — the repo already had all of it.

### Tests

`tests/fuse-connections.test.ts`, five tests pinning both directions:

| case | expected |
|---|---|
| `pin1`, `pin2`, and both together | accepted |
| `pin99`, `"not a pin at all"`, `""` | rejected |
| the same typo through `fuseProps` vs `capacitorProps` | **results must be equal** — asserted by comparison, not against a hardcoded `false` |
| array and `readonly` array targets on `pin1` | still accepted |
| no `connections` at all | still accepted (stays optional) |

The comparison test is the one that matters: it fails if fuse and the other two-pin passives ever disagree again, in either direction. The last two rows are guard rails against over-tightening — a change that simply rejected more would break them.

Bite-proofed: reverting only `lib/components/fuse.ts` takes the file from **5 pass** to **3 pass / 2 fail**.

### Verification

`bun test`: **388 pass / 0 fail** (baseline on `main` is 383 pass / 0 fail; +5 new). `bunx tsc --noEmit` clean — which is itself part of the fix, since the new `expectTypesMatch` would fail the type-check if the schema and interface disagreed. `bun run format:check` clean.
