### PR TITLE
Add generic part orientation analysis platform config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2237,8 +2237,14 @@ export interface PlatformConfig {
    */
   allowLegacyAutorouters?: boolean;
 
-  // TODO this follows a subset of the localStorage interface
-  localCacheEngine?: any;
+  /** A localStorage-compatible cache used by render phases and engines. */
+  localCacheEngine?: LocalCacheEngine;
+
+  /**
+   * Analyze rendered and supplier footprints so manufacturing exporters can
+   * align their semantic pin 1 orientations.
+   */
+  usePartOrientationAnalysis?: boolean;
 
   registryApiUrl?: string;
 

--- a/README.md
+++ b/README.md
@@ -2244,7 +2244,7 @@ export interface PlatformConfig {
    * Analyze rendered and supplier footprints so manufacturing exporters can
    * align their semantic pin 1 orientations.
    */
-  usePartOrientationAnalysis?: boolean;
+  enablePartOrientationAnalysis?: boolean;
 
   registryApiUrl?: string;
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1949,7 +1949,7 @@ export interface PlatformConfig {
    * Analyze rendered and supplier footprints so manufacturing exporters can
    * align their semantic pin 1 orientations.
    */
-  usePartOrientationAnalysis?: boolean
+  enablePartOrientationAnalysis?: boolean
 
   registryApiUrl?: string
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1382,6 +1382,13 @@ export interface LayoutConfig {
 }
 
 
+export interface LocalCacheEngine {
+  getItem(key: string): string | Promise<string | null> | null
+  setItem(key: string, value: string): void | Promise<void>
+  removeItem?(key: string): void | Promise<void>
+}
+
+
 export interface ManualEditsFile {
   pcb_placements?: ManualPcbPlacement[]
   manual_trace_hints?: ManualTraceHint[]
@@ -1935,8 +1942,14 @@ export interface PlatformConfig {
    */
   allowLegacyAutorouters?: boolean
 
-  // TODO this follows a subset of the localStorage interface
-  localCacheEngine?: any
+  /** A localStorage-compatible cache used by render phases and engines. */
+  localCacheEngine?: LocalCacheEngine
+
+  /**
+   * Analyze rendered and supplier footprints so manufacturing exporters can
+   * align their semantic pin 1 orientations.
+   */
+  usePartOrientationAnalysis?: boolean
 
   registryApiUrl?: string
 

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -85,7 +85,7 @@ export interface PlatformConfig {
    * Analyze rendered and supplier footprints so manufacturing exporters can
    * align their semantic pin 1 orientations.
    */
-  usePartOrientationAnalysis?: boolean
+  enablePartOrientationAnalysis?: boolean
 
   registryApiUrl?: string
 
@@ -254,7 +254,7 @@ export const platformConfig = z.object({
   defaultSpiceEngine: defaultSpiceEngine.optional(),
   unitPreference: z.enum(["mm", "in", "mil"]).optional(),
   localCacheEngine: localCacheEngine.optional(),
-  usePartOrientationAnalysis: z.boolean().optional(),
+  enablePartOrientationAnalysis: z.boolean().optional(),
   pcbDisabled: z.boolean().optional(),
   routingDisabled: z.boolean().optional(),
   schematicDisabled: z.boolean().optional(),

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -45,6 +45,12 @@ export interface AutorouterDefinition {
   ) => AutorouterInstance | Promise<AutorouterInstance>
 }
 
+export interface LocalCacheEngine {
+  getItem(key: string): string | Promise<string | null> | null
+  setItem(key: string, value: string): void | Promise<void>
+  removeItem?(key: string): void | Promise<void>
+}
+
 /** e.g. "kicad", this is the prefix used to reference libraries in footprinter strings e.g. kicad:Resistor_0402 **/
 type FootprintLibraryPrefix = string
 
@@ -72,8 +78,14 @@ export interface PlatformConfig {
    */
   allowLegacyAutorouters?: boolean
 
-  // TODO this follows a subset of the localStorage interface
-  localCacheEngine?: any
+  /** A localStorage-compatible cache used by render phases and engines. */
+  localCacheEngine?: LocalCacheEngine
+
+  /**
+   * Analyze rendered and supplier footprints so manufacturing exporters can
+   * align their semantic pin 1 orientations.
+   */
+  usePartOrientationAnalysis?: boolean
 
   registryApiUrl?: string
 
@@ -205,6 +217,16 @@ const platformFetch = z
   .custom<typeof fetch>((value) => typeof value === "function")
   .describe("A fetch-like function to use for platform requests")
 
+const localCacheEngine = z.custom<LocalCacheEngine>(
+  (value) =>
+    typeof value === "object" &&
+    value !== null &&
+    "getItem" in value &&
+    typeof value.getItem === "function" &&
+    "setItem" in value &&
+    typeof value.setItem === "function",
+)
+
 export const platformConfig = z.object({
   partsEngine: partsEngine.optional(),
   autorouter: autorouterProp.optional(),
@@ -231,7 +253,8 @@ export const platformConfig = z.object({
     .optional(),
   defaultSpiceEngine: defaultSpiceEngine.optional(),
   unitPreference: z.enum(["mm", "in", "mil"]).optional(),
-  localCacheEngine: z.any().optional(),
+  localCacheEngine: localCacheEngine.optional(),
+  usePartOrientationAnalysis: z.boolean().optional(),
   pcbDisabled: z.boolean().optional(),
   routingDisabled: z.boolean().optional(),
   schematicDisabled: z.boolean().optional(),

--- a/tests/platform-config-part-orientation-analysis.test.ts
+++ b/tests/platform-config-part-orientation-analysis.test.ts
@@ -4,20 +4,20 @@ import { platformConfig } from "lib/platformConfig"
 test("platformConfig accepts part orientation analysis and a local cache", () => {
   const cache = new Map<string, string>()
   const parsed = platformConfig.parse({
-    usePartOrientationAnalysis: true,
+    enablePartOrientationAnalysis: true,
     localCacheEngine: {
       getItem: (key: string) => cache.get(key) ?? null,
       setItem: (key: string, value: string) => cache.set(key, value),
     },
   })
 
-  expect(parsed.usePartOrientationAnalysis).toBe(true)
+  expect(parsed.enablePartOrientationAnalysis).toBe(true)
   expect(parsed.localCacheEngine).toBeDefined()
 })
 
 test("platformConfig rejects invalid orientation analysis and cache values", () => {
   expect(() =>
-    platformConfig.parse({ usePartOrientationAnalysis: "yes" }),
+    platformConfig.parse({ enablePartOrientationAnalysis: "yes" }),
   ).toThrow()
   expect(() => platformConfig.parse({ localCacheEngine: {} })).toThrow()
 })

--- a/tests/platform-config-part-orientation-analysis.test.ts
+++ b/tests/platform-config-part-orientation-analysis.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import { platformConfig } from "lib/platformConfig"
+
+test("platformConfig accepts part orientation analysis and a local cache", () => {
+  const cache = new Map<string, string>()
+  const parsed = platformConfig.parse({
+    usePartOrientationAnalysis: true,
+    localCacheEngine: {
+      getItem: (key: string) => cache.get(key) ?? null,
+      setItem: (key: string, value: string) => cache.set(key, value),
+    },
+  })
+
+  expect(parsed.usePartOrientationAnalysis).toBe(true)
+  expect(parsed.localCacheEngine).toBeDefined()
+})
+
+test("platformConfig rejects invalid orientation analysis and cache values", () => {
+  expect(() =>
+    platformConfig.parse({ usePartOrientationAnalysis: "yes" }),
+  ).toThrow()
+  expect(() => platformConfig.parse({ localCacheEngine: {} })).toThrow()
+})


### PR DESCRIPTION
## Summary

- add the manufacturer-independent `enablePartOrientationAnalysis` platform flag
- define the localStorage-like `LocalCacheEngine` contract already consumed by render phases
- validate both options through `platformConfig`
- regenerate checked-in props documentation

This is the platform-side prerequisite for enriching Circuit JSON with semantic local and supplier pin-1 locations.

## Testing

- `bun test` (405 tests)
- `bun run typecheck`
- `bun run build`
- `bun run check-circular-deps`
- `bun run format:check`
- all required repository generation scripts
