### PR TITLE
feat(group): accept `placementDrcChecksDisabled` on subcircuits and boards

### DIFF
--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -484,6 +484,12 @@ export interface SubcircuitGroupProps
     RoutingTolerances {
   manualEdits?: ManualEditsFileInput
   routingDisabled?: boolean
+  /**
+   * Skip the PCB placement design rule checks for this subcircuit. Placement
+   * errors otherwise cause autorouting to be skipped entirely, so this is the
+   * escape hatch for a placement the checks flag but you intend to keep.
+   */
+  placementDrcChecksDisabled?: boolean
   bomDisabled?: boolean
   defaultTraceWidth?: Distance
 
@@ -668,6 +674,7 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   schTraceAutoLabelEnabled: z.boolean().optional(),
   schMaxTraceDistance: distance.optional(),
   routingDisabled: z.boolean().optional(),
+  placementDrcChecksDisabled: z.boolean().optional(),
   bomDisabled: z.boolean().optional(),
   defaultTraceWidth: length.optional(),
   ...routingTolerances.shape,

--- a/tests/board.test.ts
+++ b/tests/board.test.ts
@@ -126,3 +126,12 @@ test("should parse isViaInPadAllowed prop", () => {
   expect(boardProps.parse(disabled).isViaInPadAllowed).toBe(false)
   expect(boardProps.parse({ name: "board" }).isViaInPadAllowed).toBeUndefined()
 })
+
+// core reads this through getInheritedProperty("placementDrcChecksDisabled"),
+// so it has to survive the zod parse to reach the autorouting gate
+
+test("should parse placementDrcChecksDisabled prop", () => {
+  const raw: BoardProps = { name: "board", placementDrcChecksDisabled: true }
+  const parsed = boardProps.parse(raw)
+  expect(parsed.placementDrcChecksDisabled).toBe(true)
+})


### PR DESCRIPTION
## Problem

When autorouting is skipped because of placement errors, core emits:

> Autorouting was skipped because N PCB placement errors were found. Fix the placement errors or set `placementDrcChecksDisabled` to true to route anyway.

Following that advice does nothing. `placementDrcChecksDisabled` lives only on `PlatformConfig`, so `<board placementDrcChecksDisabled>` is stripped by zod with no error and the board stays unrouted — the user is left with pads, no traces, and a message pointing at a setting they cannot reach.

## Fix

Add the key to `subcircuitGroupProps` (inherited by `boardProps`). No core change is needed: `Board_doInitialPcbPlacementDesignRuleChecks` already resolves it as

```ts
board.root?.platform?.placementDrcChecksDisabled ??
  board.getInheritedProperty("placementDrcChecksDisabled")
```

so the prop reaches the gate as soon as it survives parsing. Being a subcircuit prop rather than board-only is the useful shape here — it lets you exempt one dense subcircuit (a fine-pitch QFN escape, say) without disabling placement checks for the whole board.

## Tests

`tests/board.test.ts` — asserts the prop survives `boardProps.parse`. Full suite: 414 pass.

## Related

tscircuit/cli#4071 makes `tsci build --ignore-placement-drc` lift the same gate; today it only filters the diagnostics while leaving the board unrouted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)