### PR TITLE
Allow distance units for capacitor decoupling trace limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,8 @@ export interface CapacitorProps<
   decouplingTo?: string;
   bypassFor?: string;
   bypassTo?: string;
-  maxDecouplingTraceLength?: number;
+  /** Maximum allowed PCB trace length between this capacitor and the component it decouples */
+  maxDecouplingTraceLength?: number | string;
   schOrientation?: SchematicOrientation;
   schSize?: SchematicSymbolSize;
   connections?: Connections<CapacitorPinLabels>;

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1456,11 +1456,12 @@ export interface CapacitorProps<PinLabel extends string = string>
   decouplingTo?: string
   bypassFor?: string
   bypassTo?: string
-  maxDecouplingTraceLength?: number
+  maxDecouplingTraceLength?: number | string
   schOrientation?: SchematicOrientation
   schSize?: SchematicSymbolSize
   connections?: Connections<CapacitorPinLabels>
 }
+/** Maximum allowed PCB trace length between this capacitor and the component it decouples */
 export const capacitorProps = commonComponentProps.extend({
   capacitance,
   maxVoltageRating: voltage.optional(),
@@ -1470,7 +1471,7 @@ export const capacitorProps = commonComponentProps.extend({
   decouplingTo: z.string().optional(),
   bypassFor: z.string().optional(),
   bypassTo: z.string().optional(),
-  maxDecouplingTraceLength: z.number().optional(),
+  maxDecouplingTraceLength: distance.optional(),
   schOrientation: schematicOrientation.optional(),
   schSize: schematicSymbolSize.optional(),
   connections: createConnectionsProp(capacitorPinLabels).optional(),
@@ -2533,6 +2534,7 @@ export interface SubcircuitGroupProps
     RoutingTolerances {
   manualEdits?: ManualEditsFileInput
   routingDisabled?: boolean
+  placementDrcChecksDisabled?: boolean
   bomDisabled?: boolean
   defaultTraceWidth?: Distance
 
@@ -2689,6 +2691,7 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   schTraceAutoLabelEnabled: z.boolean().optional(),
   schMaxTraceDistance: distance.optional(),
   routingDisabled: z.boolean().optional(),
+  placementDrcChecksDisabled: z.boolean().optional(),
   bomDisabled: z.boolean().optional(),
   defaultTraceWidth: length.optional(),
   ...routingTolerances.shape,

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -538,7 +538,8 @@ export interface CapacitorProps<PinLabel extends string = string>
   decouplingTo?: string
   bypassFor?: string
   bypassTo?: string
-  maxDecouplingTraceLength?: number
+  /** Maximum allowed PCB trace length between this capacitor and the component it decouples */
+  maxDecouplingTraceLength?: number | string
   schOrientation?: SchematicOrientation
   schSize?: SchematicSymbolSize
   connections?: Connections<CapacitorPinLabels>
@@ -2488,6 +2489,12 @@ export interface SubcircuitGroupProps
     RoutingTolerances {
   manualEdits?: ManualEditsFileInput
   routingDisabled?: boolean
+  /**
+   * Skip the PCB placement design rule checks for this subcircuit. Placement
+   * errors otherwise cause autorouting to be skipped entirely, so this is the
+   * escape hatch for a placement the checks flag but you intend to keep.
+   */
+  placementDrcChecksDisabled?: boolean
   bomDisabled?: boolean
   defaultTraceWidth?: Distance
 

--- a/lib/components/capacitor.ts
+++ b/lib/components/capacitor.ts
@@ -1,4 +1,4 @@
-import { capacitance, voltage } from "circuit-json"
+import { capacitance, distance, voltage } from "circuit-json"
 import { createConnectionsProp } from "lib/common/connectionsProp"
 import {
   type CommonComponentProps,
@@ -37,7 +37,8 @@ export interface CapacitorProps<PinLabel extends string = string>
   decouplingTo?: string
   bypassFor?: string
   bypassTo?: string
-  maxDecouplingTraceLength?: number
+  /** Maximum allowed PCB trace length between this capacitor and the component it decouples */
+  maxDecouplingTraceLength?: number | string
   schOrientation?: SchematicOrientation
   schSize?: SchematicSymbolSize
   connections?: Connections<CapacitorPinLabels>
@@ -52,7 +53,7 @@ export const capacitorProps = commonComponentProps.extend({
   decouplingTo: z.string().optional(),
   bypassFor: z.string().optional(),
   bypassTo: z.string().optional(),
-  maxDecouplingTraceLength: z.number().optional(),
+  maxDecouplingTraceLength: distance.optional(),
   schOrientation: schematicOrientation.optional(),
   schSize: schematicSymbolSize.optional(),
   connections: createConnectionsProp(capacitorPinLabels).optional(),

--- a/tests/capacitor.test.ts
+++ b/tests/capacitor.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import {
+  type CapacitorProps,
+  capacitorProps,
+} from "../lib/components/capacitor"
+
+test("parses maxDecouplingTraceLength with distance units", () => {
+  const rawProps: CapacitorProps = {
+    name: "C1",
+    capacitance: "100nF",
+    maxDecouplingTraceLength: "0.1in",
+  }
+
+  const parsedProps = capacitorProps.parse(rawProps)
+
+  expect(parsedProps.maxDecouplingTraceLength).toBeCloseTo(2.54)
+})
+
+test("parses numeric maxDecouplingTraceLength as millimeters", () => {
+  const rawProps: CapacitorProps = {
+    name: "C1",
+    capacitance: "100nF",
+    maxDecouplingTraceLength: 3,
+  }
+
+  const parsedProps = capacitorProps.parse(rawProps)
+
+  expect(parsedProps.maxDecouplingTraceLength).toBe(3)
+})


### PR DESCRIPTION
## Summary

- allow `maxDecouplingTraceLength` on capacitors to accept unit-bearing distance strings such as `"1mm"`
- normalize values through the shared `circuit-json` distance parser while preserving numeric millimeter inputs
- add parser coverage for unit strings and numeric backwards compatibility
- regenerate props documentation

## Testing

- `bun test`
- `bun run typecheck`
- `bun run build`
- `bun run format:check`
- `bun run check-circular-deps`