### PR TITLE
feat: default breakout autorouter to fanout

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,11 @@ export interface BreakoutProps extends Omit<
   SubcircuitGroupProps,
   "subcircuit"
 > {
+  /**
+   * Autorouter used to escape the components inside the breakout boundary.
+   * Defaults to the multilayer fanout autorouter.
+   */
+  autorouter?: AutorouterProp;
   padding?: Distance;
   paddingLeft?: Distance;
   paddingRight?: Distance;

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1257,13 +1257,19 @@ export const boardProps = subcircuitGroupProps
 ```typescript
 export interface BreakoutProps
   extends Omit<SubcircuitGroupProps, "subcircuit"> {
+  autorouter?: AutorouterProp
   padding?: Distance
   paddingLeft?: Distance
   paddingRight?: Distance
   paddingTop?: Distance
   paddingBottom?: Distance
 }
+/**
+   * Autorouter used to escape the components inside the breakout boundary.
+   * Defaults to the multilayer fanout autorouter.
+   */
 export const breakoutProps = subcircuitGroupProps.extend({
+  autorouter: autorouterProp.default("fanout"),
   padding: distance.optional(),
   paddingLeft: distance.optional(),
   paddingRight: distance.optional(),

--- a/lib/components/breakout.ts
+++ b/lib/components/breakout.ts
@@ -2,10 +2,20 @@ import { distance } from "circuit-json"
 import type { Distance } from "lib/common/distance"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
-import { subcircuitGroupProps, type SubcircuitGroupProps } from "./group"
+import {
+  autorouterProp,
+  subcircuitGroupProps,
+  type AutorouterProp,
+  type SubcircuitGroupProps,
+} from "./group"
 
 export interface BreakoutProps
   extends Omit<SubcircuitGroupProps, "subcircuit"> {
+  /**
+   * Autorouter used to escape the components inside the breakout boundary.
+   * Defaults to the multilayer fanout autorouter.
+   */
+  autorouter?: AutorouterProp
   padding?: Distance
   paddingLeft?: Distance
   paddingRight?: Distance
@@ -14,6 +24,7 @@ export interface BreakoutProps
 }
 
 export const breakoutProps = subcircuitGroupProps.extend({
+  autorouter: autorouterProp.default("fanout"),
   padding: distance.optional(),
   paddingLeft: distance.optional(),
   paddingRight: distance.optional(),

--- a/tests/breakout.test.ts
+++ b/tests/breakout.test.ts
@@ -17,6 +17,13 @@ test("should parse breakout props with padding", () => {
   expect(parsed.paddingLeft).toBe(2)
 })
 
+test("breakout and fanout elements default to the fanout autorouter", () => {
+  expect(breakoutProps.parse({}).autorouter).toBe("fanout")
+  expect(
+    breakoutProps.parse({ autorouter: "single_layer_fanout" }).autorouter,
+  ).toBe("single_layer_fanout")
+})
+
 test("should parse breakout point props", () => {
   const raw: BreakoutPointProps = {
     pcbX: 5,


### PR DESCRIPTION
## Summary

- make the `autorouter` contract explicit on `BreakoutProps`
- default the shared breakout/fanout schema to `autorouter="fanout"`
- preserve explicit autorouter overrides such as `single_layer_fanout`
- update generated component documentation

`<breakout>` and `<fanout>` both use `BreakoutProps`, so this establishes the default once at the props boundary instead of duplicating it in core.

## Validation

- `bun test` — 388 passing, 0 failing
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`
- all GitHub test, type-check, and format checks passing
