### PR TITLE
Add routingPhaseIndex to bus props

### DIFF
--- a/lib/components/bus.ts
+++ b/lib/components/bus.ts
@@ -11,11 +11,14 @@ export interface BusProps {
   name?: string
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[]
+  /** Autorouting phase in which this bus constraint should be applied. */
+  routingPhaseIndex?: number | null
 }
 
 export const busProps = z.object({
   name: z.string().optional(),
   connections: z.array(z.string()).min(2),
+  routingPhaseIndex: z.number().nullable().optional(),
 })
 
 type InferredBusProps = z.input<typeof busProps>

--- a/tests/bus.test.ts
+++ b/tests/bus.test.ts
@@ -5,6 +5,7 @@ test("busProps accepts two or more connection references", () => {
   const rawProps = {
     name: "DATA",
     connections: ["D0", ".U1 > .D1"],
+    routingPhaseIndex: 2,
   } satisfies BusProps
 
   expect(busProps.parse(rawProps)).toEqual(rawProps)


### PR DESCRIPTION
## Summary

Add an optional `routingPhaseIndex` prop to `<bus>`.

With no phase, a bus only declares membership and does not affect how its traces are assigned to routing phases:

```tsx
<bus name="EMMC_DATA" connections={["DAT0", "DAT1"]} />
```

When a phase is explicit, all member traces are assigned to that phase:

```tsx
<bus
  name="EMMC_DATA"
  connections={["DAT0", "DAT1"]}
  routingPhaseIndex={2}
/>
```

This is a four-line public type/schema change. Phase planning is implemented in tscircuit/core#2946; `routingPhaseIndex` is not added to `SimpleRouteJson`.

## Validation

- `bun test tests/bus.test.ts`
- `bunx tsc --noEmit`
