### PR TITLE
fix: key fuse connections on pin labels (#754)

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,7 +941,7 @@ export interface FuseProps<
   /**
    * Connections to other components
    */
-  connections?: Connections<PinLabel>;
+  connections?: Connections<FusePinLabels>;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2155,7 +2155,7 @@ export interface FuseProps<PinLabel extends string = string>
 
   schOrientation?: SchematicOrientation
 
-  connections?: Connections<PinLabel>
+  connections?: Connections<FusePinLabels>
 }
 /**
  * Schema for validating fuse props
@@ -2165,16 +2165,7 @@ export const fuseProps = commonComponentProps.extend({
   voltageRating: z.union([z.number(), z.string()]).optional(),
   schShowRatings: z.boolean().optional(),
   schOrientation: schematicOrientation.optional(),
-  connections: z
-    .record(
-      z.string(),
-      z.union([
-        z.string(),
-        z.array(z.string()).readonly(),
-        z.array(z.string()),
-      ]),
-    )
-    .optional(),
+  connections: createConnectionsProp(fusePinLabels).optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1119,7 +1119,7 @@ export interface FuseProps<PinLabel extends string = string>
   /**
    * Connections to other components
    */
-  connections?: Connections<PinLabel>
+  connections?: Connections<FusePinLabels>
 }
 
 

--- a/lib/components/fuse.ts
+++ b/lib/components/fuse.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import { createConnectionsProp } from "lib/common/connectionsProp"
 import {
   type CommonComponentProps,
   commonComponentProps,
@@ -7,6 +8,7 @@ import {
   schematicOrientation,
   type SchematicOrientation,
 } from "lib/common/schematicOrientation"
+import { expectTypesMatch } from "lib/typecheck"
 import type { Connections } from "lib/utility-types/connections-and-selectors"
 
 /**
@@ -38,7 +40,7 @@ export interface FuseProps<PinLabel extends string = string>
   /**
    * Connections to other components
    */
-  connections?: Connections<PinLabel>
+  connections?: Connections<FusePinLabels>
 }
 
 /**
@@ -49,16 +51,9 @@ export const fuseProps = commonComponentProps.extend({
   voltageRating: z.union([z.number(), z.string()]).optional(),
   schShowRatings: z.boolean().optional(),
   schOrientation: schematicOrientation.optional(),
-  connections: z
-    .record(
-      z.string(),
-      z.union([
-        z.string(),
-        z.array(z.string()).readonly(),
-        z.array(z.string()),
-      ]),
-    )
-    .optional(),
+  connections: createConnectionsProp(fusePinLabels).optional(),
 })
 
 export type InferredFuseProps = z.input<typeof fuseProps>
+
+expectTypesMatch<FuseProps, InferredFuseProps>(true)

--- a/tests/fuse.test.ts
+++ b/tests/fuse.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import { fuseProps, type FuseProps } from "lib/components/fuse"
+
+test("should parse fuse connections keyed by pin labels", () => {
+  const raw: FuseProps = {
+    name: "F1",
+    currentRating: "1A",
+    connections: {
+      pin1: "net.VCC",
+      pin2: ["net.GND"],
+    },
+  }
+
+  const parsed = fuseProps.parse(raw)
+  expect(parsed.connections).toEqual({
+    pin1: "net.VCC",
+    pin2: ["net.GND"],
+  })
+})
+
+test("should reject fuse connections keyed by an unknown pin", () => {
+  const parsed = fuseProps.safeParse({
+    name: "F1",
+    currentRating: "1A",
+    connections: { pin99: ".R1 > .pin1" },
+  })
+
+  expect(parsed.success).toBe(false)
+})
+
+test("should reject fuse connections keyed by an empty string", () => {
+  const parsed = fuseProps.safeParse({
+    name: "F1",
+    currentRating: "1A",
+    connections: { "": ".R1 > .pin1" },
+  })
+
+  expect(parsed.success).toBe(false)
+})
+
+test("should allow optional fuse connections", () => {
+  const parsed = fuseProps.parse({
+    name: "F1",
+    currentRating: "1A",
+  })
+
+  expect(parsed.connections).toBeUndefined()
+})


### PR DESCRIPTION
Fixes #754

### Problem

`fuseProps` accepted **any string** as a `connections` key, so a typo'd pin name passed validation silently:

```ts
const typo = { pin99: ".R1 > .pin1" }

fuseProps.safeParse({ name: "F1", currentRating: "1A", connections: typo })      // success ✅  ← wrong
capacitorProps.safeParse({ name: "C1", capacitance: "1uF", connections: typo })  // success ❌
resistorProps.safeParse({ name: "R1", resistance: "1k", connections: typo })     // success ❌
```

`{ "not a pin at all": ... }` and `{ "": ... }` got through too. A fuse is a two-pin passive like a resistor or capacitor, so there's no reason for it to differ.

### Cause

Two related gaps in `lib/components/fuse.ts`:

1. **It hand-rolled the schema** as `z.record(z.string(), ...)` instead of using the shared `createConnectionsProp` helper, which keys the record on `z.enum(labels)` so unknown keys fail. `fusePinLabels` was already defined and exported in the file — it just wasn't used here.

2. **Nothing checked the schema against the interface.** `FuseProps` declared `connections?: Connections<PinLabel>` while the schema produced `Record<string, ...>`. Fuse was the only component in `lib/components/` that exported both an interface and an `Inferred*` type without calling `expectTypesMatch`, which is why the two were able to drift.

### Change

- `connections: createConnectionsProp(fusePinLabels).optional()`
- Narrow the interface to `Connections<FusePinLabels>`, matching `capacitor.ts` and `resistor.ts`
- Add `expectTypesMatch<FuseProps, InferredFuseProps>(true)` so this can't drift again

This is the idiom AGENTS.md already calls for: *"Electrical connectivity should usually be `connections` keyed by known pin labels."*

Adding the assertion to the **unfixed** file fails, confirming the drift was real:

```
error TS2345: Argument of type 'true' is not assignable to parameter of
type '"property connections has mismatched types"'.
```

### Behaviour

| `connections` | before | after |
|---|---|---|
| `{ pin1: "net.VCC", pin2: ["net.GND"] }` | accepted | accepted (unchanged) |
| `{ pin99: "..." }` | **accepted** | rejected |
| `{ "not a pin at all": "..." }` | **accepted** | rejected |
| `{ "": "..." }` | **accepted** | rejected |
| omitted | `undefined` | `undefined` (unchanged) |

Valid fuse connections parse to exactly the same value as before, so no real circuit changes behaviour.

Generated docs were refreshed per AGENTS.md (`generate-component-types`, `generate-manual-edits-docs`, `generate-readme-docs`, `generate-props-overview`); the only diffs are the fuse sections.

### Verification

- `bun test` — **416 pass / 0 fail** (was 412; +4 new tests in `tests/fuse.test.ts`)
- `bunx tsc --noEmit` — clean (this is what exercises the new `expectTypesMatch`)
- `bun run format:check` — clean
- `git diff --check` — clean