### PR TITLE
Rename insertionDirection front/back to top/bottom and add axis aliases

### DIFF
--- a/lib/components/footprint.ts
+++ b/lib/components/footprint.ts
@@ -1,19 +1,38 @@
-import { type LayerRef, layer_ref } from "circuit-json"
+import {
+  type InsertionDirectionInput,
+  type LayerRef,
+  layer_ref,
+} from "circuit-json"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 import { type FootprintProp, footprintProp } from "../common/footprintProp"
 
-export type FootprintInsertionDirection =
-  | "from_above"
-  | "from_left"
-  | "from_right"
-  | "from_front"
-  | "from_back"
+/**
+ * Direction a cable or mating part is attached from, named for the side of the
+ * footprint it approaches from.
+ *
+ * Aliased to Circuit JSON's input union so the two cannot drift apart. Both the
+ * named spellings and their Cartesian equivalents are accepted here, as are the
+ * deprecated `from_front` (now `from_top`) and `from_back` (now `from_bottom`).
+ * Core normalizes them to the six named values before writing
+ * `pcb_component.insertion_direction`.
+ */
+export type FootprintInsertionDirection = InsertionDirectionInput
 
 export const footprintInsertionDirection = z.enum([
-  "from_above",
   "from_left",
   "from_right",
+  "from_top",
+  "from_bottom",
+  "from_above",
+  "from_below",
+  "from_x_neg",
+  "from_x_pos",
+  "from_y_pos",
+  "from_y_neg",
+  "from_z_pos",
+  "from_z_neg",
+  // Deprecated, accepted so existing sources keep type-checking.
   "from_front",
   "from_back",
 ])
@@ -45,8 +64,21 @@ export interface FootprintProps {
    */
   src?: FootprintProp
   /**
-   * Direction a cable or mating part is inserted into this footprint in its
-   * unrotated orientation.
+   * Direction a cable or mating part is attached from, in the footprint's own
+   * frame -- the same frame its pads are drawn in. Directions are named for the
+   * footprint as drawn in the 2D PCB view: `from_top` is +Y, `from_bottom` -Y,
+   * `from_left` -X, `from_right` +X, `from_above` +Z and `from_below` -Z.
+   * Cartesian spellings such as `from_y_pos` are also accepted.
+   *
+   * This names a side, not a motion. A receptacle on the +Y edge is `from_top`
+   * because that is the side the plug comes from, even though the plug itself
+   * moves in -Y as it seats.
+   *
+   * This is a property of the part, so it is authored without regard to where
+   * the part is placed. Rotating or flipping the component rotates this with it,
+   * and `pcb_component.insertion_direction` reports the result in board
+   * coordinates. The two frames coincide for an unrotated top-layer part, which
+   * makes the distinction easy to miss.
    */
   insertionDirection?: FootprintInsertionDirection
 }
@@ -60,7 +92,7 @@ export const footprintProps = z.object({
   insertionDirection: footprintInsertionDirection
     .optional()
     .describe(
-      "Direction a cable or mating part is inserted into this footprint in its unrotated orientation.",
+      "Direction a cable or mating part is attached from, named for the side of the footprint it approaches from, in its unrotated orientation.",
     ),
 })
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/node": "^20.12.11",
     "@types/react": "^18.3.2",
     "ava": "^6.1.3",
-    "circuit-json": "^0.0.455",
+    "circuit-json": "^0.0.461",
     "expect-type": "^1.3.0",
     "glob": "^11.0.0",
     "madge": "^8.0.0",

--- a/tests/footprint.test.ts
+++ b/tests/footprint.test.ts
@@ -9,9 +9,18 @@ test("should parse footprint name", () => {
 
 test("should parse footprint insertionDirection options", () => {
   const insertionDirections = [
-    "from_above",
     "from_left",
     "from_right",
+    "from_top",
+    "from_bottom",
+    "from_above",
+    "from_below",
+    "from_x_neg",
+    "from_x_pos",
+    "from_y_pos",
+    "from_y_neg",
+    "from_z_pos",
+    "from_z_neg",
     "from_front",
     "from_back",
   ] as const
@@ -24,9 +33,7 @@ test("should parse footprint insertionDirection options", () => {
 })
 
 test("should fail for invalid footprint insertionDirection", () => {
-  expect(() =>
-    footprintProps.parse({
-      insertionDirection: "from_side",
-    } as any),
-  ).toThrow()
+  for (const insertionDirection of ["from_side", "from_y+", "from_beneath"]) {
+    expect(() => footprintProps.parse({ insertionDirection } as any)).toThrow()
+  }
 })


### PR DESCRIPTION
Follows the matching Circuit JSON change. The +/-Y values are renamed from "from_front"/"from_back" to "from_top"/"from_bottom" so every name is read off the footprint as drawn in the 2D PCB view, "from_below" (-Z) is added to pair with "from_above" (+Z), and each direction gains an equivalent Cartesian spelling ("from_y+", "from_x-", ...).

FootprintInsertionDirection is now an alias of Circuit JSON's InsertionDirectionInput so the two lists cannot drift apart; expectTypesMatch fails the build if the local z.enum stops agreeing with it.

Both spellings are kept in the prop type rather than normalized here, because FootprintProps is the type JSX authors write against. Core normalizes to the six named values before writing pcb_component.insertion_direction.