### PR TITLE
Add maxViaCount constraint to trace props

### DIFF
--- a/lib/components/trace.ts
+++ b/lib/components/trace.ts
@@ -59,6 +59,12 @@ const baseTraceProps = z.object({
   schStroke: z.string().optional(),
   highlightColor: z.string().optional(),
   maxLength: distance.optional(),
+  maxViaCount: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe("Maximum number of vias allowed in the PCB trace route"),
   connectsTo: z.string().or(z.array(z.string())).optional(),
 })
 

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -89,6 +89,20 @@ test("supports pcbStraightLine flag", () => {
   expect(parsed.pcbStraightLine).toBe(true)
 })
 
+test("supports limiting the maximum number of PCB vias", () => {
+  const raw: TraceProps = {
+    from: "A",
+    to: "B",
+    maxViaCount: 0,
+  }
+
+  const parsed = traceProps.parse(raw)
+
+  expect(parsed.maxViaCount).toBe(0)
+  expect(() => traceProps.parse({ ...raw, maxViaCount: -1 })).toThrow()
+  expect(() => traceProps.parse({ ...raw, maxViaCount: 1.5 })).toThrow()
+})
+
 test("accepts start/end aliases for trace endpoints", () => {
   const raw: TraceProps = {
     start: "A",


### PR DESCRIPTION
## What changed

- add an optional `maxViaCount` prop to `<trace>`
- accept only non-negative integer limits
- add parsing coverage for zero, negative, and fractional values

## Why

RF, clock, and other critical PCB traces often need an explicit via budget. For example, `maxViaCount={0}` lets a design state that an antenna matching or feed trace must remain on one layer instead of relying on autorouter heuristics.

The prop is optional and has no default, so existing routing behavior is unchanged.

## Follow-up implementation

Core should pass this constraint into circuit-json, and the autorouter should reject routes whose via count exceeds the limit. If no valid route exists, routing should fail with a constraint-specific error instead of silently inserting a via.

## Validation

- `bun test tests/trace.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run format:check`
- required generated-document scripts (no generated diff)
