### PR TITLE
Add fanout pour net map props

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,11 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
    * boundary where fanout traces terminate.
    */
   fanoutBoundaryPadding?: FanoutBoundaryPadding;
+  /**
+   * Copper layers available to boundary-terminated fanout buses. Plane
+   * terminations still use the layer declared on their bus.
+   */
+  fanoutRoutingLayers?: LayerRefInput[];
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -458,6 +458,13 @@ export interface BusProps {
   name?: string;
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[];
+  /**
+   * How this bus should terminate during fanout.
+   *
+   * Plane termination escapes each source pad to a local via on the selected
+   * layer instead of routing the bus to the breakout boundary.
+   */
+  fanoutTermination?: BusFanoutTermination;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -353,10 +353,19 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
    */
   fanoutBoundaryPadding?: FanoutBoundaryPadding;
   /**
-   * Copper layers available to boundary-terminated fanout buses. Plane
-   * terminations still use the layer declared on their bus.
+   * Copper layers available to boundary-terminated fanout buses. Source-only
+   * traces whose nets are mapped by `fanoutPourNetMap` terminate on their
+   * mapped plane layer.
    */
   fanoutRoutingLayers?: LayerRefInput[];
+  /**
+   * Maps copper layers to the net or nets poured on them. During fanout,
+   * source-only traces on those nets drop to the mapped layer instead of
+   * routing to the breakout boundary.
+   *
+   * This is inferred from `<copperpour>` components when omitted.
+   */
+  fanoutPourNetMap?: FanoutPourNetMap;
 }
 ```
 
@@ -463,13 +472,6 @@ export interface BusProps {
   name?: string;
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[];
-  /**
-   * How this bus should terminate during fanout.
-   *
-   * Plane termination escapes each source pad to a local via on the selected
-   * layer instead of routing the bus to the breakout boundary.
-   */
-  fanoutTermination?: BusFanoutTermination;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -155,6 +155,35 @@ export const pcbCoordinate = calcString.or(baseDistance)
 export { length }
 ```
 
+### fanoutBoundaryPadding
+
+```typescript
+export interface DirectionalFanoutBoundaryPadding {
+  top?: Distance
+  right?: Distance
+  bottom?: Distance
+  left?: Distance
+}
+/**
+ * Padding between the union of the fanout source pads and the shared boundary
+ * where fanout traces terminate. Omitted directional values are treated as
+ * zero.
+ */
+export type FanoutBoundaryPadding = Distance | DirectionalFanoutBoundaryPadding
+
+const nonnegativeDistance = distance.refine((value) => value >= 0, {
+  message: "Fanout boundary padding cannot be negative",
+})
+export const fanoutBoundaryPadding = z.union([
+  nonnegativeDistance,
+  z.object({
+    top: nonnegativeDistance.optional(),
+    right: nonnegativeDistance.optional(),
+    bottom: nonnegativeDistance.optional(),
+    left: nonnegativeDistance.optional(),
+  }),
+```
+
 ### footprintProp
 
 ```typescript
@@ -1148,10 +1177,11 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
   connections?: string[]
   reroute?: boolean
   busFanoutDirections?: Record<BusName, BusFanoutDirection>
+  fanoutBoundaryPadding?: FanoutBoundaryPadding
 }
 /**
-   * Fanout direction for each named bus in this phase. `center` leaves the
-   * direction unconstrained.
+   * Padding between the union of the fanout source pads and the shared
+   * boundary where fanout traces terminate.
    */
 export const autoroutingPhaseProps = z
   .object({
@@ -1173,6 +1203,7 @@ export const autoroutingPhaseProps = z
     connections: z.array(z.string()).optional(),
     reroute: z.boolean().optional(),
     busFanoutDirections: z.record(busFanoutDirection).optional(),
+    fanoutBoundaryPadding: fanoutBoundaryPadding.optional(),
   })
 ```
 
@@ -1263,10 +1294,12 @@ export interface BreakoutProps
   paddingRight?: Distance
   paddingTop?: Distance
   paddingBottom?: Distance
+  fanoutBoundaryPadding?: FanoutBoundaryPadding
 }
 /**
-   * Autorouter used to escape the components inside the breakout boundary.
-   * Defaults to the multilayer fanout autorouter.
+   * Padding between the union of the fanout source pads and the shared
+   * boundary where fanout traces terminate. This is independent of the
+   * breakout group's layout padding.
    */
 export const breakoutProps = subcircuitGroupProps.extend({
   autorouter: autorouterProp.default("fanout"),
@@ -1275,6 +1308,7 @@ export const breakoutProps = subcircuitGroupProps.extend({
   paddingRight: distance.optional(),
   paddingTop: distance.optional(),
   paddingBottom: distance.optional(),
+  fanoutBoundaryPadding: fanoutBoundaryPadding.optional(),
 })
 ```
 
@@ -1295,6 +1329,10 @@ export const breakoutPointProps = pcbLayoutProps
 ### bus
 
 ```typescript
+export type BusFanoutTermination =
+  | {
+      type: "boundary"
+    }
 /**
  * Declares a group of connections that an autorouter should keep together.
  * Each connection may be a trace name or a port selector.
@@ -1302,12 +1340,20 @@ export const breakoutPointProps = pcbLayoutProps
 export interface BusProps {
   name?: string
   connections: string[]
+  fanoutTermination?: BusFanoutTermination
 }
-/** Trace names or port selectors for the connections in the bus. */
-export const busProps = z.object({
-  name: z.string().optional(),
-  connections: z.array(z.string()).min(2),
-})
+/**
+   * How this bus should terminate during fanout.
+   *
+   * Plane termination escapes each source pad to a local via on the selected
+   * layer instead of routing the bus to the breakout boundary.
+   */
+export const busProps = z
+  .object({
+    name: z.string().optional(),
+    connections: z.array(z.string()).min(1),
+    fanoutTermination: busFanoutTermination.optional(),
+  })
 ```
 
 ### cadassembly

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1179,10 +1179,14 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
   busFanoutDirections?: Record<BusName, BusFanoutDirection>
   fanoutBoundaryPadding?: FanoutBoundaryPadding
   fanoutRoutingLayers?: LayerRefInput[]
+  fanoutPourNetMap?: FanoutPourNetMap
 }
 /**
-   * Copper layers available to boundary-terminated fanout buses. Plane
-   * terminations still use the layer declared on their bus.
+   * Maps copper layers to the net or nets poured on them. During fanout,
+   * source-only traces on those nets drop to the mapped layer instead of
+   * routing to the breakout boundary.
+   *
+   * This is inferred from `<copperpour>` components when omitted.
    */
 export const autoroutingPhaseProps = z
   .object({
@@ -1206,6 +1210,9 @@ export const autoroutingPhaseProps = z
     busFanoutDirections: z.record(busFanoutDirection).optional(),
     fanoutBoundaryPadding: fanoutBoundaryPadding.optional(),
     fanoutRoutingLayers: z.array(layer_ref).min(1).optional(),
+    fanoutPourNetMap: z
+      .record(layer_ref, z.union([z.string(), z.array(z.string()).min(1)]))
+      .optional(),
   })
 ```
 
@@ -1331,10 +1338,6 @@ export const breakoutPointProps = pcbLayoutProps
 ### bus
 
 ```typescript
-export type BusFanoutTermination =
-  | {
-      type: "boundary"
-    }
 /**
  * Declares a group of connections that an autorouter should keep together.
  * Each connection may be a trace name or a port selector.
@@ -1342,20 +1345,12 @@ export type BusFanoutTermination =
 export interface BusProps {
   name?: string
   connections: string[]
-  fanoutTermination?: BusFanoutTermination
 }
-/**
-   * How this bus should terminate during fanout.
-   *
-   * Plane termination escapes each source pad to a local via on the selected
-   * layer instead of routing the bus to the breakout boundary.
-   */
-export const busProps = z
-  .object({
-    name: z.string().optional(),
-    connections: z.array(z.string()).min(1),
-    fanoutTermination: busFanoutTermination.optional(),
-  })
+/** Trace names or port selectors for the connections in the bus. */
+export const busProps = z.object({
+  name: z.string().optional(),
+  connections: z.array(z.string()).min(2),
+})
 ```
 
 ### cadassembly

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1178,10 +1178,11 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
   reroute?: boolean
   busFanoutDirections?: Record<BusName, BusFanoutDirection>
   fanoutBoundaryPadding?: FanoutBoundaryPadding
+  fanoutRoutingLayers?: LayerRefInput[]
 }
 /**
-   * Padding between the union of the fanout source pads and the shared
-   * boundary where fanout traces terminate.
+   * Copper layers available to boundary-terminated fanout buses. Plane
+   * terminations still use the layer declared on their bus.
    */
 export const autoroutingPhaseProps = z
   .object({
@@ -1204,6 +1205,7 @@ export const autoroutingPhaseProps = z
     reroute: z.boolean().optional(),
     busFanoutDirections: z.record(busFanoutDirection).optional(),
     fanoutBoundaryPadding: fanoutBoundaryPadding.optional(),
+    fanoutRoutingLayers: z.array(layer_ref).min(1).optional(),
   })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -210,6 +210,11 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
    * direction unconstrained.
    */
   busFanoutDirections?: Record<BusName, BusFanoutDirection>
+  /**
+   * Padding between the union of the fanout source pads and the shared
+   * boundary where fanout traces terminate.
+   */
+  fanoutBoundaryPadding?: FanoutBoundaryPadding
 }
 
 
@@ -408,11 +413,22 @@ export interface BreakoutPointProps
 
 export interface BreakoutProps
   extends Omit<SubcircuitGroupProps, "subcircuit"> {
+  /**
+   * Autorouter used to escape the components inside the breakout boundary.
+   * Defaults to the multilayer fanout autorouter.
+   */
+  autorouter?: AutorouterProp
   padding?: Distance
   paddingLeft?: Distance
   paddingRight?: Distance
   paddingTop?: Distance
   paddingBottom?: Distance
+  /**
+   * Padding between the union of the fanout source pads and the shared
+   * boundary where fanout traces terminate. This is independent of the
+   * breakout group's layout padding.
+   */
+  fanoutBoundaryPadding?: FanoutBoundaryPadding
 }
 
 
@@ -420,6 +436,13 @@ export interface BusProps {
   name?: string
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[]
+  /**
+   * How this bus should terminate during fanout.
+   *
+   * Plane termination escapes each source pad to a local via on the selected
+   * layer instead of routing the bus to the breakout boundary.
+   */
+  fanoutTermination?: BusFanoutTermination
 }
 
 
@@ -875,6 +898,14 @@ export interface DiodeProps<PinLabel extends string = string>
   photo?: boolean
   tvs?: boolean
   schOrientation?: SchematicOrientation
+}
+
+
+export interface DirectionalFanoutBoundaryPadding {
+  top?: Distance
+  right?: Distance
+  bottom?: Distance
+  left?: Distance
 }
 
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -215,6 +215,11 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
    * boundary where fanout traces terminate.
    */
   fanoutBoundaryPadding?: FanoutBoundaryPadding
+  /**
+   * Copper layers available to boundary-terminated fanout buses. Plane
+   * terminations still use the layer declared on their bus.
+   */
+  fanoutRoutingLayers?: LayerRefInput[]
 }
 
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -216,10 +216,19 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
    */
   fanoutBoundaryPadding?: FanoutBoundaryPadding
   /**
-   * Copper layers available to boundary-terminated fanout buses. Plane
-   * terminations still use the layer declared on their bus.
+   * Copper layers available to boundary-terminated fanout buses. Source-only
+   * traces whose nets are mapped by `fanoutPourNetMap` terminate on their
+   * mapped plane layer.
    */
   fanoutRoutingLayers?: LayerRefInput[]
+  /**
+   * Maps copper layers to the net or nets poured on them. During fanout,
+   * source-only traces on those nets drop to the mapped layer instead of
+   * routing to the breakout boundary.
+   *
+   * This is inferred from `<copperpour>` components when omitted.
+   */
+  fanoutPourNetMap?: FanoutPourNetMap
 }
 
 
@@ -441,13 +450,6 @@ export interface BusProps {
   name?: string
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[]
-  /**
-   * How this bus should terminate during fanout.
-   *
-   * Plane termination escapes each source pad to a local via on the selected
-   * layer instead of routing the bus to the breakout boundary.
-   */
-  fanoutTermination?: BusFanoutTermination
 }
 
 

--- a/lib/components/autoroutingphase.ts
+++ b/lib/components/autoroutingphase.ts
@@ -1,6 +1,6 @@
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
-import { layer_ref, type LayerRefInput } from "circuit-json"
+import { layer_ref, type LayerRef, type LayerRefInput } from "circuit-json"
 import {
   type FanoutBoundaryPadding,
   fanoutBoundaryPadding,
@@ -22,6 +22,10 @@ export type BusFanoutDirection =
   | {
       direction: NinePointAnchor
     }
+
+export type FanoutPourNetMap = Partial<
+  Record<Extract<LayerRef, string>, string | string[]>
+>
 
 export interface AutoroutingPhaseProps extends RoutingTolerances {
   key?: any
@@ -49,10 +53,19 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
    */
   fanoutBoundaryPadding?: FanoutBoundaryPadding
   /**
-   * Copper layers available to boundary-terminated fanout buses. Plane
-   * terminations still use the layer declared on their bus.
+   * Copper layers available to boundary-terminated fanout buses. Source-only
+   * traces whose nets are mapped by `fanoutPourNetMap` terminate on their
+   * mapped plane layer.
    */
   fanoutRoutingLayers?: LayerRefInput[]
+  /**
+   * Maps copper layers to the net or nets poured on them. During fanout,
+   * source-only traces on those nets drop to the mapped layer instead of
+   * routing to the breakout boundary.
+   *
+   * This is inferred from `<copperpour>` components when omitted.
+   */
+  fanoutPourNetMap?: FanoutPourNetMap
 }
 
 const busFanoutDirection = z.union([
@@ -82,6 +95,9 @@ export const autoroutingPhaseProps = z
     busFanoutDirections: z.record(busFanoutDirection).optional(),
     fanoutBoundaryPadding: fanoutBoundaryPadding.optional(),
     fanoutRoutingLayers: z.array(layer_ref).min(1).optional(),
+    fanoutPourNetMap: z
+      .record(layer_ref, z.union([z.string(), z.array(z.string()).min(1)]))
+      .optional(),
   })
   .superRefine((value, ctx) => {
     if (

--- a/lib/components/autoroutingphase.ts
+++ b/lib/components/autoroutingphase.ts
@@ -1,5 +1,6 @@
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
+import { layer_ref, type LayerRefInput } from "circuit-json"
 import {
   type FanoutBoundaryPadding,
   fanoutBoundaryPadding,
@@ -47,6 +48,11 @@ export interface AutoroutingPhaseProps extends RoutingTolerances {
    * boundary where fanout traces terminate.
    */
   fanoutBoundaryPadding?: FanoutBoundaryPadding
+  /**
+   * Copper layers available to boundary-terminated fanout buses. Plane
+   * terminations still use the layer declared on their bus.
+   */
+  fanoutRoutingLayers?: LayerRefInput[]
 }
 
 const busFanoutDirection = z.union([
@@ -75,6 +81,7 @@ export const autoroutingPhaseProps = z
     reroute: z.boolean().optional(),
     busFanoutDirections: z.record(busFanoutDirection).optional(),
     fanoutBoundaryPadding: fanoutBoundaryPadding.optional(),
+    fanoutRoutingLayers: z.array(layer_ref).min(1).optional(),
   })
   .superRefine((value, ctx) => {
     if (

--- a/lib/components/bus.ts
+++ b/lib/components/bus.ts
@@ -1,7 +1,17 @@
+import { layer_ref, type LayerRefInput } from "circuit-json"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
 export type BusName = string
+
+export type BusFanoutTermination =
+  | {
+      type: "boundary"
+    }
+  | {
+      type: "plane"
+      layer: LayerRefInput
+    }
 
 /**
  * Declares a group of connections that an autorouter should keep together.
@@ -11,12 +21,44 @@ export interface BusProps {
   name?: string
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[]
+  /**
+   * How this bus should terminate during fanout.
+   *
+   * Plane termination escapes each source pad to a local via on the selected
+   * layer instead of routing the bus to the breakout boundary.
+   */
+  fanoutTermination?: BusFanoutTermination
 }
 
-export const busProps = z.object({
-  name: z.string().optional(),
-  connections: z.array(z.string()).min(2),
-})
+const busFanoutTermination = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("boundary") }),
+  z.object({
+    type: z.literal("plane"),
+    layer: layer_ref,
+  }),
+])
+
+export const busProps = z
+  .object({
+    name: z.string().optional(),
+    connections: z.array(z.string()).min(1),
+    fanoutTermination: busFanoutTermination.optional(),
+  })
+  .superRefine((props, ctx) => {
+    if (
+      props.connections.length < 2 &&
+      props.fanoutTermination?.type !== "plane"
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.too_small,
+        minimum: 2,
+        type: "array",
+        inclusive: true,
+        message: "Boundary-routed buses must contain at least two connections",
+        path: ["connections"],
+      })
+    }
+  })
 
 type InferredBusProps = z.input<typeof busProps>
 expectTypesMatch<BusProps, InferredBusProps>(true)

--- a/lib/components/bus.ts
+++ b/lib/components/bus.ts
@@ -1,17 +1,7 @@
-import { layer_ref, type LayerRefInput } from "circuit-json"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
 export type BusName = string
-
-export type BusFanoutTermination =
-  | {
-      type: "boundary"
-    }
-  | {
-      type: "plane"
-      layer: LayerRefInput
-    }
 
 /**
  * Declares a group of connections that an autorouter should keep together.
@@ -21,44 +11,12 @@ export interface BusProps {
   name?: string
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[]
-  /**
-   * How this bus should terminate during fanout.
-   *
-   * Plane termination escapes each source pad to a local via on the selected
-   * layer instead of routing the bus to the breakout boundary.
-   */
-  fanoutTermination?: BusFanoutTermination
 }
 
-const busFanoutTermination = z.discriminatedUnion("type", [
-  z.object({ type: z.literal("boundary") }),
-  z.object({
-    type: z.literal("plane"),
-    layer: layer_ref,
-  }),
-])
-
-export const busProps = z
-  .object({
-    name: z.string().optional(),
-    connections: z.array(z.string()).min(1),
-    fanoutTermination: busFanoutTermination.optional(),
-  })
-  .superRefine((props, ctx) => {
-    if (
-      props.connections.length < 2 &&
-      props.fanoutTermination?.type !== "plane"
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.too_small,
-        minimum: 2,
-        type: "array",
-        inclusive: true,
-        message: "Boundary-routed buses must contain at least two connections",
-        path: ["connections"],
-      })
-    }
-  })
+export const busProps = z.object({
+  name: z.string().optional(),
+  connections: z.array(z.string()).min(2),
+})
 
 type InferredBusProps = z.input<typeof busProps>
 expectTypesMatch<BusProps, InferredBusProps>(true)

--- a/tests/autoroutingphase.test.ts
+++ b/tests/autoroutingphase.test.ts
@@ -42,6 +42,15 @@ test("autorouting phase accepts per-bus fanout directions", () => {
   expect(autoroutingPhaseProps.parse(raw)).toEqual(raw)
 })
 
+test("autorouting phase accepts fanout routing layers", () => {
+  const parsed = autoroutingPhaseProps.parse({
+    autorouter: "fanout",
+    fanoutRoutingLayers: ["top", { name: "inner3" }, "bottom"],
+  })
+
+  expect(parsed.fanoutRoutingLayers).toEqual(["top", "inner3", "bottom"])
+})
+
 test("autorouting phase accepts scalar fanout boundary padding", () => {
   const raw = {
     autorouter: "fanout",

--- a/tests/autoroutingphase.test.ts
+++ b/tests/autoroutingphase.test.ts
@@ -51,6 +51,18 @@ test("autorouting phase accepts fanout routing layers", () => {
   expect(parsed.fanoutRoutingLayers).toEqual(["top", "inner3", "bottom"])
 })
 
+test("autorouting phase accepts a fanout pour net map", () => {
+  const raw = {
+    autorouter: "fanout",
+    fanoutPourNetMap: {
+      inner1: "GND",
+      inner2: ["VCC_CORE", "VCC_IO"],
+    },
+  } satisfies AutoroutingPhaseProps
+
+  expect(autoroutingPhaseProps.parse(raw)).toEqual(raw)
+})
+
 test("autorouting phase accepts scalar fanout boundary padding", () => {
   const raw = {
     autorouter: "fanout",

--- a/tests/bus.test.ts
+++ b/tests/bus.test.ts
@@ -2,15 +2,28 @@ import { expect, test } from "bun:test"
 import { busProps, type BusProps } from "lib/components/bus"
 
 test("busProps accepts two or more connection references", () => {
-  const rawProps: BusProps = {
+  const rawProps = {
     name: "DATA",
     connections: ["D0", ".U1 > .D1"],
-  }
+  } satisfies BusProps
 
   expect(busProps.parse(rawProps)).toEqual(rawProps)
 })
 
-test("busProps rejects a single connection", () => {
+test("busProps accepts a source-only plane connection", () => {
+  const rawProps = {
+    name: "GROUND_A1",
+    connections: ["GND_A1"],
+    fanoutTermination: {
+      type: "plane",
+      layer: "inner1",
+    },
+  } satisfies BusProps
+
+  expect(busProps.parse(rawProps)).toEqual(rawProps)
+})
+
+test("busProps rejects a single boundary connection", () => {
   expect(
     busProps.safeParse({
       name: "DATA",

--- a/tests/bus.test.ts
+++ b/tests/bus.test.ts
@@ -9,25 +9,3 @@ test("busProps accepts two or more connection references", () => {
 
   expect(busProps.parse(rawProps)).toEqual(rawProps)
 })
-
-test("busProps accepts a source-only plane connection", () => {
-  const rawProps = {
-    name: "GROUND_A1",
-    connections: ["GND_A1"],
-    fanoutTermination: {
-      type: "plane",
-      layer: "inner1",
-    },
-  } satisfies BusProps
-
-  expect(busProps.parse(rawProps)).toEqual(rawProps)
-})
-
-test("busProps rejects a single boundary connection", () => {
-  expect(
-    busProps.safeParse({
-      name: "DATA",
-      connections: ["D0"],
-    }).success,
-  ).toBe(false)
-})


### PR DESCRIPTION
## Summary

- add `fanoutRoutingLayers` to keep boundary-routed signal escapes off reserved plane layers
- add `fanoutPourNetMap` to map a layer to one net or an array of isolated nets
- keep `<bus>` focused on ordinary multi-connection bus grouping
- regenerate the public props documentation

## Why

Power and ground plane drops are properties of the board stackup and copper
intent, not special singleton buses. Core can infer the same map from
`<copperpour>` components when the prop is omitted.

```tsx
<autoroutingphase
  autorouter="fanout"
  fanoutPourNetMap={{
    inner1: "GND",
    inner2: ["VCC_CORE", "VCC_IO"],
  }}
/>
```

## Validation

- `bun test tests/bus.test.ts tests/autoroutingphase.test.ts` — 16 passed
- `bun run typecheck`
- `bun run build`
- `bun run format`
