### PR TITLE
Use pipeline names for autorouter versions

### DIFF
--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2529,6 +2529,38 @@ export const autorouterConfig = z.object({
     .optional(),
   local: z.boolean().optional(),
 })
+export type AutorouterVersion =
+  | "beta_pipeline1"
+  | "beta_pipeline3"
+  | "beta_pipeline4"
+  | "beta_pipeline5"
+  | "beta_pipeline7"
+  | "beta_pipeline9"
+  | "latest"
+
+const knownAutorouterVersion = z.enum([
+  "beta_pipeline1",
+  "beta_pipeline3",
+  "beta_pipeline4",
+  "beta_pipeline5",
+  "beta_pipeline7",
+  "beta_pipeline9",
+  "latest",
+])
+
+const autorouterVersion = z
+  .custom<AutocompleteString<AutorouterVersion>>(
+    (value) => typeof value === "string",
+  )
+  .transform((value): AutorouterVersion => {
+    const parsedAutorouterVersion = knownAutorouterVersion.safeParse(value)
+    if (parsedAutorouterVersion.success) return parsedAutorouterVersion.data
+
+    console.warn(
+      `Unknown autorouterVersion "${value}", falling back to "latest".`,
+    )
+    return "latest"
+  })
 export interface SubcircuitGroupProps
   extends BaseGroupProps,
     RoutingTolerances {
@@ -2551,6 +2583,7 @@ export interface SubcircuitGroupProps
     | "beta_pipeline7"
     | "beta_pipeline9"
     | "latest"
+    | (string & {})
 
   circuitJson?: any[]
 
@@ -2700,17 +2733,7 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   pcbRouteCache: z.custom<PcbRouteCache>((v) => true).optional(),
   autorouter: autorouterProp.optional(),
   autorouterEffortLevel: autorouterEffortLevel.optional(),
-  autorouterVersion: z
-    .enum([
-      "beta_pipeline1",
-      "beta_pipeline3",
-      "beta_pipeline4",
-      "beta_pipeline5",
-      "beta_pipeline7",
-      "beta_pipeline9",
-      "latest",
-    ])
-    .optional(),
+  autorouterVersion: autorouterVersion.optional(),
   square: z.boolean().optional(),
   emptyArea: z.string().optional(),
   filledArea: z.string().optional(),

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -2544,12 +2544,11 @@ export interface SubcircuitGroupProps
   autorouter?: AutorouterProp
   autorouterEffortLevel?: "1x" | "2x" | "5x" | "10x" | "100x"
   autorouterVersion?:
-    | "v1"
-    | "v2"
-    | "v3"
-    | "v4"
-    | "v5"
-    | "v6"
+    | "beta_pipeline1"
+    | "beta_pipeline3"
+    | "beta_pipeline4"
+    | "beta_pipeline5"
+    | "beta_pipeline7"
     | "beta_pipeline9"
     | "latest"
 
@@ -2702,7 +2701,15 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   autorouter: autorouterProp.optional(),
   autorouterEffortLevel: autorouterEffortLevel.optional(),
   autorouterVersion: z
-    .enum(["v1", "v2", "v3", "v4", "v5", "v6", "beta_pipeline9", "latest"])
+    .enum([
+      "beta_pipeline1",
+      "beta_pipeline3",
+      "beta_pipeline4",
+      "beta_pipeline5",
+      "beta_pipeline7",
+      "beta_pipeline9",
+      "latest",
+    ])
     .optional(),
   square: z.boolean().optional(),
   emptyArea: z.string().optional(),

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -2503,6 +2503,10 @@ export interface SubcircuitGroupProps
 
   autorouter?: AutorouterProp
   autorouterEffortLevel?: "1x" | "2x" | "5x" | "10x" | "100x"
+  /**
+   * Selects the local autorouting pipeline. Unknown string values emit a
+   * warning and fall back to `latest`.
+   */
   autorouterVersion?:
     | "beta_pipeline1"
     | "beta_pipeline3"
@@ -2511,6 +2515,7 @@ export interface SubcircuitGroupProps
     | "beta_pipeline7"
     | "beta_pipeline9"
     | "latest"
+    | (string & {})
 
   /**
    * Serialized circuit JSON describing a precompiled subcircuit

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -2504,12 +2504,11 @@ export interface SubcircuitGroupProps
   autorouter?: AutorouterProp
   autorouterEffortLevel?: "1x" | "2x" | "5x" | "10x" | "100x"
   autorouterVersion?:
-    | "v1"
-    | "v2"
-    | "v3"
-    | "v4"
-    | "v5"
-    | "v6"
+    | "beta_pipeline1"
+    | "beta_pipeline3"
+    | "beta_pipeline4"
+    | "beta_pipeline5"
+    | "beta_pipeline7"
     | "beta_pipeline9"
     | "latest"
 

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -499,12 +499,11 @@ export interface SubcircuitGroupProps
   autorouter?: AutorouterProp
   autorouterEffortLevel?: "1x" | "2x" | "5x" | "10x" | "100x"
   autorouterVersion?:
-    | "v1"
-    | "v2"
-    | "v3"
-    | "v4"
-    | "v5"
-    | "v6"
+    | "beta_pipeline1"
+    | "beta_pipeline3"
+    | "beta_pipeline4"
+    | "beta_pipeline5"
+    | "beta_pipeline7"
     | "beta_pipeline9"
     | "latest"
 
@@ -685,7 +684,15 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   autorouter: autorouterProp.optional(),
   autorouterEffortLevel: autorouterEffortLevel.optional(),
   autorouterVersion: z
-    .enum(["v1", "v2", "v3", "v4", "v5", "v6", "beta_pipeline9", "latest"])
+    .enum([
+      "beta_pipeline1",
+      "beta_pipeline3",
+      "beta_pipeline4",
+      "beta_pipeline5",
+      "beta_pipeline7",
+      "beta_pipeline9",
+      "latest",
+    ])
     .optional(),
   square: z.boolean().optional(),
   emptyArea: z.string().optional(),

--- a/lib/components/group.ts
+++ b/lib/components/group.ts
@@ -479,6 +479,39 @@ export const autorouterProp: z.ZodType<AutorouterProp> = z.union([
 
 export const autorouterEffortLevel = z.enum(["1x", "2x", "5x", "10x", "100x"])
 
+export type AutorouterVersion =
+  | "beta_pipeline1"
+  | "beta_pipeline3"
+  | "beta_pipeline4"
+  | "beta_pipeline5"
+  | "beta_pipeline7"
+  | "beta_pipeline9"
+  | "latest"
+
+const knownAutorouterVersion = z.enum([
+  "beta_pipeline1",
+  "beta_pipeline3",
+  "beta_pipeline4",
+  "beta_pipeline5",
+  "beta_pipeline7",
+  "beta_pipeline9",
+  "latest",
+])
+
+const autorouterVersion = z
+  .custom<AutocompleteString<AutorouterVersion>>(
+    (value) => typeof value === "string",
+  )
+  .transform((value): AutorouterVersion => {
+    const parsedAutorouterVersion = knownAutorouterVersion.safeParse(value)
+    if (parsedAutorouterVersion.success) return parsedAutorouterVersion.data
+
+    console.warn(
+      `Unknown autorouterVersion "${value}", falling back to "latest".`,
+    )
+    return "latest"
+  })
+
 export interface SubcircuitGroupProps
   extends BaseGroupProps,
     RoutingTolerances {
@@ -498,6 +531,10 @@ export interface SubcircuitGroupProps
 
   autorouter?: AutorouterProp
   autorouterEffortLevel?: "1x" | "2x" | "5x" | "10x" | "100x"
+  /**
+   * Selects the local autorouting pipeline. Unknown string values emit a
+   * warning and fall back to `latest`.
+   */
   autorouterVersion?:
     | "beta_pipeline1"
     | "beta_pipeline3"
@@ -506,6 +543,7 @@ export interface SubcircuitGroupProps
     | "beta_pipeline7"
     | "beta_pipeline9"
     | "latest"
+    | (string & {})
 
   /**
    * Serialized circuit JSON describing a precompiled subcircuit
@@ -683,17 +721,7 @@ export const subcircuitGroupProps = baseGroupProps.extend({
   pcbRouteCache: z.custom<PcbRouteCache>((v) => true).optional(),
   autorouter: autorouterProp.optional(),
   autorouterEffortLevel: autorouterEffortLevel.optional(),
-  autorouterVersion: z
-    .enum([
-      "beta_pipeline1",
-      "beta_pipeline3",
-      "beta_pipeline4",
-      "beta_pipeline5",
-      "beta_pipeline7",
-      "beta_pipeline9",
-      "latest",
-    ])
-    .optional(),
+  autorouterVersion: autorouterVersion.optional(),
   square: z.boolean().optional(),
   emptyArea: z.string().optional(),
   filledArea: z.string().optional(),

--- a/tests/autorouter.test.ts
+++ b/tests/autorouter.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test"
+import { expect, spyOn, test } from "bun:test"
 import {
   autorouterConfig,
   autorouterProp,
@@ -108,12 +108,21 @@ test("supports pipeline-based autorouter versions", () => {
   }
 })
 
-test("rejects v-prefixed autorouter versions", () => {
-  for (const autorouterVersion of ["v1", "v2", "v3", "v4", "v5", "v6"]) {
-    const result = subcircuitGroupPropsWithBool.safeParse({
-      subcircuit: true,
-      autorouterVersion,
-    })
-    expect(result.success).toBe(false)
+test("warns and falls back to latest for unknown autorouter versions", () => {
+  const consoleWarn = spyOn(console, "warn").mockImplementation(() => {})
+
+  try {
+    for (const autorouterVersion of ["v1", "v6", "beta_pipeline999"]) {
+      const result = subcircuitGroupPropsWithBool.parse({
+        subcircuit: true,
+        autorouterVersion,
+      })
+      expect(result.autorouterVersion).toBe("latest")
+      expect(consoleWarn).toHaveBeenCalledWith(
+        `Unknown autorouterVersion "${autorouterVersion}", falling back to "latest".`,
+      )
+    }
+  } finally {
+    consoleWarn.mockRestore()
   }
 })

--- a/tests/autorouter.test.ts
+++ b/tests/autorouter.test.ts
@@ -88,34 +88,32 @@ test("supports shared routing tolerances", () => {
   expect(result.minViaPadDiameter).toBe(0.6)
 })
 
-test("supports autorouter version v4", () => {
-  const result = subcircuitGroupPropsWithBool.parse({
-    subcircuit: true,
-    autorouterVersion: "v4",
-  })
-  expect(result.autorouterVersion).toBe("v4")
+test("supports pipeline-based autorouter versions", () => {
+  const autorouterVersions = [
+    "beta_pipeline1",
+    "beta_pipeline3",
+    "beta_pipeline4",
+    "beta_pipeline5",
+    "beta_pipeline7",
+    "beta_pipeline9",
+    "latest",
+  ] as const
+
+  for (const autorouterVersion of autorouterVersions) {
+    const result = subcircuitGroupPropsWithBool.parse({
+      subcircuit: true,
+      autorouterVersion,
+    })
+    expect(result.autorouterVersion).toBe(autorouterVersion)
+  }
 })
 
-test("supports autorouter version v5", () => {
-  const result = subcircuitGroupPropsWithBool.parse({
-    subcircuit: true,
-    autorouterVersion: "v5",
-  })
-  expect(result.autorouterVersion).toBe("v5")
-})
-
-test("supports autorouter version v6", () => {
-  const result = subcircuitGroupPropsWithBool.parse({
-    subcircuit: true,
-    autorouterVersion: "v6",
-  })
-  expect(result.autorouterVersion).toBe("v6")
-})
-
-test("supports autorouter version beta_pipeline9", () => {
-  const result = subcircuitGroupPropsWithBool.parse({
-    subcircuit: true,
-    autorouterVersion: "beta_pipeline9",
-  })
-  expect(result.autorouterVersion).toBe("beta_pipeline9")
+test("rejects v-prefixed autorouter versions", () => {
+  for (const autorouterVersion of ["v1", "v2", "v3", "v4", "v5", "v6"]) {
+    const result = subcircuitGroupPropsWithBool.safeParse({
+      subcircuit: true,
+      autorouterVersion,
+    })
+    expect(result.success).toBe(false)
+  }
 })


### PR DESCRIPTION
## Summary

- replace the legacy `v1`–`v6` autorouter version strings with pipeline-specific beta names
- expose `beta_pipeline1`, `beta_pipeline3`, `beta_pipeline4`, `beta_pipeline5`, `beta_pipeline7`, and `beta_pipeline9`, while retaining `latest`
- accept unknown version strings for compatibility, emit a warning, and normalize them to `latest`
- regenerate the generated props documentation

## Why

The former version numbers did not consistently match the underlying capacity-autorouter pipeline. In `tscircuit/core`, `v1`, `v3`, `v4`, and `v5` select their same-numbered pipelines, while `v6` selects pipeline 7. `v2` has no dedicated mapping and falls through to the pipeline-7 default. Naming supported values after the actual pipelines makes the API explicit without breaking consumers that still supply a legacy or future string.

## Impact

Consumers receive autocomplete for the pipeline-specific `beta_pipeline${number}` names. Legacy or otherwise unknown string values remain parseable, produce a console warning, and use `latest`.

## Validation

- `bun test` (415 passing)
- `bun run typecheck`
- `bun run build`
- `bun run check-circular-deps`
- `git diff --check`
- all required documentation generators