### PR TITLE
docs: include fanout boundary padding props

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,11 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
    * direction unconstrained.
    */
   busFanoutDirections?: Record<BusName, BusFanoutDirection>;
+  /**
+   * Padding between the union of the fanout source pads and the shared
+   * boundary where fanout traces terminate.
+   */
+  fanoutBoundaryPadding?: FanoutBoundaryPadding;
 }
 ```
 
@@ -422,6 +427,12 @@ export interface BreakoutProps extends Omit<
   paddingRight?: Distance;
   paddingTop?: Distance;
   paddingBottom?: Distance;
+  /**
+   * Padding between the union of the fanout source pads and the shared
+   * boundary where fanout traces terminate. This is independent of the
+   * breakout group's layout padding.
+   */
+  fanoutBoundaryPadding?: FanoutBoundaryPadding;
 }
 ```
 


### PR DESCRIPTION
## Summary

- regenerate the README entries for `AutoroutingPhaseProps` and `BreakoutProps`
- document the merged `fanoutBoundaryPadding` field in both public prop tables

## Why

The README update job raced with the release generated by #763, so the merged fields were omitted from the checked-in generated documentation. The same release race left `0.0.597` containing the previous generated `dist`; merging this follow-up from current `main` will also allow the normal release workflow to publish the merged API cleanly.

## Validation

- `bun run format:check`
- `bun test tests/breakout.test.ts tests/autoroutingphase.test.ts`
- `git diff --check`