### PR TITLE
feat: add showHiddenEdges to FDM enclosures

### DIFF
--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -1060,6 +1060,8 @@ export interface EnclosureFdmBoxProps {
   lidLipDepth?: Distance
   /** Disable placement of apertures explicitly declared by enclosed components. */
   disableCutouts?: boolean
+  /** Show edges hidden behind the enclosure surface in compatible 3D viewers. */
+  showHiddenEdges?: boolean
 }
 
 

--- a/lib/enclosure/fdm/box.ts
+++ b/lib/enclosure/fdm/box.ts
@@ -41,6 +41,8 @@ export interface EnclosureFdmBoxProps {
   lidLipDepth?: Distance
   /** Disable placement of apertures explicitly declared by enclosed components. */
   disableCutouts?: boolean
+  /** Show edges hidden behind the enclosure surface in compatible 3D viewers. */
+  showHiddenEdges?: boolean
 }
 
 export const enclosureFdmBoxProps = z.object({
@@ -57,6 +59,7 @@ export const enclosureFdmBoxProps = z.object({
   topHeadroom: distance.optional(),
   lidLipDepth: distance.optional(),
   disableCutouts: z.boolean().optional(),
+  showHiddenEdges: z.boolean().optional(),
 })
 
 export type EnclosureFdmBoxPropsInput = z.input<typeof enclosureFdmBoxProps>

--- a/tests/enclosure-fdm-box.test.ts
+++ b/tests/enclosure-fdm-box.test.ts
@@ -20,6 +20,7 @@ test("parses enclosure.fdm.box props with a boardRef", () => {
     topHeadroom: "6mm",
     lidLipDepth: "3mm",
     disableCutouts: true,
+    showHiddenEdges: true,
   }
 
   expect(enclosureFdmBoxProps.parse(input)).toEqual({
@@ -36,6 +37,7 @@ test("parses enclosure.fdm.box props with a boardRef", () => {
     topHeadroom: 6,
     lidLipDepth: 3,
     disableCutouts: true,
+    showHiddenEdges: true,
   })
 })
 


### PR DESCRIPTION
## Summary

- add the end-user `showHiddenEdges` boolean to `EnclosureFdmBoxProps`
- accept it in the `enclosure.fdm.box` Zod schema
- regenerate the props overview and cover parsing in tests

## Why

FDM enclosure authors need a declarative way to request hidden-edge visualization in compatible 3D viewers.

## Impact

This is an optional, backward-compatible prop. Omitting it preserves existing rendering.

## Checks

- `bun test tests/enclosure-fdm-box.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run format:check`
- required generated documentation scripts