### PR TITLE
Allow custom pin labels on LEDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,8 +879,21 @@ export interface FootprintProps {
    */
   src?: FootprintProp;
   /**
-   * Direction a cable or mating part is inserted into this footprint in its
-   * unrotated orientation.
+   * Direction a cable or mating part is attached from, in the footprint's own
+   * frame -- the same frame its pads are drawn in. Directions are named for the
+   * footprint as drawn in the 2D PCB view: `from_top` is +Y, `from_bottom` -Y,
+   * `from_left` -X, `from_right` +X, `from_above` +Z and `from_below` -Z.
+   * Cartesian spellings such as `from_y_pos` are also accepted.
+   *
+   * This names a side, not a motion. A receptacle on the +Y edge is `from_top`
+   * because that is the side the plug comes from, even though the plug itself
+   * moves in -Y as it seats.
+   *
+   * This is a property of the part, so it is authored without regard to where
+   * the part is placed. Rotating or flipping the component rotates this with it,
+   * and `pcb_component.insertion_direction` reports the result in board
+   * coordinates. The two frames coincide for an unrotated top-layer part, which
+   * makes the distinction easy to miss.
    */
   insertionDirection?: FootprintInsertionDirection;
 }

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2096,8 +2096,21 @@ export interface FootprintProps {
   insertionDirection?: FootprintInsertionDirection
 }
 /**
-   * Direction a cable or mating part is inserted into this footprint in its
-   * unrotated orientation.
+   * Direction a cable or mating part is attached from, in the footprint's own
+   * frame -- the same frame its pads are drawn in. Directions are named for the
+   * footprint as drawn in the 2D PCB view: `from_top` is +Y, `from_bottom` -Y,
+   * `from_left` -X, `from_right` +X, `from_above` +Z and `from_below` -Z.
+   * Cartesian spellings such as `from_y_pos` are also accepted.
+   *
+   * This names a side, not a motion. A receptacle on the +Y edge is `from_top`
+   * because that is the side the plug comes from, even though the plug itself
+   * moves in -Y as it seats.
+   *
+   * This is a property of the part, so it is authored without regard to where
+   * the part is placed. Rotating or flipping the component rotates this with it,
+   * and `pcb_component.insertion_direction` reports the result in board
+   * coordinates. The two frames coincide for an unrotated top-layer part, which
+   * makes the distinction easy to miss.
    */
 export const footprintProps = z.object({
   children: z.any().optional(),
@@ -2108,7 +2121,7 @@ export const footprintProps = z.object({
   insertionDirection: footprintInsertionDirection
     .optional()
     .describe(
-      "Direction a cable or mating part is inserted into this footprint in its unrotated orientation.",
+      "Direction a cable or mating part is attached from, named for the side of the footprint it approaches from, in its unrotated orientation.",
     ),
 })
 ```
@@ -2873,6 +2886,7 @@ export const ledProps = commonComponentProps.extend({
   wavelength: z.string().optional(),
   schDisplayValue: z.string().optional(),
   schOrientation: schematicOrientation.optional(),
+  pinLabels: diodePinLabelsProp.optional(),
   connections: createConnectionsProp(lrPolarPins).optional(),
   laser: z.boolean().optional(),
 })

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1063,8 +1063,21 @@ export interface FootprintProps {
    */
   src?: FootprintProp
   /**
-   * Direction a cable or mating part is inserted into this footprint in its
-   * unrotated orientation.
+   * Direction a cable or mating part is attached from, in the footprint's own
+   * frame -- the same frame its pads are drawn in. Directions are named for the
+   * footprint as drawn in the 2D PCB view: `from_top` is +Y, `from_bottom` -Y,
+   * `from_left` -X, `from_right` +X, `from_above` +Z and `from_below` -Z.
+   * Cartesian spellings such as `from_y_pos` are also accepted.
+   *
+   * This names a side, not a motion. A receptacle on the +Y edge is `from_top`
+   * because that is the side the plug comes from, even though the plug itself
+   * moves in -Y as it seats.
+   *
+   * This is a property of the part, so it is authored without regard to where
+   * the part is placed. Rotating or flipping the component rotates this with it,
+   * and `pcb_component.insertion_direction` reports the result in board
+   * coordinates. The two frames coincide for an unrotated top-layer part, which
+   * makes the distinction easy to miss.
    */
   insertionDirection?: FootprintInsertionDirection
 }

--- a/lib/components/diode.ts
+++ b/lib/components/diode.ts
@@ -33,7 +33,7 @@ const connectionTarget = z
 
 const connectionsProp = z.record(diodeConnectionKeys, connectionTarget)
 
-const diodePinLabelsProp = z.record(
+export const diodePinLabelsProp = z.record(
   z.enum(diodePins),
   schematicPinLabel
     .or(z.array(schematicPinLabel).readonly())

--- a/lib/components/led.ts
+++ b/lib/components/led.ts
@@ -2,6 +2,7 @@ import { commonComponentProps, lrPolarPins } from "lib/common/layout"
 import { schematicOrientation } from "lib/common/schematicOrientation"
 import { z } from "zod"
 import { createConnectionsProp } from "lib/common/connectionsProp"
+import { diodePinLabelsProp } from "lib/components/diode"
 
 export type LedPinLabels = (typeof lrPolarPins)[number]
 
@@ -10,6 +11,7 @@ export const ledProps = commonComponentProps.extend({
   wavelength: z.string().optional(),
   schDisplayValue: z.string().optional(),
   schOrientation: schematicOrientation.optional(),
+  pinLabels: diodePinLabelsProp.optional(),
   connections: createConnectionsProp(lrPolarPins).optional(),
   laser: z.boolean().optional(),
 })

--- a/tests/led.test.ts
+++ b/tests/led.test.ts
@@ -93,3 +93,20 @@ test("should allow optional connections", () => {
   const parsedProps = ledProps.parse(rawProps)
   expect(parsedProps.connections).toBeUndefined()
 })
+
+test("should parse supplier-specific LED pin labels", () => {
+  const rawProps: LedProps = {
+    name: "led",
+    pinLabels: {
+      pin1: ["cathode", "neg"],
+      pin2: ["anode", "pos"],
+    },
+  }
+
+  const parsedProps = ledProps.parse(rawProps)
+
+  expect(parsedProps.pinLabels).toEqual({
+    pin1: ["cathode", "neg"],
+    pin2: ["anode", "pos"],
+  })
+})


### PR DESCRIPTION
## Summary
- allow `<led>` to accept custom `pinLabels`
- reuse the diode pin-label schema so supplier wrappers can preserve non-generic polarity mappings
- add a regression test for an LED whose pin 1 is cathode and pin 2 is anode
- regenerate the checked-in API documentation

## Root cause
The LED props schema did not include `pinLabels`, so React props supplied by part wrappers were stripped during parsing before `@tscircuit/core` could build source ports.

## Validation
- `bun test` (402 passed)
- `bun run typecheck`
- `bun run build`
- `bun run check-circular-deps`
- `bun run format:check`
- all required documentation generators