### PR TITLE
Add legacy autorouter platform override

### DIFF
--- a/README.md
+++ b/README.md
@@ -2230,6 +2230,13 @@ export interface PlatformConfig {
 
   autorouterMap?: Record<string, AutorouterDefinition>;
 
+  /**
+   * Allows the deprecated sequential_trace and auto_cloud autorouter presets.
+   * Defaults to false because these presets are otherwise disabled.
+   * Platforms should only enable this temporarily while migrating projects.
+   */
+  allowLegacyAutorouters?: boolean;
+
   // TODO this follows a subset of the localStorage interface
   localCacheEngine?: any;
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1928,6 +1928,13 @@ export interface PlatformConfig {
 
   autorouterMap?: Record<string, AutorouterDefinition>
 
+  /**
+   * Allows the deprecated sequential_trace and auto_cloud autorouter presets.
+   * Defaults to false because these presets are otherwise disabled.
+   * Platforms should only enable this temporarily while migrating projects.
+   */
+  allowLegacyAutorouters?: boolean
+
   // TODO this follows a subset of the localStorage interface
   localCacheEngine?: any
 

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -65,6 +65,13 @@ export interface PlatformConfig {
 
   autorouterMap?: Record<string, AutorouterDefinition>
 
+  /**
+   * Allows the deprecated sequential_trace and auto_cloud autorouter presets.
+   * Defaults to false because these presets are otherwise disabled.
+   * Platforms should only enable this temporarily while migrating projects.
+   */
+  allowLegacyAutorouters?: boolean
+
   // TODO this follows a subset of the localStorage interface
   localCacheEngine?: any
 
@@ -202,6 +209,7 @@ export const platformConfig = z.object({
   partsEngine: partsEngine.optional(),
   autorouter: autorouterProp.optional(),
   autorouterMap: z.record(z.string(), autorouterDefinition).optional(),
+  allowLegacyAutorouters: z.boolean().optional(),
   registryApiUrl: url.optional(),
   cloudAutorouterUrl: url.optional(),
   projectName: z.string().optional(),

--- a/tests/platform-config-allow-legacy-autorouters.test.ts
+++ b/tests/platform-config-allow-legacy-autorouters.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test"
+import { platformConfig } from "lib/platformConfig"
+
+test("platformConfig accepts the legacy autorouter override", () => {
+  expect(
+    platformConfig.parse({ allowLegacyAutorouters: true })
+      .allowLegacyAutorouters,
+  ).toBe(true)
+
+  expect(platformConfig.parse({}).allowLegacyAutorouters).toBeUndefined()
+})


### PR DESCRIPTION
## Summary

- add `allowLegacyAutorouters` to `PlatformConfig`
- validate the optional boolean in `platformConfig`
- document that it temporarily re-enables the deprecated `sequential_trace` and `auto_cloud` presets
- regenerate the checked-in API documentation

## Why

`@tscircuit/core` is disabling legacy autorouters by default. Platforms need an explicit, temporary migration escape hatch for existing projects.

## Impact

The option is platform-only and defaults to false. Existing platform configurations are unchanged unless they opt in.

## Validation

- `bun test` (403 passing)
- `bun run typecheck`
- `bun run build`
- `bun run check-circular-deps`
- required documentation generators