### PR TITLE
Add via-in-pad autorouter opt-in

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2329,6 +2329,7 @@ export interface AutorouterConfig {
   cache?: PcbRouteCache
   traceClearance?: Distance
   availableJumperTypes?: Array<"1206x4" | "0603">
+  allowViaInPad?: boolean
   groupMode?:
     | "sequential_trace"
     | "subcircuit"
@@ -2371,6 +2372,12 @@ export const autorouterConfig = z.object({
   cache: z.custom<PcbRouteCache>((v) => true).optional(),
   traceClearance: length.optional(),
   availableJumperTypes: z.array(z.enum(["1206x4", "0603"])).optional(),
+  allowViaInPad: z
+    .boolean()
+    .optional()
+    .describe(
+      "Allows the autorouter to place vias inside connected pads. Omitted or false keeps via-in-pad routing disabled.",
+    ),
   groupMode: z
     .enum(["sequential_trace", "subcircuit", "sequential-trace"])
     .optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -148,10 +148,6 @@ export interface AutorouterConfig {
   cache?: PcbRouteCache
   traceClearance?: Distance
   availableJumperTypes?: Array<"1206x4" | "0603">
-  /**
-   * Allows the autorouter to place vias inside connected pads.
-   * Omitted or false keeps via-in-pad routing disabled.
-   */
   allowViaInPad?: boolean
   groupMode?:
     | "sequential_trace"

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -148,6 +148,11 @@ export interface AutorouterConfig {
   cache?: PcbRouteCache
   traceClearance?: Distance
   availableJumperTypes?: Array<"1206x4" | "0603">
+  /**
+   * Allows the autorouter to place vias inside connected pads.
+   * Omitted or false keeps via-in-pad routing disabled.
+   */
+  allowViaInPad?: boolean
   groupMode?:
     | "sequential_trace"
     | "subcircuit"

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -335,6 +335,11 @@ export interface AutorouterConfig {
   cache?: PcbRouteCache
   traceClearance?: Distance
   availableJumperTypes?: Array<"1206x4" | "0603">
+  /**
+   * Allows the autorouter to place vias inside connected pads.
+   * Omitted or false keeps via-in-pad routing disabled.
+   */
+  allowViaInPad?: boolean
   groupMode?:
     | "sequential_trace"
     | "subcircuit"
@@ -404,6 +409,12 @@ export const autorouterConfig = z.object({
   cache: z.custom<PcbRouteCache>((v) => true).optional(),
   traceClearance: length.optional(),
   availableJumperTypes: z.array(z.enum(["1206x4", "0603"])).optional(),
+  allowViaInPad: z
+    .boolean()
+    .optional()
+    .describe(
+      "Allows the autorouter to place vias inside connected pads. Omitted or false keeps via-in-pad routing disabled.",
+    ),
   groupMode: z
     .enum(["sequential_trace", "subcircuit", "sequential-trace"])
     .optional(),

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -335,10 +335,6 @@ export interface AutorouterConfig {
   cache?: PcbRouteCache
   traceClearance?: Distance
   availableJumperTypes?: Array<"1206x4" | "0603">
-  /**
-   * Allows the autorouter to place vias inside connected pads.
-   * Omitted or false keeps via-in-pad routing disabled.
-   */
   allowViaInPad?: boolean
   groupMode?:
     | "sequential_trace"

--- a/tests/autorouter.test.ts
+++ b/tests/autorouter.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from "bun:test"
 import {
+  autorouterConfig,
   autorouterProp,
   routingTolerances,
   subcircuitGroupPropsWithBool,
+  type AutorouterConfig,
   type RoutingTolerances,
 } from "../lib/components/group"
 
@@ -27,6 +29,15 @@ test("supports default preset", () => {
 test("supports auto jumper preset", () => {
   const result = autorouterProp.parse("auto_jumper")
   expect(result).toBe("auto_jumper")
+})
+
+test("supports opting in to via-in-pad routing", () => {
+  const enabled: AutorouterConfig = { allowViaInPad: true }
+  const disabled: AutorouterConfig = { allowViaInPad: false }
+
+  expect(autorouterConfig.parse(enabled).allowViaInPad).toBe(true)
+  expect(autorouterConfig.parse(disabled).allowViaInPad).toBe(false)
+  expect(autorouterConfig.parse({}).allowViaInPad).toBeUndefined()
 })
 
 test("supports laser prefab preset", () => {


### PR DESCRIPTION
## Summary

- add `allowViaInPad?: boolean` to `AutorouterConfig`
- validate the option through the public autorouter Zod schema
- document that omitted or `false` keeps via-in-pad routing disabled
- regenerate the component-types and props-overview documentation

## Why

Via-in-pad manufacturing can incur additional fabrication cost, so it should be an explicit autorouter opt-in. This props change establishes the user-facing API for the downstream Circuit JSON, core, and capacity-autorouter integrations.

This PR only introduces the props contract; it does not enable via-in-pad routing by itself.

## Validation

- `bun test` — 386 pass, 0 fail
- `bun run typecheck`
- `bun run build`
- `bun run format:check`
- `bun run check-circular-deps`
- all required documentation generators
