### PR TITLE
fix: accept legacy numeric LED pin labels

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2881,12 +2881,27 @@ export const jumperProps = commonComponentProps.extend({
 ### led
 
 ```typescript
+export type LedPinLabels = (typeof lrPolarPins)[number]
+
+const legacyNumericLedPinLabelsProp = z
+  .record(
+    z.enum(["1", "2"]),
+    schematicPinLabel
+      .or(z.array(schematicPinLabel).readonly())
+      .or(z.array(schematicPinLabel)),
+  )
+  .transform((pinLabels) => ({
+    ...(pinLabels["1"] === undefined ? {} : { pin1: pinLabels["1"] }),
+    ...(pinLabels["2"] === undefined ? {} : { pin2: pinLabels["2"] }),
+  }))
 export const ledProps = commonComponentProps.extend({
   color: z.string().optional(),
   wavelength: z.string().optional(),
   schDisplayValue: z.string().optional(),
   schOrientation: schematicOrientation.optional(),
-  pinLabels: diodePinLabelsProp.optional(),
+  // Numeric keys are accepted for compatibility with legacy generated LED
+  // wrappers, then normalized to the canonical pin1/pin2 representation.
+  pinLabels: diodePinLabelsProp.or(legacyNumericLedPinLabelsProp).optional(),
   connections: createConnectionsProp(lrPolarPins).optional(),
   laser: z.boolean().optional(),
 })

--- a/lib/components/led.ts
+++ b/lib/components/led.ts
@@ -3,15 +3,30 @@ import { schematicOrientation } from "lib/common/schematicOrientation"
 import { z } from "zod"
 import { createConnectionsProp } from "lib/common/connectionsProp"
 import { diodePinLabelsProp } from "lib/components/diode"
+import { schematicPinLabel } from "lib/common/schematicPinLabel"
 
 export type LedPinLabels = (typeof lrPolarPins)[number]
+
+const legacyNumericLedPinLabelsProp = z
+  .record(
+    z.enum(["1", "2"]),
+    schematicPinLabel
+      .or(z.array(schematicPinLabel).readonly())
+      .or(z.array(schematicPinLabel)),
+  )
+  .transform((pinLabels) => ({
+    ...(pinLabels["1"] === undefined ? {} : { pin1: pinLabels["1"] }),
+    ...(pinLabels["2"] === undefined ? {} : { pin2: pinLabels["2"] }),
+  }))
 
 export const ledProps = commonComponentProps.extend({
   color: z.string().optional(),
   wavelength: z.string().optional(),
   schDisplayValue: z.string().optional(),
   schOrientation: schematicOrientation.optional(),
-  pinLabels: diodePinLabelsProp.optional(),
+  // Numeric keys are accepted for compatibility with legacy generated LED
+  // wrappers, then normalized to the canonical pin1/pin2 representation.
+  pinLabels: diodePinLabelsProp.or(legacyNumericLedPinLabelsProp).optional(),
   connections: createConnectionsProp(lrPolarPins).optional(),
   laser: z.boolean().optional(),
 })

--- a/tests/led2-backward-compatible-pin-labels.test.ts
+++ b/tests/led2-backward-compatible-pin-labels.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test"
+import { ledProps, type LedProps } from "lib/components/led"
+
+test("normalizes legacy numeric LED pin-label keys", () => {
+  const rawProps: LedProps = {
+    name: "LED1",
+    pinLabels: {
+      "1": "pos",
+      "2": "neg",
+    },
+  }
+
+  const parsedProps = ledProps.parse(rawProps)
+
+  expect(parsedProps.pinLabels).toEqual({
+    pin1: "pos",
+    pin2: "neg",
+  })
+})


### PR DESCRIPTION
## Summary

- accept legacy numeric `pinLabels` keys (`"1"` and `"2"`) on `<led>` props
- normalize those keys to core's canonical `pin1` / `pin2` representation
- add a regression test and regenerate component-type documentation

## Root cause

`@tscircuit/props` 0.0.607 began validating LED pin labels through the diode schema. Existing registry-generated LED wrappers, including `@tsci/seveibar.red-led`, still emit numeric keys. The new validation rejected those wrappers and caused `tscircuit/eval`'s circuit-runner test to emit a `source_failed_to_create_component_error`, blocking its automated dependency update PR.

This keeps the compatibility behavior LED-specific and leaves diode parsing unchanged.

## Impact

Legacy generated LED components render again with current props versions, while parsed props use the canonical shape expected by `@tscircuit/core`.

## Validation

- `bun test` — 407 passed
- `bun run typecheck`
- `bun run build`
- `bun run check-circular-deps`
- `bun run format:check`
- exact failing eval integration test: `bun test tests/circuit-runner/circuitrunner1-readme-example.test.tsx --timeout 30000`

Related failure: https://github.com/tscircuit/eval/actions/runs/30849147103/job/91804710887