### PR TITLE
Add a platform-level solver cache provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2255,6 +2255,9 @@ export interface PlatformConfig {
   /** A localStorage-compatible cache used by render phases and engines. */
   localCacheEngine?: LocalCacheEngine;
 
+  /** A solver cache forwarded unchanged to local autorouters. */
+  cacheProvider?: CacheProvider;
+
   /**
    * Analyze rendered and supplier footprints so manufacturing exporters can
    * align their semantic pin 1 orientations.

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -436,6 +436,21 @@ export interface BusProps {
 }
 
 
+export interface CacheProvider {
+  isSyncCache: boolean
+  cacheHits: number
+  cacheMisses: number
+  cacheHitsByPrefix: Record<string, number>
+  cacheMissesByPrefix: Record<string, number>
+  getCachedSolutionSync(cacheKey: string): unknown
+  getCachedSolution(cacheKey: string): Promise<unknown>
+  setCachedSolutionSync(cacheKey: string, cachedSolution: unknown): void
+  setCachedSolution(cacheKey: string, cachedSolution: unknown): Promise<void>
+  getAllCacheKeys(): string[]
+  clearCache(): void
+}
+
+
 export interface CadAssemblyProps {
   /**
    * The layer that the CAD assembly is designed for. If you set this to "top"
@@ -1959,6 +1974,9 @@ export interface PlatformConfig {
 
   /** A localStorage-compatible cache used by render phases and engines. */
   localCacheEngine?: LocalCacheEngine
+
+  /** A solver cache forwarded unchanged to local autorouters. */
+  cacheProvider?: CacheProvider
 
   /**
    * Analyze rendered and supplier footprints so manufacturing exporters can

--- a/lib/platformConfig.ts
+++ b/lib/platformConfig.ts
@@ -51,6 +51,21 @@ export interface LocalCacheEngine {
   removeItem?(key: string): void | Promise<void>
 }
 
+/** A solver cache supplied by the host platform and shared across renders. */
+export interface CacheProvider {
+  isSyncCache: boolean
+  cacheHits: number
+  cacheMisses: number
+  cacheHitsByPrefix: Record<string, number>
+  cacheMissesByPrefix: Record<string, number>
+  getCachedSolutionSync(cacheKey: string): unknown
+  getCachedSolution(cacheKey: string): Promise<unknown>
+  setCachedSolutionSync(cacheKey: string, cachedSolution: unknown): void
+  setCachedSolution(cacheKey: string, cachedSolution: unknown): Promise<void>
+  getAllCacheKeys(): string[]
+  clearCache(): void
+}
+
 /** e.g. "kicad", this is the prefix used to reference libraries in footprinter strings e.g. kicad:Resistor_0402 **/
 type FootprintLibraryPrefix = string
 
@@ -80,6 +95,9 @@ export interface PlatformConfig {
 
   /** A localStorage-compatible cache used by render phases and engines. */
   localCacheEngine?: LocalCacheEngine
+
+  /** A solver cache forwarded unchanged to local autorouters. */
+  cacheProvider?: CacheProvider
 
   /**
    * Analyze rendered and supplier footprints so manufacturing exporters can
@@ -233,6 +251,34 @@ const localCacheEngine = z.custom<LocalCacheEngine>(
     typeof value.setItem === "function",
 )
 
+const cacheProvider = z.custom<CacheProvider>(
+  (value) =>
+    typeof value === "object" &&
+    value !== null &&
+    "isSyncCache" in value &&
+    typeof value.isSyncCache === "boolean" &&
+    "cacheHits" in value &&
+    typeof value.cacheHits === "number" &&
+    "cacheMisses" in value &&
+    typeof value.cacheMisses === "number" &&
+    "cacheHitsByPrefix" in value &&
+    typeof value.cacheHitsByPrefix === "object" &&
+    "cacheMissesByPrefix" in value &&
+    typeof value.cacheMissesByPrefix === "object" &&
+    "getCachedSolutionSync" in value &&
+    typeof value.getCachedSolutionSync === "function" &&
+    "getCachedSolution" in value &&
+    typeof value.getCachedSolution === "function" &&
+    "setCachedSolutionSync" in value &&
+    typeof value.setCachedSolutionSync === "function" &&
+    "setCachedSolution" in value &&
+    typeof value.setCachedSolution === "function" &&
+    "getAllCacheKeys" in value &&
+    typeof value.getAllCacheKeys === "function" &&
+    "clearCache" in value &&
+    typeof value.clearCache === "function",
+)
+
 export const platformConfig = z.object({
   partsEngine: partsEngine.optional(),
   autorouter: autorouterProp.optional(),
@@ -260,6 +306,7 @@ export const platformConfig = z.object({
   defaultSpiceEngine: defaultSpiceEngine.optional(),
   unitPreference: z.enum(["mm", "in", "mil"]).optional(),
   localCacheEngine: localCacheEngine.optional(),
+  cacheProvider: cacheProvider.optional(),
   enablePartOrientationAnalysis: z.boolean().optional(),
   pcbPackSolverTimeoutMs: z.number().finite().positive().optional(),
   pcbDisabled: z.boolean().optional(),

--- a/tests/platform-config-cache-provider.test.ts
+++ b/tests/platform-config-cache-provider.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import { platformConfig } from "lib/platformConfig"
+
+test("platformConfig accepts a solver cache provider", () => {
+  const cachedSolutions = new Map<string, unknown>()
+  const cacheProvider = {
+    isSyncCache: true,
+    cacheHits: 0,
+    cacheMisses: 0,
+    cacheHitsByPrefix: {},
+    cacheMissesByPrefix: {},
+    getCachedSolutionSync: (cacheKey: string) => cachedSolutions.get(cacheKey),
+    getCachedSolution: async (cacheKey: string) =>
+      cachedSolutions.get(cacheKey),
+    setCachedSolutionSync: (cacheKey: string, cachedSolution: unknown) => {
+      cachedSolutions.set(cacheKey, cachedSolution)
+    },
+    setCachedSolution: async (cacheKey: string, cachedSolution: unknown) => {
+      cachedSolutions.set(cacheKey, cachedSolution)
+    },
+    getAllCacheKeys: () => [...cachedSolutions.keys()],
+    clearCache: () => cachedSolutions.clear(),
+  }
+
+  const parsed = platformConfig.parse({ cacheProvider })
+
+  expect(parsed.cacheProvider).toBe(cacheProvider)
+  expect(() => platformConfig.parse({ cacheProvider: {} })).toThrow()
+})


### PR DESCRIPTION
## What
- add a typed cacheProvider field to PlatformConfig
- validate the complete synchronous/asynchronous solver-cache contract in the platformConfig schema
- export the structural CacheProvider interface for platforms and consumers
- regenerate the platform configuration documentation

## Why
Platforms need to opt into solver caching by supplying the cache implementation themselves. Core should forward that exact provider to local autorouter pipelines instead of selecting a global cache based on the chosen pipeline or the presence of an unrelated localCacheEngine.

## Impact
No cache is enabled by default. Platforms that want solver caching can construct a compatible provider and assign it to platformConfig.cacheProvider. The initial consumer is tscircuit/core#3083.

## Checks
- bun run typecheck
- bun test tests/platform-config-cache-provider.test.ts
- bun run build
- bun run check-circular-deps
- bun run format:check
- all required documentation generation scripts
- git diff --check