### PR TITLE
Clarify bus routing phase semantics

### DIFF
--- a/lib/components/bus.ts
+++ b/lib/components/bus.ts
@@ -11,7 +11,7 @@ export interface BusProps {
   name?: string
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[]
-  /** Autorouting phase in which this bus constraint should be applied. */
+  /** If set, every trace in this bus is assigned to this autorouting phase. */
   routingPhaseIndex?: number | null
 }
 


### PR DESCRIPTION
## Summary

Clarify the public `BusProps.routingPhaseIndex` documentation after #769 merged.

An omitted phase only declares bus membership and does not affect routing-phase assignment. When the prop is set, core assigns every member trace to that autorouting phase.

This PR changes one documentation line and does not change the schema or runtime behavior.

## Validation

- `bun test tests/bus.test.ts`
- `bunx tsc --noEmit`