### PR TITLE
fix: require pinHeader pinCount to be a positive integer (#756)

### DIFF
--- a/lib/components/pin-header.ts
+++ b/lib/components/pin-header.ts
@@ -123,7 +123,7 @@ export interface PinHeaderProps extends CommonComponentProps {
 }
 
 export const pinHeaderProps = commonComponentProps.extend({
-  pinCount: z.number(),
+  pinCount: z.number().int().positive(),
   pitch: distance.optional(),
   schFacingDirection: z.enum(["up", "down", "left", "right"]).optional(),
   gender: z.enum(["male", "female", "unpopulated"]).optional().default("male"),

--- a/tests/pin-header-pin-count.test.ts
+++ b/tests/pin-header-pin-count.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import { pinHeaderProps } from "lib/components/pin-header"
+
+const parse = (pinCount: unknown) =>
+  pinHeaderProps.safeParse({ name: "H1", pinCount })
+
+test("pinCount accepts whole positive counts", () => {
+  expect(parse(1).success).toBe(true)
+  expect(parse(4).success).toBe(true)
+  expect(parse(40).success).toBe(true)
+})
+
+test("pinCount rejects a fractional count", () => {
+  // Previously accepted. A fractional count produced a header whose port count
+  // and pad count disagreed (pinCount 2.5 -> 2 source_ports but 3 pads) with no
+  // error raised anywhere.
+  expect(parse(2.5).success).toBe(false)
+  expect(parse(3.7).success).toBe(false)
+})
+
+test("pinCount rejects zero and negative counts", () => {
+  // A header with no pins is not a header; these previously reached the renderer
+  // and surfaced later as an unrelated pcb_missing_footprint_error.
+  expect(parse(0).success).toBe(false)
+  expect(parse(-4).success).toBe(false)
+})
+
+test("pinCount rejects non-finite counts", () => {
+  expect(parse(Number.NaN).success).toBe(false)
+  expect(parse(Number.POSITIVE_INFINITY).success).toBe(false)
+})
+
+test("pinCount is still required", () => {
+  // The guard must not turn a required prop into an optional one.
+  expect(pinHeaderProps.safeParse({ name: "H1" }).success).toBe(false)
+})
+
+test("a valid pinCount still parses to the same value", () => {
+  const result = pinHeaderProps.safeParse({ name: "H1", pinCount: 8 })
+
+  expect(result.success).toBe(true)
+  if (result.success) expect(result.data.pinCount).toBe(8)
+})


### PR DESCRIPTION
Fixes #756. Independent of my #755 (different file) — either order.

### What was wrong

`pinCount: z.number()` accepted fractional, zero, negative and infinite values. The fractional case is the damaging one — it produces a header whose **ports and pads disagree**, silently:

| `pinCount` | `source_port`s | pads | errors |
|---|---|---|---|
| 2 | 2 | 2 | 0 |
| **2.5** | **2** | **3** | **0** |
| 3 | 3 | 3 | 0 |
| **3.7** | **3** | **4** | **0** |
| 4 | 4 | 4 | 0 |

Every whole number agrees; every fractional one leaves a pad with no port behind it. That renders and exports without complaint.

Zero and negative counts fail too, but later and misleadingly — they surface as `pcb_missing_footprint_error`, which points at the footprint when the mistake was the count.

### The fix

```ts
- pinCount: z.number(),
+ pinCount: z.number().int().positive(),
```

`.int()` catches the fractional case, `.positive()` catches `0` and negatives, and together they also reject `Infinity` (which `z.number()` lets through — it only excludes `NaN`).

This is the idiom the repo already uses: `lib/components/analogacsweepsimulation.ts` has `z.number().int().positive()` for `sampleCount` and `samplesPerInterval`. No new convention.

### Scope

`pinCount` only. I checked the neighbouring schemas rather than assuming — it's the sole bare `z.number()` in `pin-header.ts`, and `breakout.ts` / `chip.ts` have no comparable count field taking a raw number. Anything broader would be speculative.

### Tests

`tests/pin-header-pin-count.test.ts`, six tests pinning both directions:

| case | expected |
|---|---|
| `1`, `4`, `40` | accepted |
| `2.5`, `3.7` | rejected |
| `0`, `-4` | rejected |
| `NaN`, `Infinity` | rejected |
| no `pinCount` at all | still rejected — the guard must not make a required prop optional |
| `pinCount: 8` | parses through to `8` unchanged |

The last two rows are the guard rails: a change that made the field optional, or that coerced values, would break them while a bare "rejects bad input" check would not.

Bite-proofed: reverting only `lib/components/pin-header.ts` takes the file from **6 pass** to **3 pass / 3 fail**.

### Verification

`bun test`: **389 pass / 0 fail** (baseline on `main` is 383 pass / 0 fail; +6 new). `bunx tsc --noEmit` clean, `bun run format:check` clean.
