### PR TITLE
Add DDR routing constraint props

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,14 @@ export interface BusProps {
   connections: string[];
   /** If set, every trace in this bus is assigned to this autorouting phase. */
   routingPhaseIndex?: number | null;
+  /** Maximum routed-length difference between bus members. Raw numbers are millimeters. */
+  maxLengthSkew?: number | string;
+  /** Intended single-ended characteristic impedance. Raw numbers are ohms. */
+  targetImpedance?: number | string;
+  /** Explicit PCB trace width for every bus member. Raw numbers are millimeters. */
+  pcbTraceWidth?: number | string;
+  /** PCB layers on which the bus may be routed. */
+  pcbAllowedLayers?: LayerRefInput[];
 }
 ```
 
@@ -733,8 +741,14 @@ export interface DifferentialPairProps {
   positiveConnection: string;
   /** Name of the trace or pin carrying the negative signal. */
   negativeConnection: string;
-  /** Maximum permitted routed-length skew in millimeters. */
-  maxLengthSkew?: number;
+  /** Maximum permitted routed-length skew. Raw numbers are millimeters. */
+  maxLengthSkew?: number | string;
+  /** Intended differential characteristic impedance. Raw numbers are ohms. */
+  targetDifferentialImpedance?: number | string;
+  /** Edge-to-edge PCB copper gap between the pair. Raw numbers are millimeters. */
+  pcbTraceGap?: number | string;
+  /** Maximum length over which the pair may be routed without coupling. Raw numbers are millimeters. */
+  maxUncoupledLength?: number | string;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1372,12 +1372,20 @@ export interface BusProps {
   name?: string
   connections: string[]
   routingPhaseIndex?: number | null
+  maxLengthSkew?: number | string
+  targetImpedance?: number | string
+  pcbTraceWidth?: number | string
+  pcbAllowedLayers?: LayerRefInput[]
 }
-/** If set, every trace in this bus is assigned to this autorouting phase. */
+/** PCB layers on which the bus may be routed. */
 export const busProps = z.object({
   name: z.string().optional(),
   connections: z.array(z.string()).min(2),
   routingPhaseIndex: z.number().nullable().optional(),
+  maxLengthSkew: distance.pipe(z.number().min(0).finite()).optional(),
+  targetImpedance: resistance.pipe(z.number().positive().finite()).optional(),
+  pcbTraceWidth: distance.pipe(z.number().positive().finite()).optional(),
+  pcbAllowedLayers: z.array(layer_ref).min(1).optional(),
 })
 ```
 
@@ -1888,14 +1896,22 @@ export interface DifferentialPairProps {
   name?: string
   positiveConnection: string
   negativeConnection: string
-  maxLengthSkew?: number
+  maxLengthSkew?: number | string
+  targetDifferentialImpedance?: number | string
+  pcbTraceGap?: number | string
+  maxUncoupledLength?: number | string
 }
-/** Maximum permitted routed-length skew in millimeters. */
+/** Maximum length over which the pair may be routed without coupling. Raw numbers are millimeters. */
 export const differentialPairProps = z.object({
   name: z.string().optional(),
   positiveConnection: z.string(),
   negativeConnection: z.string(),
-  maxLengthSkew: z.number().min(0).finite().optional(),
+  maxLengthSkew: distance.pipe(z.number().min(0).finite()).optional(),
+  targetDifferentialImpedance: resistance
+    .pipe(z.number().positive().finite())
+    .optional(),
+  pcbTraceGap: distance.pipe(z.number().positive().finite()).optional(),
+  maxUncoupledLength: distance.pipe(z.number().min(0).finite()).optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -425,6 +425,14 @@ export interface BusProps {
   connections: string[]
   /** If set, every trace in this bus is assigned to this autorouting phase. */
   routingPhaseIndex?: number | null
+  /** Maximum routed-length difference between bus members. Raw numbers are millimeters. */
+  maxLengthSkew?: number | string
+  /** Intended single-ended characteristic impedance. Raw numbers are ohms. */
+  targetImpedance?: number | string
+  /** Explicit PCB trace width for every bus member. Raw numbers are millimeters. */
+  pcbTraceWidth?: number | string
+  /** PCB layers on which the bus may be routed. */
+  pcbAllowedLayers?: LayerRefInput[]
 }
 
 
@@ -857,8 +865,14 @@ export interface DifferentialPairProps {
   positiveConnection: string
   /** Name of the trace or pin carrying the negative signal. */
   negativeConnection: string
-  /** Maximum permitted routed-length skew in millimeters. */
-  maxLengthSkew?: number
+  /** Maximum permitted routed-length skew. Raw numbers are millimeters. */
+  maxLengthSkew?: number | string
+  /** Intended differential characteristic impedance. Raw numbers are ohms. */
+  targetDifferentialImpedance?: number | string
+  /** Edge-to-edge PCB copper gap between the pair. Raw numbers are millimeters. */
+  pcbTraceGap?: number | string
+  /** Maximum length over which the pair may be routed without coupling. Raw numbers are millimeters. */
+  maxUncoupledLength?: number | string
 }
 
 

--- a/lib/components/bus.ts
+++ b/lib/components/bus.ts
@@ -1,4 +1,10 @@
 import { expectTypesMatch } from "lib/typecheck"
+import {
+  distance,
+  layer_ref,
+  resistance,
+  type LayerRefInput,
+} from "circuit-json"
 import { z } from "zod"
 
 export type BusName = string
@@ -13,12 +19,24 @@ export interface BusProps {
   connections: string[]
   /** If set, every trace in this bus is assigned to this autorouting phase. */
   routingPhaseIndex?: number | null
+  /** Maximum routed-length difference between bus members. Raw numbers are millimeters. */
+  maxLengthSkew?: number | string
+  /** Intended single-ended characteristic impedance. Raw numbers are ohms. */
+  targetImpedance?: number | string
+  /** Explicit PCB trace width for every bus member. Raw numbers are millimeters. */
+  pcbTraceWidth?: number | string
+  /** PCB layers on which the bus may be routed. */
+  pcbAllowedLayers?: LayerRefInput[]
 }
 
 export const busProps = z.object({
   name: z.string().optional(),
   connections: z.array(z.string()).min(2),
   routingPhaseIndex: z.number().nullable().optional(),
+  maxLengthSkew: distance.pipe(z.number().min(0).finite()).optional(),
+  targetImpedance: resistance.pipe(z.number().positive().finite()).optional(),
+  pcbTraceWidth: distance.pipe(z.number().positive().finite()).optional(),
+  pcbAllowedLayers: z.array(layer_ref).min(1).optional(),
 })
 
 type InferredBusProps = z.input<typeof busProps>

--- a/lib/components/differentialpair.ts
+++ b/lib/components/differentialpair.ts
@@ -1,4 +1,5 @@
 import { expectTypesMatch } from "lib/typecheck"
+import { distance, resistance } from "circuit-json"
 import { z } from "zod"
 
 /**
@@ -11,15 +12,26 @@ export interface DifferentialPairProps {
   positiveConnection: string
   /** Name of the trace or pin carrying the negative signal. */
   negativeConnection: string
-  /** Maximum permitted routed-length skew in millimeters. */
-  maxLengthSkew?: number
+  /** Maximum permitted routed-length skew. Raw numbers are millimeters. */
+  maxLengthSkew?: number | string
+  /** Intended differential characteristic impedance. Raw numbers are ohms. */
+  targetDifferentialImpedance?: number | string
+  /** Edge-to-edge PCB copper gap between the pair. Raw numbers are millimeters. */
+  pcbTraceGap?: number | string
+  /** Maximum length over which the pair may be routed without coupling. Raw numbers are millimeters. */
+  maxUncoupledLength?: number | string
 }
 
 export const differentialPairProps = z.object({
   name: z.string().optional(),
   positiveConnection: z.string(),
   negativeConnection: z.string(),
-  maxLengthSkew: z.number().min(0).finite().optional(),
+  maxLengthSkew: distance.pipe(z.number().min(0).finite()).optional(),
+  targetDifferentialImpedance: resistance
+    .pipe(z.number().positive().finite())
+    .optional(),
+  pcbTraceGap: distance.pipe(z.number().positive().finite()).optional(),
+  maxUncoupledLength: distance.pipe(z.number().min(0).finite()).optional(),
 })
 
 type InferredDifferentialPairProps = z.input<typeof differentialPairProps>

--- a/tests/bus-ddr-routing-constraints.test.ts
+++ b/tests/bus-ddr-routing-constraints.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import { busProps, type BusProps } from "lib/components/bus"
+
+test("parses DDR bus routing constraints into canonical units", () => {
+  const rawProps = {
+    name: "DDR3_BYTE0",
+    connections: ["DQ0", "DQ1", "DQ2", "DQ3"],
+    maxLengthSkew: "4mil",
+    targetImpedance: "50ohm",
+    pcbTraceWidth: "5mil",
+    pcbAllowedLayers: ["inner2"],
+  } satisfies BusProps
+
+  expect(busProps.parse(rawProps)).toEqual({
+    ...rawProps,
+    maxLengthSkew: 0.1016,
+    targetImpedance: 50,
+    pcbTraceWidth: 0.127,
+  })
+})
+
+test("rejects invalid DDR bus routing constraints", () => {
+  const baseProps = { connections: ["DQ0", "DQ1"] }
+
+  expect(() =>
+    busProps.parse({ ...baseProps, maxLengthSkew: "-1mm" }),
+  ).toThrow()
+  expect(() => busProps.parse({ ...baseProps, targetImpedance: 0 })).toThrow()
+  expect(() => busProps.parse({ ...baseProps, pcbTraceWidth: 0 })).toThrow()
+  expect(() => busProps.parse({ ...baseProps, pcbAllowedLayers: [] })).toThrow()
+})

--- a/tests/differentialpair1.test.ts
+++ b/tests/differentialpair1.test.ts
@@ -5,12 +5,12 @@ import {
 } from "lib/components/differentialpair"
 
 test("parses a differential pair with maximum length skew", () => {
-  const raw: DifferentialPairProps = {
+  const raw = {
     name: "data",
     positiveConnection: "data-positive",
     negativeConnection: "data-negative",
     maxLengthSkew: 2.5,
-  }
+  } satisfies DifferentialPairProps
 
   const parsed = differentialPairProps.parse(raw)
 

--- a/tests/differentialpair5.test.ts
+++ b/tests/differentialpair5.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test"
+import {
+  differentialPairProps,
+  type DifferentialPairProps,
+} from "lib/components/differentialpair"
+
+test("parses DDR differential-pair constraints into canonical units", () => {
+  const rawProps = {
+    name: "DDR3_DQS0",
+    positiveConnection: "DQS0_P",
+    negativeConnection: "DQS0_N",
+    maxLengthSkew: "2mil",
+    targetDifferentialImpedance: "100ohm",
+    pcbTraceGap: "5mil",
+    maxUncoupledLength: "1mm",
+  } satisfies DifferentialPairProps
+
+  expect(differentialPairProps.parse(rawProps)).toEqual({
+    ...rawProps,
+    maxLengthSkew: 0.0508,
+    targetDifferentialImpedance: 100,
+    pcbTraceGap: 0.127,
+    maxUncoupledLength: 1,
+  })
+})
+
+test("rejects invalid DDR differential-pair constraints", () => {
+  const baseProps = {
+    positiveConnection: "DQS0_P",
+    negativeConnection: "DQS0_N",
+  }
+
+  expect(() =>
+    differentialPairProps.parse({
+      ...baseProps,
+      targetDifferentialImpedance: 0,
+    }),
+  ).toThrow()
+  expect(() =>
+    differentialPairProps.parse({ ...baseProps, pcbTraceGap: 0 }),
+  ).toThrow()
+  expect(() =>
+    differentialPairProps.parse({ ...baseProps, maxUncoupledLength: "-1mm" }),
+  ).toThrow()
+})


### PR DESCRIPTION
## What changed

- add unit-aware bus constraints for maximum length skew, target single-ended impedance, explicit PCB trace width, and allowed PCB layers
- add unit-aware differential-pair constraints for target differential impedance, PCB trace gap, maximum uncoupled length, and length skew
- regenerate the props README and generated API documentation

## Why

DDR and other source-synchronous interfaces need declarative electrical and geometric routing intent before core and specialized autorouters can preserve impedance, coupling, and length matching. This PR defines that TSX-facing contract without introducing automatic routing behavior.

Raw distance values remain millimeters and raw impedance values are ohms. Unit strings such as `4mil`, `0.1mm`, and `100ohm` are normalized to canonical numeric outputs.

## Checks

- `bun test` — 410 tests pass
- `bun run typecheck`
- `bun run build`
- `bun run check-circular-deps`
- `bun run format:check`
- all required documentation generators
