### PR TITLE
Add rotated pill SmtPad props

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -4302,6 +4302,19 @@ export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   solderMaskMargin?: Distance
   solderPasteMargin?: Distance
 }
+export interface RotatedPillSmtPadProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
+  shape: "rotated_pill"
+  width: Distance
+  height: Distance
+  radius: Distance
+  ccwRotation: number
+  portHints?: PortHints
+  coveredWithSolderMask?: boolean
+  solderMaskMargin?: Distance
+  solderPasteMargin?: Distance
+}
 export interface PolygonSmtPadProps
   extends Omit<PcbLayoutProps, "pcbRotation"> {
   name?: string
@@ -4367,6 +4380,20 @@ export const pillSmtPadProps = pcbLayoutProps
     width: distance,
     height: distance,
     radius: distance,
+    portHints: portHints.optional(),
+    coveredWithSolderMask: z.boolean().optional(),
+    solderMaskMargin: distance.optional(),
+    solderPasteMargin: distance.optional(),
+  })
+export const rotatedPillSmtPadProps = pcbLayoutProps
+  .omit({ pcbRotation: true })
+  .extend({
+    name: z.string().optional(),
+    shape: z.literal("rotated_pill"),
+    width: distance,
+    height: distance,
+    radius: distance,
+    ccwRotation: z.number(),
     portHints: portHints.optional(),
     coveredWithSolderMask: z.boolean().optional(),
     solderMaskMargin: distance.optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -2102,6 +2102,21 @@ export interface ResonatorProps extends CommonComponentProps {
 }
 
 
+export interface RotatedPillSmtPadProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
+  shape: "rotated_pill"
+  width: Distance
+  height: Distance
+  radius: Distance
+  ccwRotation: number
+  portHints?: PortHints
+  coveredWithSolderMask?: boolean
+  solderMaskMargin?: Distance
+  solderPasteMargin?: Distance
+}
+
+
 export interface RotatedRectSmtPadProps
   extends Omit<PcbLayoutProps, "pcbRotation"> {
   name?: string

--- a/lib/components/smtpad.ts
+++ b/lib/components/smtpad.ts
@@ -66,6 +66,20 @@ export interface PillSmtPadProps extends Omit<PcbLayoutProps, "pcbRotation"> {
   solderPasteMargin?: Distance
 }
 
+export interface RotatedPillSmtPadProps
+  extends Omit<PcbLayoutProps, "pcbRotation"> {
+  name?: string
+  shape: "rotated_pill"
+  width: Distance
+  height: Distance
+  radius: Distance
+  ccwRotation: number
+  portHints?: PortHints
+  coveredWithSolderMask?: boolean
+  solderMaskMargin?: Distance
+  solderPasteMargin?: Distance
+}
+
 export interface PolygonSmtPadProps
   extends Omit<PcbLayoutProps, "pcbRotation"> {
   name?: string
@@ -82,6 +96,7 @@ export type SmtPadProps =
   | CircleSmtPadProps
   | RotatedRectSmtPadProps
   | PillSmtPadProps
+  | RotatedPillSmtPadProps
   | PolygonSmtPadProps
 
 // ----------------------------------------------------------------------------
@@ -160,6 +175,23 @@ export const pillSmtPadProps = pcbLayoutProps
 type InferredPillSmtPadProps = z.input<typeof pillSmtPadProps>
 expectTypesMatch<InferredPillSmtPadProps, PillSmtPadProps>(true)
 
+export const rotatedPillSmtPadProps = pcbLayoutProps
+  .omit({ pcbRotation: true })
+  .extend({
+    name: z.string().optional(),
+    shape: z.literal("rotated_pill"),
+    width: distance,
+    height: distance,
+    radius: distance,
+    ccwRotation: z.number(),
+    portHints: portHints.optional(),
+    coveredWithSolderMask: z.boolean().optional(),
+    solderMaskMargin: distance.optional(),
+    solderPasteMargin: distance.optional(),
+  })
+type InferredRotatedPillSmtPadProps = z.input<typeof rotatedPillSmtPadProps>
+expectTypesMatch<InferredRotatedPillSmtPadProps, RotatedPillSmtPadProps>(true)
+
 export const polygonSmtPadProps = pcbLayoutProps
   .omit({ pcbRotation: true })
   .extend({
@@ -179,6 +211,7 @@ export const smtPadProps = z.discriminatedUnion("shape", [
   rectSmtPadProps,
   rotatedRectSmtPadProps,
   pillSmtPadProps,
+  rotatedPillSmtPadProps,
   polygonSmtPadProps,
 ])
 

--- a/tests/smtpad.test.ts
+++ b/tests/smtpad.test.ts
@@ -2,7 +2,9 @@ import { expect, test } from "bun:test"
 import {
   smtPadProps,
   polygonSmtPadProps,
+  rotatedPillSmtPadProps,
   type PolygonSmtPadProps,
+  type RotatedPillSmtPadProps,
   type SmtPadProps,
 } from "lib/components/smtpad"
 import { expectTypeOf } from "expect-type"
@@ -46,6 +48,41 @@ test("type inference for SmtPadProps", () => {
     points: [{ x: 0, y: 0 }],
   }
   expectTypeOf(polygon).toMatchTypeOf<PolygonSmtPadProps>()
+})
+
+test("should parse RotatedPillSmtPadProps", () => {
+  const rawProps: RotatedPillSmtPadProps = {
+    name: "pad1",
+    shape: "rotated_pill",
+    width: "2mm",
+    height: "1mm",
+    radius: "0.5mm",
+    ccwRotation: 90,
+    pcbX: "1mm",
+    pcbY: 2,
+    portHints: ["1"],
+  }
+
+  expectTypeOf(rawProps).toMatchTypeOf<z.input<typeof rotatedPillSmtPadProps>>()
+
+  const parsed = rotatedPillSmtPadProps.parse(rawProps)
+  expect(parsed).toMatchObject({
+    name: "pad1",
+    shape: "rotated_pill",
+    width: 2,
+    height: 1,
+    radius: 0.5,
+    ccwRotation: 90,
+    pcbX: 1,
+    pcbY: 2,
+    portHints: ["1"],
+  })
+
+  const parsedUnion = smtPadProps.parse(rawProps)
+  if (parsedUnion.shape !== "rotated_pill") {
+    throw new Error("Expected RotatedPillSmtPadProps")
+  }
+  expect(parsedUnion.ccwRotation).toBe(90)
 })
 
 test("should parse RectSmtPadProps with individual solder mask margins", () => {
@@ -108,6 +145,19 @@ test("should parse solder paste margin on every smtpad shape", () => {
   })
   if (pill.shape !== "pill") throw new Error("Expected pill")
   expect(pill.solderPasteMargin).toBe(-0.1)
+
+  const rotatedPill = smtPadProps.parse({
+    shape: "rotated_pill",
+    width: 2,
+    height: 1,
+    radius: 0.5,
+    ccwRotation: 90,
+    solderPasteMargin: -0.1,
+  })
+  if (rotatedPill.shape !== "rotated_pill") {
+    throw new Error("Expected rotated_pill")
+  }
+  expect(rotatedPill.solderPasteMargin).toBe(-0.1)
 
   const polygon = smtPadProps.parse({
     shape: "polygon",


### PR DESCRIPTION
## Summary

- add first-class `RotatedPillSmtPadProps` with `shape: "rotated_pill"`
- model the pad's intrinsic angle with required `ccwRotation`, matching `RotatedRectSmtPadProps`
- keep `pcbRotation` omitted from the SmtPad shape
- add the schema to the `SmtPadProps` discriminated union
- regenerate the component type and props overview documentation

## Why

Circuit JSON supports `PcbSmtPadRotatedPill`, but `@tscircuit/props` had no corresponding SmtPad input variant. Core therefore could not inflate imported rotated-pill pads without introducing an internal schema or abusing the component-level `pcbRotation` transform.

This makes rotated-pill geometry a first-class prop using the same shape-specific rotation pattern as `rotated_rect`.

## Validation

- `bun test` — 404 tests passed
- `bun run typecheck`
- `bun run format:check`
- `bun run build`
- all repository-required documentation generators