### PR TITLE
feat: add fanout autorouter phase props

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,12 +342,11 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
   connection?: string;
   connections?: string[];
   reroute?: boolean;
-  /** Selector for the component whose pads should be escaped in this phase. */
-  fanoutComponent?: string;
-  /** Direction in which complete buses should leave the selected component. */
-  fanoutDirection?: FanoutDirection;
-  /** Boundary edge or corner toward which buses should leave the component. */
-  fanoutPreferredExit?: FanoutPreferredExit;
+  /**
+   * Fanout direction for each named bus in this phase. `center` leaves the
+   * direction unconstrained.
+   */
+  busFanoutDirections?: Record<BusName, BusFanoutDirection>;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,12 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
   connection?: string;
   connections?: string[];
   reroute?: boolean;
+  /** Selector for the component whose pads should be escaped in this phase. */
+  fanoutComponent?: string;
+  /** Direction in which complete buses should leave the selected component. */
+  fanoutDirection?: FanoutDirection;
+  /** Boundary edge or corner toward which buses should leave the component. */
+  fanoutPreferredExit?: FanoutPreferredExit;
 }
 ```
 
@@ -437,10 +443,6 @@ export interface BusProps {
   name?: string;
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[];
-  /** Direction in which this complete bus should leave its source footprint. */
-  pcbFanoutDirection?: BusPcbFanoutDirection;
-  /** Board edge or corner toward which this complete bus should fan out. */
-  pcbFanoutPreferredExit?: BusPcbFanoutPreferredExit;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -437,6 +437,10 @@ export interface BusProps {
   name?: string;
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[];
+  /** Direction in which this complete bus should leave its source footprint. */
+  pcbFanoutDirection?: BusPcbFanoutDirection;
+  /** Board edge or corner toward which this complete bus should fan out. */
+  pcbFanoutPreferredExit?: BusPcbFanoutPreferredExit;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1285,11 +1285,26 @@ export const breakoutPointProps = pcbLayoutProps
 export interface BusProps {
   name?: string
   connections: string[]
+  pcbFanoutDirection?: BusPcbFanoutDirection
+  pcbFanoutPreferredExit?: BusPcbFanoutPreferredExit
 }
-/** Trace names or port selectors for the connections in the bus. */
+/** Board edge or corner toward which this complete bus should fan out. */
 export const busProps = z.object({
   name: z.string().optional(),
   connections: z.array(z.string()).min(2),
+  pcbFanoutDirection: z.enum(["left", "right", "up", "down"]).optional(),
+  pcbFanoutPreferredExit: z
+    .enum([
+      "left",
+      "right",
+      "top",
+      "bottom",
+      "top_left",
+      "top_right",
+      "bottom_left",
+      "bottom_right",
+    ])
+    .optional(),
 })
 ```
 
@@ -2347,6 +2362,8 @@ export interface AutorouterConfig {
     | "krt"
     | "freerouting"
     | "laser_prefab" // Prefabricated PCB with laser copper ablation
+    | "single_layer_fanout"
+    | "fanout"
     | /** @deprecated Use "auto_jumper" */ "auto-jumper"
     | /** @deprecated Use "sequential_trace" */ "sequential-trace"
     | /** @deprecated Use "auto_local" */ "auto-local"
@@ -2392,6 +2409,8 @@ export const autorouterConfig = z.object({
       "krt",
       "freerouting",
       "laser_prefab",
+      "single_layer_fanout",
+      "fanout",
       "auto-jumper",
       "sequential-trace",
       "auto-local",

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1142,7 +1142,11 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
   connection?: string
   connections?: string[]
   reroute?: boolean
+  fanoutComponent?: string
+  fanoutDirection?: FanoutDirection
+  fanoutPreferredExit?: FanoutPreferredExit
 }
+/** Boundary edge or corner toward which buses should leave the component. */
 export const autoroutingPhaseProps = z
   .object({
     key: z.any().optional(),
@@ -1162,6 +1166,20 @@ export const autoroutingPhaseProps = z
     connection: z.string().optional(),
     connections: z.array(z.string()).optional(),
     reroute: z.boolean().optional(),
+    fanoutComponent: z.string().optional(),
+    fanoutDirection: z.enum(["left", "right", "up", "down"]).optional(),
+    fanoutPreferredExit: z
+      .enum([
+        "left",
+        "right",
+        "top",
+        "bottom",
+        "top_left",
+        "top_right",
+        "bottom_left",
+        "bottom_right",
+      ])
+      .optional(),
   })
 ```
 
@@ -1285,26 +1303,11 @@ export const breakoutPointProps = pcbLayoutProps
 export interface BusProps {
   name?: string
   connections: string[]
-  pcbFanoutDirection?: BusPcbFanoutDirection
-  pcbFanoutPreferredExit?: BusPcbFanoutPreferredExit
 }
-/** Board edge or corner toward which this complete bus should fan out. */
+/** Trace names or port selectors for the connections in the bus. */
 export const busProps = z.object({
   name: z.string().optional(),
   connections: z.array(z.string()).min(2),
-  pcbFanoutDirection: z.enum(["left", "right", "up", "down"]).optional(),
-  pcbFanoutPreferredExit: z
-    .enum([
-      "left",
-      "right",
-      "top",
-      "bottom",
-      "top_left",
-      "top_right",
-      "bottom_left",
-      "bottom_right",
-    ])
-    .optional(),
 })
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1127,6 +1127,11 @@ export const analogTransientSimulationProps = z
 ### autoroutingphase
 
 ```typescript
+export type BusFanoutDirection =
+  | NinePointAnchor
+  | {
+      direction: NinePointAnchor
+    }
 export interface AutoroutingPhaseProps extends RoutingTolerances {
   key?: any
   name?: string
@@ -1142,11 +1147,12 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
   connection?: string
   connections?: string[]
   reroute?: boolean
-  fanoutComponent?: string
-  fanoutDirection?: FanoutDirection
-  fanoutPreferredExit?: FanoutPreferredExit
+  busFanoutDirections?: Record<BusName, BusFanoutDirection>
 }
-/** Boundary edge or corner toward which buses should leave the component. */
+/**
+   * Fanout direction for each named bus in this phase. `center` leaves the
+   * direction unconstrained.
+   */
 export const autoroutingPhaseProps = z
   .object({
     key: z.any().optional(),
@@ -1166,20 +1172,7 @@ export const autoroutingPhaseProps = z
     connection: z.string().optional(),
     connections: z.array(z.string()).optional(),
     reroute: z.boolean().optional(),
-    fanoutComponent: z.string().optional(),
-    fanoutDirection: z.enum(["left", "right", "up", "down"]).optional(),
-    fanoutPreferredExit: z
-      .enum([
-        "left",
-        "right",
-        "top",
-        "bottom",
-        "top_left",
-        "top_right",
-        "bottom_left",
-        "bottom_right",
-      ])
-      .optional(),
+    busFanoutDirections: z.record(busFanoutDirection).optional(),
   })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -204,6 +204,12 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
   connection?: string
   connections?: string[]
   reroute?: boolean
+  /** Selector for the component whose pads should be escaped in this phase. */
+  fanoutComponent?: string
+  /** Direction in which complete buses should leave the selected component. */
+  fanoutDirection?: FanoutDirection
+  /** Boundary edge or corner toward which buses should leave the component. */
+  fanoutPreferredExit?: FanoutPreferredExit
 }
 
 
@@ -414,10 +420,6 @@ export interface BusProps {
   name?: string
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[]
-  /** Direction in which this complete bus should leave its source footprint. */
-  pcbFanoutDirection?: BusPcbFanoutDirection
-  /** Board edge or corner toward which this complete bus should fan out. */
-  pcbFanoutPreferredExit?: BusPcbFanoutPreferredExit
 }
 
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -204,12 +204,11 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
   connection?: string
   connections?: string[]
   reroute?: boolean
-  /** Selector for the component whose pads should be escaped in this phase. */
-  fanoutComponent?: string
-  /** Direction in which complete buses should leave the selected component. */
-  fanoutDirection?: FanoutDirection
-  /** Boundary edge or corner toward which buses should leave the component. */
-  fanoutPreferredExit?: FanoutPreferredExit
+  /**
+   * Fanout direction for each named bus in this phase. `center` leaves the
+   * direction unconstrained.
+   */
+  busFanoutDirections?: Record<BusName, BusFanoutDirection>
 }
 
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -166,6 +166,8 @@ export interface AutorouterConfig {
     | "krt"
     | "freerouting"
     | "laser_prefab" // Prefabricated PCB with laser copper ablation
+    | "single_layer_fanout"
+    | "fanout"
     | /** @deprecated Use "auto_jumper" */ "auto-jumper"
     | /** @deprecated Use "sequential_trace" */ "sequential-trace"
     | /** @deprecated Use "auto_local" */ "auto-local"
@@ -412,6 +414,10 @@ export interface BusProps {
   name?: string
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[]
+  /** Direction in which this complete bus should leave its source footprint. */
+  pcbFanoutDirection?: BusPcbFanoutDirection
+  /** Board edge or corner toward which this complete bus should fan out. */
+  pcbFanoutPreferredExit?: BusPcbFanoutPreferredExit
 }
 
 

--- a/lib/common/ninePointAnchor.ts
+++ b/lib/common/ninePointAnchor.ts
@@ -11,3 +11,5 @@ export const ninePointAnchor = z.enum([
   "bottom_center",
   "bottom_right",
 ])
+
+export type NinePointAnchor = z.infer<typeof ninePointAnchor>

--- a/lib/components/autoroutingphase.ts
+++ b/lib/components/autoroutingphase.ts
@@ -1,23 +1,22 @@
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 import {
+  type NinePointAnchor,
+  ninePointAnchor,
+} from "../common/ninePointAnchor"
+import type { BusName } from "./bus"
+import {
   type AutorouterProp,
   type RoutingTolerances,
   autorouterProp,
   routingTolerances,
 } from "./group"
 
-export type FanoutDirection = "left" | "right" | "up" | "down"
-
-export type FanoutPreferredExit =
-  | "left"
-  | "right"
-  | "top"
-  | "bottom"
-  | "top_left"
-  | "top_right"
-  | "bottom_left"
-  | "bottom_right"
+export type BusFanoutDirection =
+  | NinePointAnchor
+  | {
+      direction: NinePointAnchor
+    }
 
 export interface AutoroutingPhaseProps extends RoutingTolerances {
   key?: any
@@ -34,13 +33,17 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
   connection?: string
   connections?: string[]
   reroute?: boolean
-  /** Selector for the component whose pads should be escaped in this phase. */
-  fanoutComponent?: string
-  /** Direction in which complete buses should leave the selected component. */
-  fanoutDirection?: FanoutDirection
-  /** Boundary edge or corner toward which buses should leave the component. */
-  fanoutPreferredExit?: FanoutPreferredExit
+  /**
+   * Fanout direction for each named bus in this phase. `center` leaves the
+   * direction unconstrained.
+   */
+  busFanoutDirections?: Record<BusName, BusFanoutDirection>
 }
+
+const busFanoutDirection = z.union([
+  ninePointAnchor,
+  z.object({ direction: ninePointAnchor }),
+])
 
 export const autoroutingPhaseProps = z
   .object({
@@ -61,20 +64,7 @@ export const autoroutingPhaseProps = z
     connection: z.string().optional(),
     connections: z.array(z.string()).optional(),
     reroute: z.boolean().optional(),
-    fanoutComponent: z.string().optional(),
-    fanoutDirection: z.enum(["left", "right", "up", "down"]).optional(),
-    fanoutPreferredExit: z
-      .enum([
-        "left",
-        "right",
-        "top",
-        "bottom",
-        "top_left",
-        "top_right",
-        "bottom_left",
-        "bottom_right",
-      ])
-      .optional(),
+    busFanoutDirections: z.record(busFanoutDirection).optional(),
   })
   .superRefine((value, ctx) => {
     if (
@@ -88,18 +78,6 @@ export const autoroutingPhaseProps = z
         message:
           "region, connection, or connections is required when reroute is provided",
         path: ["region"],
-      })
-    }
-    if (
-      value.fanoutComponent === undefined &&
-      (value.fanoutDirection !== undefined ||
-        value.fanoutPreferredExit !== undefined)
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          "fanoutComponent is required when fanoutDirection or fanoutPreferredExit is provided",
-        path: ["fanoutComponent"],
       })
     }
   })

--- a/lib/components/autoroutingphase.ts
+++ b/lib/components/autoroutingphase.ts
@@ -7,6 +7,18 @@ import {
   routingTolerances,
 } from "./group"
 
+export type FanoutDirection = "left" | "right" | "up" | "down"
+
+export type FanoutPreferredExit =
+  | "left"
+  | "right"
+  | "top"
+  | "bottom"
+  | "top_left"
+  | "top_right"
+  | "bottom_left"
+  | "bottom_right"
+
 export interface AutoroutingPhaseProps extends RoutingTolerances {
   key?: any
   name?: string
@@ -22,6 +34,12 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
   connection?: string
   connections?: string[]
   reroute?: boolean
+  /** Selector for the component whose pads should be escaped in this phase. */
+  fanoutComponent?: string
+  /** Direction in which complete buses should leave the selected component. */
+  fanoutDirection?: FanoutDirection
+  /** Boundary edge or corner toward which buses should leave the component. */
+  fanoutPreferredExit?: FanoutPreferredExit
 }
 
 export const autoroutingPhaseProps = z
@@ -43,6 +61,20 @@ export const autoroutingPhaseProps = z
     connection: z.string().optional(),
     connections: z.array(z.string()).optional(),
     reroute: z.boolean().optional(),
+    fanoutComponent: z.string().optional(),
+    fanoutDirection: z.enum(["left", "right", "up", "down"]).optional(),
+    fanoutPreferredExit: z
+      .enum([
+        "left",
+        "right",
+        "top",
+        "bottom",
+        "top_left",
+        "top_right",
+        "bottom_left",
+        "bottom_right",
+      ])
+      .optional(),
   })
   .superRefine((value, ctx) => {
     if (
@@ -56,6 +88,18 @@ export const autoroutingPhaseProps = z
         message:
           "region, connection, or connections is required when reroute is provided",
         path: ["region"],
+      })
+    }
+    if (
+      value.fanoutComponent === undefined &&
+      (value.fanoutDirection !== undefined ||
+        value.fanoutPreferredExit !== undefined)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "fanoutComponent is required when fanoutDirection or fanoutPreferredExit is provided",
+        path: ["fanoutComponent"],
       })
     }
   })

--- a/lib/components/bus.ts
+++ b/lib/components/bus.ts
@@ -1,6 +1,18 @@
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
+export type BusPcbFanoutDirection = "left" | "right" | "up" | "down"
+
+export type BusPcbFanoutPreferredExit =
+  | "left"
+  | "right"
+  | "top"
+  | "bottom"
+  | "top_left"
+  | "top_right"
+  | "bottom_left"
+  | "bottom_right"
+
 /**
  * Declares a group of connections that an autorouter should keep together.
  * Each connection may be a trace name or a port selector.
@@ -9,11 +21,28 @@ export interface BusProps {
   name?: string
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[]
+  /** Direction in which this complete bus should leave its source footprint. */
+  pcbFanoutDirection?: BusPcbFanoutDirection
+  /** Board edge or corner toward which this complete bus should fan out. */
+  pcbFanoutPreferredExit?: BusPcbFanoutPreferredExit
 }
 
 export const busProps = z.object({
   name: z.string().optional(),
   connections: z.array(z.string()).min(2),
+  pcbFanoutDirection: z.enum(["left", "right", "up", "down"]).optional(),
+  pcbFanoutPreferredExit: z
+    .enum([
+      "left",
+      "right",
+      "top",
+      "bottom",
+      "top_left",
+      "top_right",
+      "bottom_left",
+      "bottom_right",
+    ])
+    .optional(),
 })
 
 type InferredBusProps = z.input<typeof busProps>

--- a/lib/components/bus.ts
+++ b/lib/components/bus.ts
@@ -1,18 +1,6 @@
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
-export type BusPcbFanoutDirection = "left" | "right" | "up" | "down"
-
-export type BusPcbFanoutPreferredExit =
-  | "left"
-  | "right"
-  | "top"
-  | "bottom"
-  | "top_left"
-  | "top_right"
-  | "bottom_left"
-  | "bottom_right"
-
 /**
  * Declares a group of connections that an autorouter should keep together.
  * Each connection may be a trace name or a port selector.
@@ -21,28 +9,11 @@ export interface BusProps {
   name?: string
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[]
-  /** Direction in which this complete bus should leave its source footprint. */
-  pcbFanoutDirection?: BusPcbFanoutDirection
-  /** Board edge or corner toward which this complete bus should fan out. */
-  pcbFanoutPreferredExit?: BusPcbFanoutPreferredExit
 }
 
 export const busProps = z.object({
   name: z.string().optional(),
   connections: z.array(z.string()).min(2),
-  pcbFanoutDirection: z.enum(["left", "right", "up", "down"]).optional(),
-  pcbFanoutPreferredExit: z
-    .enum([
-      "left",
-      "right",
-      "top",
-      "bottom",
-      "top_left",
-      "top_right",
-      "bottom_left",
-      "bottom_right",
-    ])
-    .optional(),
 })
 
 type InferredBusProps = z.input<typeof busProps>

--- a/lib/components/bus.ts
+++ b/lib/components/bus.ts
@@ -1,6 +1,8 @@
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
+export type BusName = string
+
 /**
  * Declares a group of connections that an autorouter should keep together.
  * Each connection may be a trace name or a port selector.

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -353,6 +353,8 @@ export interface AutorouterConfig {
     | "krt"
     | "freerouting"
     | "laser_prefab" // Prefabricated PCB with laser copper ablation
+    | "single_layer_fanout"
+    | "fanout"
     | /** @deprecated Use "auto_jumper" */ "auto-jumper"
     | /** @deprecated Use "sequential_trace" */ "sequential-trace"
     | /** @deprecated Use "auto_local" */ "auto-local"
@@ -371,6 +373,8 @@ export type AutorouterPreset =
   | "krt"
   | "freerouting"
   | "laser_prefab"
+  | "single_layer_fanout"
+  | "fanout"
   | "auto-jumper"
   | "sequential-trace"
   | "auto-local"
@@ -425,6 +429,8 @@ export const autorouterConfig = z.object({
       "krt",
       "freerouting",
       "laser_prefab",
+      "single_layer_fanout",
+      "fanout",
       "auto-jumper",
       "sequential-trace",
       "auto-local",
@@ -446,6 +452,8 @@ export const autorouterPreset = z.union([
   z.literal("krt"),
   z.literal("freerouting"),
   z.literal("laser_prefab"), // Prefabricated PCB with laser copper ablation
+  z.literal("single_layer_fanout"),
+  z.literal("fanout"),
   z.literal("auto-jumper"),
   z.literal("sequential-trace"),
   z.literal("auto-local"),

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/node": "^20.12.11",
     "@types/react": "^18.3.2",
     "ava": "^6.1.3",
-    "circuit-json": "^0.0.450",
+    "circuit-json": "^0.0.455",
     "expect-type": "^1.3.0",
     "glob": "^11.0.0",
     "madge": "^8.0.0",

--- a/tests/autorouter.test.ts
+++ b/tests/autorouter.test.ts
@@ -44,6 +44,16 @@ test("supports krt preset", () => {
   expect(result).toBe("krt")
 })
 
+test("supports fanout presets", () => {
+  expect(autorouterProp.parse("single_layer_fanout")).toBe(
+    "single_layer_fanout",
+  )
+  expect(autorouterProp.parse("fanout")).toBe("fanout")
+  expect(autorouterProp.parse({ preset: "fanout" })).toMatchObject({
+    preset: "fanout",
+  })
+})
+
 test("still supports deprecated kebab-case presets", () => {
   const result = autorouterProp.parse("auto-cloud")
   expect(result).toBe("auto-cloud")

--- a/tests/autoroutingphase.test.ts
+++ b/tests/autoroutingphase.test.ts
@@ -30,6 +30,26 @@ test("autorouting phase accepts autorouter and phase index", () => {
   expect(parsed.phaseIndex).toBe(1)
 })
 
+test("autorouting phase accepts component-scoped fanout controls", () => {
+  const raw = {
+    autorouter: "fanout",
+    fanoutComponent: ".U1",
+    fanoutDirection: "right",
+    fanoutPreferredExit: "top_right",
+  } satisfies AutoroutingPhaseProps
+
+  expect(autoroutingPhaseProps.parse(raw)).toEqual(raw)
+})
+
+test("autorouting phase requires a component for directed fanout", () => {
+  expect(
+    autoroutingPhaseProps.safeParse({
+      autorouter: "fanout",
+      fanoutDirection: "right",
+    }).success,
+  ).toBe(false)
+})
+
 test("autorouting phase accepts a single connection", () => {
   const raw: AutoroutingPhaseProps = {
     phaseIndex: 2,

--- a/tests/autoroutingphase.test.ts
+++ b/tests/autoroutingphase.test.ts
@@ -30,24 +30,16 @@ test("autorouting phase accepts autorouter and phase index", () => {
   expect(parsed.phaseIndex).toBe(1)
 })
 
-test("autorouting phase accepts component-scoped fanout controls", () => {
+test("autorouting phase accepts per-bus fanout directions", () => {
   const raw = {
     autorouter: "fanout",
-    fanoutComponent: ".U1",
-    fanoutDirection: "right",
-    fanoutPreferredExit: "top_right",
+    busFanoutDirections: {
+      DATA: "top_right",
+      CONTROL: { direction: "center_left" },
+    },
   } satisfies AutoroutingPhaseProps
 
   expect(autoroutingPhaseProps.parse(raw)).toEqual(raw)
-})
-
-test("autorouting phase requires a component for directed fanout", () => {
-  expect(
-    autoroutingPhaseProps.safeParse({
-      autorouter: "fanout",
-      fanoutDirection: "right",
-    }).success,
-  ).toBe(false)
 })
 
 test("autorouting phase accepts a single connection", () => {

--- a/tests/bus.test.ts
+++ b/tests/bus.test.ts
@@ -5,6 +5,8 @@ test("busProps accepts two or more connection references", () => {
   const rawProps: BusProps = {
     name: "DATA",
     connections: ["D0", ".U1 > .D1"],
+    pcbFanoutDirection: "right",
+    pcbFanoutPreferredExit: "top_right",
   }
 
   expect(busProps.parse(rawProps)).toEqual(rawProps)

--- a/tests/bus.test.ts
+++ b/tests/bus.test.ts
@@ -5,8 +5,6 @@ test("busProps accepts two or more connection references", () => {
   const rawProps: BusProps = {
     name: "DATA",
     connections: ["D0", ".U1 > .D1"],
-    pcbFanoutDirection: "right",
-    pcbFanoutPreferredExit: "top_right",
   }
 
   expect(busProps.parse(rawProps)).toEqual(rawProps)


### PR DESCRIPTION
## Summary

- add `single_layer_fanout` and `fanout` as first-class autorouter presets
- add `busFanoutDirections` to `<autoroutingphase>` as `Record<BusName, NinePointAnchor | { direction: NinePointAnchor }>`
- support all nine-point anchors, with `center` leaving a bus unconstrained
- keep `<bus>` limited to electrical connection membership
- export the reusable `NinePointAnchor` and `BusName` types
- update generated component/props documentation
- align the `circuit-json` dependency with core

Fanout direction is routing-phase policy keyed by bus name. The props API does not require a component selector; the fanout solver infers the footprint side that needs escaping.

This is the props prerequisite for tscircuit/core#2889.

## Validation

- `bun test` (387 passing)
- `bun run typecheck`
- `bun run build`
- `bun run check-circular-deps`
- `bun run format:check`
- `git diff --check`
