### PR TITLE
Add excludeRefs to PCB keepout props

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,8 @@ export interface BusProps {
   name?: string;
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[];
+  /** If set, every trace in this bus is assigned to this autorouting phase. */
+  routingPhaseIndex?: number | null;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1364,11 +1364,13 @@ export const breakoutPointProps = pcbLayoutProps
 export interface BusProps {
   name?: string
   connections: string[]
+  routingPhaseIndex?: number | null
 }
-/** Trace names or port selectors for the connections in the bus. */
+/** If set, every trace in this bus is assigned to this autorouting phase. */
 export const busProps = z.object({
   name: z.string().optional(),
   connections: z.array(z.string()).min(2),
+  routingPhaseIndex: z.number().nullable().optional(),
 })
 ```
 
@@ -3084,12 +3086,24 @@ pcbLayoutProps.omit({ pcbRotation: true }).extend({
     shape: z.literal("circle"),
     radius: distance,
     layers: z.array(layer_ref).optional(),
+    excludeRefs: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Component selectors excluded from the keepout, such as ".ANT1"',
+      ),
   }),
 pcbLayoutProps.extend({
     shape: z.literal("rect"),
     width: distance,
     height: distance,
     layers: z.array(layer_ref).optional(),
+    excludeRefs: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Component selectors excluded from the keepout, such as ".ANT1"',
+      ),
   }),
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -421,6 +421,8 @@ export interface BusProps {
   name?: string
   /** Trace names or port selectors for the connections in the bus. */
   connections: string[]
+  /** If set, every trace in this bus is assigned to this autorouting phase. */
+  routingPhaseIndex?: number | null
 }
 
 

--- a/lib/components/pcb-keepout.ts
+++ b/lib/components/pcb-keepout.ts
@@ -7,12 +7,24 @@ export const pcbKeepoutProps = z.union([
     shape: z.literal("circle"),
     radius: distance,
     layers: z.array(layer_ref).optional(),
+    excludeRefs: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Component selectors excluded from the keepout, such as ".ANT1"',
+      ),
   }),
   pcbLayoutProps.extend({
     shape: z.literal("rect"),
     width: distance,
     height: distance,
     layers: z.array(layer_ref).optional(),
+    excludeRefs: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Component selectors excluded from the keepout, such as ".ANT1"',
+      ),
   }),
 ])
 export type PcbKeepoutProps = z.input<typeof pcbKeepoutProps>

--- a/tests/pcb-keepout.test.ts
+++ b/tests/pcb-keepout.test.ts
@@ -30,3 +30,20 @@ test("should parse keepout layers prop", () => {
   expect(parsed.shape).toBe("circle")
   expect(parsed.layers).toEqual(["top", "bottom"])
 })
+
+test("should parse keepout excludeRefs selectors", () => {
+  const rectProps: PcbKeepoutProps = {
+    shape: "rect",
+    width: "5mm",
+    height: "2mm",
+    excludeRefs: [".ANT1", ".C1"],
+  }
+  const circleProps: PcbKeepoutProps = {
+    shape: "circle",
+    radius: "1mm",
+    excludeRefs: [".ANT1"],
+  }
+
+  expect(pcbKeepoutProps.parse(rectProps).excludeRefs).toEqual([".ANT1", ".C1"])
+  expect(pcbKeepoutProps.parse(circleProps).excludeRefs).toEqual([".ANT1"])
+})


### PR DESCRIPTION
## Summary

- add an optional `excludeRefs: string[]` prop to circular and rectangular PCB keepouts
- accept component selectors such as `".ANT1"` and preserve them unchanged in parsed props
- add tests covering both keepout shapes
- regenerate the repository's required documentation artifacts

## Why

Keepouts need a way to identify selected components that may occupy the keepout region, such as allowing an antenna component inside its own RF keepout.

This PR adds the props-layer contract only. `@tscircuit/core` will need a follow-up change to resolve the selectors and apply the exclusions while rendering routing obstacles.

## API behavior

- accepted input: an optional array of selector strings
- canonical parsed output: the same string array
- default: omitted / `undefined`
- aliases or conflicts: none
- migration: fully additive and backward compatible

## Generated documentation note

Running the generators required by `AGENTS.md` also synchronized pre-existing generated documentation drift for `BusProps.routingPhaseIndex`.

## Validation

- `bun test` — 400 passing
- `bun run typecheck`
- `bun run format:check`
- `bun run build`
- `bun run check-circular-deps`
- `git diff --check`
