### PR TITLE
Add "beta_pipeline9" autorouterVersion value

### DIFF
--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -492,7 +492,15 @@ export interface SubcircuitGroupProps
 
   autorouter?: AutorouterProp
   autorouterEffortLevel?: "1x" | "2x" | "5x" | "10x" | "100x"
-  autorouterVersion?: "v1" | "v2" | "v3" | "v4" | "v5" | "v6" | "latest"
+  autorouterVersion?:
+    | "v1"
+    | "v2"
+    | "v3"
+    | "v4"
+    | "v5"
+    | "v6"
+    | "beta_pipeline9"
+    | "latest"
 
   /**
    * Serialized circuit JSON describing a precompiled subcircuit
@@ -670,7 +678,7 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   autorouter: autorouterProp.optional(),
   autorouterEffortLevel: autorouterEffortLevel.optional(),
   autorouterVersion: z
-    .enum(["v1", "v2", "v3", "v4", "v5", "v6", "latest"])
+    .enum(["v1", "v2", "v3", "v4", "v5", "v6", "beta_pipeline9", "latest"])
     .optional(),
   square: z.boolean().optional(),
   emptyArea: z.string().optional(),

--- a/tests/autorouter.test.ts
+++ b/tests/autorouter.test.ts
@@ -111,3 +111,11 @@ test("supports autorouter version v6", () => {
   })
   expect(result.autorouterVersion).toBe("v6")
 })
+
+test("supports autorouter version beta_pipeline9", () => {
+  const result = subcircuitGroupPropsWithBool.parse({
+    subcircuit: true,
+    autorouterVersion: "beta_pipeline9",
+  })
+  expect(result.autorouterVersion).toBe("beta_pipeline9")
+})


### PR DESCRIPTION
Adds `"beta_pipeline9"` to the `autorouterVersion` enum (TS type and zod schema in `lib/components/group.ts`) so users can opt into the new Pipeline9 (`AutoroutingPipelineSolver9_PreloadedTraceGraph`) autorouter from tscircuit-autorouter.

A companion PR in tscircuit/core maps `autorouterVersion="beta_pipeline9"` to Pipeline9; that PR depends on this one being released.

- Added enum value to the type and zod schema
- Added a parse test mirroring the existing v4/v5/v6 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)