### PR TITLE
accept Footprinter strings for cadModel

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -98,6 +98,7 @@ export const cadModelJscad = cadModelBase.extend({
 })
 export const cadModelProp = z.union([
   z.null(),
+  z.literal("footprinter_string"),
   url,
   z.custom<ReactElement>((v) => {
     return v && typeof v === "object" && "type" in v && "props" in v

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -98,8 +98,7 @@ export const cadModelJscad = cadModelBase.extend({
 })
 export const cadModelProp = z.union([
   z.null(),
-  z.literal("footprinter_string"),
-  url,
+  z.string().min(1),
   z.custom<ReactElement>((v) => {
     return v && typeof v === "object" && "type" in v && "props" in v
   }),

--- a/lib/common/cadModel.ts
+++ b/lib/common/cadModel.ts
@@ -114,17 +114,15 @@ export const cadModelJscad = cadModelBase.extend({
 })
 
 /**
- * Generate the CAD representation from the component's resolved Footprinter
- * footprint instead of using a supplied or fetched CAD model.
+ * A Footprinter string used to procedurally generate the component's CAD model,
+ * independently of the component's PCB footprint.
  *
- * The component footprint must resolve to a Footprinter string. This explicit
- * value overrides CAD models returned by footprint libraries or parts engines.
+ * @example "soic8"
  */
-export type CadModelFootprinterString = "footprinter_string"
+export type CadModelFootprinterString = string
 
 export type CadModelProp =
   | null
-  | string
   | ReactElement
   | CadModelFootprinterString
   | CadModelStl
@@ -137,8 +135,7 @@ export type CadModelProp =
 
 export const cadModelProp = z.union([
   z.null(),
-  z.literal("footprinter_string"),
-  url,
+  z.string().min(1),
   z.custom<ReactElement>((v) => {
     return v && typeof v === "object" && "type" in v && "props" in v
   }),

--- a/lib/common/cadModel.ts
+++ b/lib/common/cadModel.ts
@@ -113,10 +113,20 @@ export const cadModelJscad = cadModelBase.extend({
   jscad: z.record(z.any()),
 })
 
+/**
+ * Generate the CAD representation from the component's resolved Footprinter
+ * footprint instead of using a supplied or fetched CAD model.
+ *
+ * The component footprint must resolve to a Footprinter string. This explicit
+ * value overrides CAD models returned by footprint libraries or parts engines.
+ */
+export type CadModelFootprinterString = "footprinter_string"
+
 export type CadModelProp =
   | null
   | string
   | ReactElement
+  | CadModelFootprinterString
   | CadModelStl
   | CadModelObj
   | CadModelGltf
@@ -127,6 +137,7 @@ export type CadModelProp =
 
 export const cadModelProp = z.union([
   z.null(),
+  z.literal("footprinter_string"),
   url,
   z.custom<ReactElement>((v) => {
     return v && typeof v === "object" && "type" in v && "props" in v

--- a/tests/cad-model-prop.test.ts
+++ b/tests/cad-model-prop.test.ts
@@ -2,14 +2,14 @@ import { expect, test } from "bun:test"
 import { cadModelProp } from "../lib/common/cadModel"
 import { chipProps } from "../lib/components/chip"
 
-test("cadModel accepts the footprinter_string procedural model", () => {
-  expect(cadModelProp.parse("footprinter_string")).toBe("footprinter_string")
+test("cadModel accepts a Footprinter string as the procedural model", () => {
+  expect(cadModelProp.parse("soic8")).toBe("soic8")
+  expect(() => cadModelProp.parse("")).toThrow()
 
   const parsedChip = chipProps.parse({
     name: "U1",
-    footprint: "soic8",
-    cadModel: "footprinter_string",
+    cadModel: "soic8",
   })
 
-  expect(parsedChip.cadModel).toBe("footprinter_string")
+  expect(parsedChip.cadModel).toBe("soic8")
 })

--- a/tests/cad-model-prop.test.ts
+++ b/tests/cad-model-prop.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { cadModelProp } from "../lib/common/cadModel"
+import { chipProps } from "../lib/components/chip"
+
+test("cadModel accepts the footprinter_string procedural model", () => {
+  expect(cadModelProp.parse("footprinter_string")).toBe("footprinter_string")
+
+  const parsedChip = chipProps.parse({
+    name: "U1",
+    footprint: "soic8",
+    cadModel: "footprinter_string",
+  })
+
+  expect(parsedChip.cadModel).toBe("footprinter_string")
+})


### PR DESCRIPTION
## Summary

- define a non-empty `cadModel` string as a Footprinter model string
- document the model string as independent of the component's PCB footprint
- preserve object CAD models, React-element CAD models, and `cadModel={null}`
- add parser coverage for `cadModel="soic8"`

## Contract

```tsx
<chip
  name="U1"
  footprint="custom_board_footprint"
  cadModel="soic8"
/>
```

Here, `"soic8"` describes only the procedural CAD model. It does not select or depend on the component's PCB footprint.

## Validation

- `bun test` — 389 passed, 0 failed
- `bun run typecheck`
- `bun run build`
- `bun run format:check`
- `bun run check-circular-deps`
- all required documentation generators
