### PR TITLE
Add PCB pack solver timeout platform config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2260,6 +2260,12 @@ export interface PlatformConfig {
    */
   enablePartOrientationAnalysis?: boolean;
 
+  /**
+   * Maximum time, in milliseconds, that an individual PCB pack solver may run.
+   * The timeout is checked between solver steps.
+   */
+  packSolverTimeoutMs?: number;
+
   registryApiUrl?: string;
 
   cloudAutorouterUrl?: string;

--- a/README.md
+++ b/README.md
@@ -2264,7 +2264,7 @@ export interface PlatformConfig {
    * Maximum time, in milliseconds, that an individual PCB pack solver may run.
    * The timeout is checked between solver steps.
    */
-  packSolverTimeoutMs?: number;
+  pcbPackSolverTimeoutMs?: number;
 
   registryApiUrl?: string;
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2541,7 +2541,15 @@ export interface SubcircuitGroupProps
 
   autorouter?: AutorouterProp
   autorouterEffortLevel?: "1x" | "2x" | "5x" | "10x" | "100x"
-  autorouterVersion?: "v1" | "v2" | "v3" | "v4" | "v5" | "v6" | "latest"
+  autorouterVersion?:
+    | "v1"
+    | "v2"
+    | "v3"
+    | "v4"
+    | "v5"
+    | "v6"
+    | "beta_pipeline9"
+    | "latest"
 
   circuitJson?: any[]
 
@@ -2691,7 +2699,7 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   autorouter: autorouterProp.optional(),
   autorouterEffortLevel: autorouterEffortLevel.optional(),
   autorouterVersion: z
-    .enum(["v1", "v2", "v3", "v4", "v5", "v6", "latest"])
+    .enum(["v1", "v2", "v3", "v4", "v5", "v6", "beta_pipeline9", "latest"])
     .optional(),
   square: z.boolean().optional(),
   emptyArea: z.string().optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1965,6 +1965,12 @@ export interface PlatformConfig {
    */
   enablePartOrientationAnalysis?: boolean
 
+  /**
+   * Maximum time, in milliseconds, that an individual PCB pack solver may run.
+   * The timeout is checked between solver steps.
+   */
+  packSolverTimeoutMs?: number
+
   registryApiUrl?: string
 
   cloudAutorouterUrl?: string
@@ -2490,7 +2496,15 @@ export interface SubcircuitGroupProps
 
   autorouter?: AutorouterProp
   autorouterEffortLevel?: "1x" | "2x" | "5x" | "10x" | "100x"
-  autorouterVersion?: "v1" | "v2" | "v3" | "v4" | "v5" | "v6" | "latest"
+  autorouterVersion?:
+    | "v1"
+    | "v2"
+    | "v3"
+    | "v4"
+    | "v5"
+    | "v6"
+    | "beta_pipeline9"
+    | "latest"
 
   /**
    * Serialized circuit JSON describing a precompiled subcircuit

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1969,7 +1969,7 @@ export interface PlatformConfig {
    * Maximum time, in milliseconds, that an individual PCB pack solver may run.
    * The timeout is checked between solver steps.
    */
-  packSolverTimeoutMs?: number
+  pcbPackSolverTimeoutMs?: number
 
   registryApiUrl?: string
 

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -91,7 +91,7 @@ export interface PlatformConfig {
    * Maximum time, in milliseconds, that an individual PCB pack solver may run.
    * The timeout is checked between solver steps.
    */
-  packSolverTimeoutMs?: number
+  pcbPackSolverTimeoutMs?: number
 
   registryApiUrl?: string
 
@@ -261,7 +261,7 @@ export const platformConfig = z.object({
   unitPreference: z.enum(["mm", "in", "mil"]).optional(),
   localCacheEngine: localCacheEngine.optional(),
   enablePartOrientationAnalysis: z.boolean().optional(),
-  packSolverTimeoutMs: z.number().finite().positive().optional(),
+  pcbPackSolverTimeoutMs: z.number().finite().positive().optional(),
   pcbDisabled: z.boolean().optional(),
   routingDisabled: z.boolean().optional(),
   schematicDisabled: z.boolean().optional(),

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -87,6 +87,12 @@ export interface PlatformConfig {
    */
   enablePartOrientationAnalysis?: boolean
 
+  /**
+   * Maximum time, in milliseconds, that an individual PCB pack solver may run.
+   * The timeout is checked between solver steps.
+   */
+  packSolverTimeoutMs?: number
+
   registryApiUrl?: string
 
   cloudAutorouterUrl?: string
@@ -255,6 +261,7 @@ export const platformConfig = z.object({
   unitPreference: z.enum(["mm", "in", "mil"]).optional(),
   localCacheEngine: localCacheEngine.optional(),
   enablePartOrientationAnalysis: z.boolean().optional(),
+  packSolverTimeoutMs: z.number().finite().positive().optional(),
   pcbDisabled: z.boolean().optional(),
   routingDisabled: z.boolean().optional(),
   schematicDisabled: z.boolean().optional(),

--- a/tests/platform-config-pack-solver-timeout.test.ts
+++ b/tests/platform-config-pack-solver-timeout.test.ts
@@ -3,12 +3,15 @@ import { platformConfig } from "lib/platformConfig"
 
 test("platformConfig accepts only positive finite pack solver timeouts", () => {
   expect(
-    platformConfig.parse({ packSolverTimeoutMs: 5_000 }).packSolverTimeoutMs,
+    platformConfig.parse({ pcbPackSolverTimeoutMs: 5_000 })
+      .pcbPackSolverTimeoutMs,
   ).toBe(5_000)
 
-  expect(() => platformConfig.parse({ packSolverTimeoutMs: 0 })).toThrow()
-  expect(() => platformConfig.parse({ packSolverTimeoutMs: -1 })).toThrow()
+  expect(() => platformConfig.parse({ pcbPackSolverTimeoutMs: 0 })).toThrow()
+  expect(() => platformConfig.parse({ pcbPackSolverTimeoutMs: -1 })).toThrow()
   expect(() =>
-    platformConfig.parse({ packSolverTimeoutMs: Number.POSITIVE_INFINITY }),
+    platformConfig.parse({
+      pcbPackSolverTimeoutMs: Number.POSITIVE_INFINITY,
+    }),
   ).toThrow()
 })

--- a/tests/platform-config-pack-solver-timeout.test.ts
+++ b/tests/platform-config-pack-solver-timeout.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { platformConfig } from "lib/platformConfig"
+
+test("platformConfig accepts only positive finite pack solver timeouts", () => {
+  expect(
+    platformConfig.parse({ packSolverTimeoutMs: 5_000 }).packSolverTimeoutMs,
+  ).toBe(5_000)
+
+  expect(() => platformConfig.parse({ packSolverTimeoutMs: 0 })).toThrow()
+  expect(() => platformConfig.parse({ packSolverTimeoutMs: -1 })).toThrow()
+  expect(() =>
+    platformConfig.parse({ packSolverTimeoutMs: Number.POSITIVE_INFINITY }),
+  ).toThrow()
+})


### PR DESCRIPTION
## Summary

- add `pcbPackSolverTimeoutMs` to the canonical `PlatformConfig` interface
- validate the value as a positive, finite number of milliseconds
- add validator coverage for accepted and rejected values
- refresh the required generated documentation

This provides the PCB-specific platform contract used by tscircuit/core#3015 to cooperatively stop pathological `PackSolver2` runs between solver steps.

The required generators also synchronized pre-existing stale `beta_pipeline9` entries in `COMPONENT_TYPES.md` and `PROPS_OVERVIEW.md`.

## Testing

- `bun test` — 414 passed, 0 failed
- `bun run typecheck`
- `bun run build`
- `bun run check-circular-deps`
- `bun run format`
- all four required documentation/type generators