### PR TITLE
Add via-in-pad board prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,8 @@ export interface BoardProps extends Omit<
   bottomSilkscreenColor?: BoardColor;
   /** Whether the board should be assembled on both sides */
   doubleSidedAssembly?: boolean;
+  /** Whether vias may be placed inside PCB pads */
+  isViaInPadAllowed?: boolean;
   /** Whether this board should be omitted from the schematic view */
   schematicDisabled?: boolean;
 }

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1276,6 +1276,7 @@ export interface BoardProps
   topSilkscreenColor?: BoardColor
   bottomSilkscreenColor?: BoardColor
   doubleSidedAssembly?: boolean
+  isViaInPadAllowed?: boolean
   schematicDisabled?: boolean
 }
 /** Whether this board should be omitted from the schematic view */
@@ -1308,6 +1309,12 @@ export const boardProps = subcircuitGroupProps
     topSilkscreenColor: boardColor.optional(),
     bottomSilkscreenColor: boardColor.optional(),
     doubleSidedAssembly: z.boolean().optional().default(false),
+    isViaInPadAllowed: z
+      .boolean()
+      .optional()
+      .describe(
+        "Allows intentional via-in-pad designs to pass DRC. Omitted or false keeps via-in-pad disallowed.",
+      ),
     schematicDisabled: z.boolean().optional(),
   })
 ```

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -383,6 +383,8 @@ export interface BoardProps
   bottomSilkscreenColor?: BoardColor
   /** Whether the board should be assembled on both sides */
   doubleSidedAssembly?: boolean
+  /** Whether vias may be placed inside PCB pads */
+  isViaInPadAllowed?: boolean
   /** Whether this board should be omitted from the schematic view */
   schematicDisabled?: boolean
 }

--- a/lib/components/board.ts
+++ b/lib/components/board.ts
@@ -48,6 +48,8 @@ export interface BoardProps
   bottomSilkscreenColor?: BoardColor
   /** Whether the board should be assembled on both sides */
   doubleSidedAssembly?: boolean
+  /** Whether vias may be placed inside PCB pads */
+  isViaInPadAllowed?: boolean
   /** Whether this board should be omitted from the schematic view */
   schematicDisabled?: boolean
 }
@@ -81,6 +83,12 @@ export const boardProps = subcircuitGroupProps
     topSilkscreenColor: boardColor.optional(),
     bottomSilkscreenColor: boardColor.optional(),
     doubleSidedAssembly: z.boolean().optional().default(false),
+    isViaInPadAllowed: z
+      .boolean()
+      .optional()
+      .describe(
+        "Allows intentional via-in-pad designs to pass DRC. Omitted or false keeps via-in-pad disallowed.",
+      ),
     schematicDisabled: z.boolean().optional(),
   })
 

--- a/tests/board.test.ts
+++ b/tests/board.test.ts
@@ -111,3 +111,18 @@ test("should parse schematicDisabled prop", () => {
   const parsed = boardProps.parse(raw)
   expect(parsed.schematicDisabled).toBe(true)
 })
+
+test("should parse isViaInPadAllowed prop", () => {
+  const enabled: BoardProps = {
+    name: "board",
+    isViaInPadAllowed: true,
+  }
+  const disabled: BoardProps = {
+    name: "board",
+    isViaInPadAllowed: false,
+  }
+
+  expect(boardProps.parse(enabled).isViaInPadAllowed).toBe(true)
+  expect(boardProps.parse(disabled).isViaInPadAllowed).toBe(false)
+  expect(boardProps.parse({ name: "board" }).isViaInPadAllowed).toBeUndefined()
+})


### PR DESCRIPTION
## Summary

- add `isViaInPadAllowed?: boolean` to `BoardProps` and `boardProps`
- preserve explicit `true` and `false` values while leaving the prop undefined by default
- regenerate the README and generated props/type references

## Why

`circuit-json` now exposes `pcb_board.is_via_in_pad_allowed`. TSX authors need a corresponding `<board isViaInPadAllowed />` prop so core can carry intentional via-in-pad design intent into circuit JSON and DRC checks can honor it.

This is separate from `autorouter.allowViaInPad`: the autorouter option controls route generation, while this board prop expresses whether via-in-pad is allowed by the design.

## Validation

- `bun test tests/board.test.ts`
- `bun test` (401 passing)
- `bun run typecheck`
- `bun run format:check`
- `bun run build`
- `bun run check-circular-deps`
- all required documentation generators