### PR TITLE
Add JST connector standards and pin count

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,11 @@ export interface ConnectorProps extends ChipPropsSU {
    * Connector interface or product family, e.g. usb_c, m2, jst_ph
    */
   standard?: ConnectorStandard;
+
+  /**
+   * Number of electrical circuits in the connector
+   */
+  pinCount?: number;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -579,9 +579,9 @@ export interface ChipPropsSU<
 ```ts
 export interface ConnectorProps extends ChipPropsSU {
   /**
-   * Connector standard, e.g. usb_c, m2
+   * Connector interface or product family, e.g. usb_c, m2, jst_ph
    */
-  standard?: "usb_c" | "m2";
+  standard?: ConnectorStandard;
 }
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1581,12 +1581,15 @@ export const chipProps = commonComponentProps.extend({
 ```typescript
 export interface ConnectorProps extends ChipPropsSU {
   standard?: ConnectorStandard
+
+  pinCount?: number
 }
 /**
-   * Connector interface or product family, e.g. usb_c, m2, jst_ph
+   * Number of electrical circuits in the connector
    */
 export const connectorProps = chipProps.extend({
   standard: connectorStandard.optional(),
+  pinCount: z.number().int().positive().optional(),
 })
 ```
 

--- a/generated/COMPONENT_TYPES.md
+++ b/generated/COMPONENT_TYPES.md
@@ -1580,13 +1580,13 @@ export const chipProps = commonComponentProps.extend({
 
 ```typescript
 export interface ConnectorProps extends ChipPropsSU {
-  standard?: "usb_c" | "m2"
+  standard?: ConnectorStandard
 }
 /**
-   * Connector standard, e.g. usb_c, m2
+   * Connector interface or product family, e.g. usb_c, m2, jst_ph
    */
 export const connectorProps = chipProps.extend({
-  standard: z.enum(["usb_c", "m2"]).optional(),
+  standard: connectorStandard.optional(),
 })
 ```
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -791,9 +791,9 @@ export interface CommonLayoutProps {
 
 export interface ConnectorProps extends ChipPropsSU {
   /**
-   * Connector standard, e.g. usb_c, m2
+   * Connector interface or product family, e.g. usb_c, m2, jst_ph
    */
-  standard?: "usb_c" | "m2"
+  standard?: ConnectorStandard
 }
 
 

--- a/generated/PROPS_OVERVIEW.md
+++ b/generated/PROPS_OVERVIEW.md
@@ -794,6 +794,11 @@ export interface ConnectorProps extends ChipPropsSU {
    * Connector interface or product family, e.g. usb_c, m2, jst_ph
    */
   standard?: ConnectorStandard
+
+  /**
+   * Number of electrical circuits in the connector
+   */
+  pinCount?: number
 }
 
 

--- a/lib/components/connector.ts
+++ b/lib/components/connector.ts
@@ -2,15 +2,28 @@ import { chipProps, type ChipPropsSU } from "./chip"
 import { expectTypesMatch } from "lib/typecheck"
 import { z } from "zod"
 
+export const connectorStandard = z.enum([
+  "usb_c",
+  "m2",
+  "jst_sh",
+  "jst_gh",
+  "jst_zh",
+  "jst_ph",
+  "jst_xh",
+  "jst_vh",
+])
+
+export type ConnectorStandard = z.infer<typeof connectorStandard>
+
 export interface ConnectorProps extends ChipPropsSU {
   /**
-   * Connector standard, e.g. usb_c, m2
+   * Connector interface or product family, e.g. usb_c, m2, jst_ph
    */
-  standard?: "usb_c" | "m2"
+  standard?: ConnectorStandard
 }
 
 export const connectorProps = chipProps.extend({
-  standard: z.enum(["usb_c", "m2"]).optional(),
+  standard: connectorStandard.optional(),
 })
 
 type InferredConnectorProps = z.input<typeof connectorProps>

--- a/lib/components/connector.ts
+++ b/lib/components/connector.ts
@@ -20,10 +20,16 @@ export interface ConnectorProps extends ChipPropsSU {
    * Connector interface or product family, e.g. usb_c, m2, jst_ph
    */
   standard?: ConnectorStandard
+
+  /**
+   * Number of electrical circuits in the connector
+   */
+  pinCount?: number
 }
 
 export const connectorProps = chipProps.extend({
   standard: connectorStandard.optional(),
+  pinCount: z.number().int().positive().optional(),
 })
 
 type InferredConnectorProps = z.input<typeof connectorProps>

--- a/tests/connector.test.ts
+++ b/tests/connector.test.ts
@@ -1,17 +1,17 @@
 import { expect, test } from "bun:test"
-import { connectorProps, type ConnectorProps } from "lib/components/connector"
+import {
+  connectorProps,
+  connectorStandard,
+  type ConnectorProps,
+} from "lib/components/connector"
 
-test("should parse connector with usb_c standard", () => {
-  const raw: ConnectorProps = { name: "conn", standard: "usb_c" }
-  const parsed = connectorProps.parse(raw)
-  expect(parsed.standard).toBe("usb_c")
-})
-
-test("should parse connector with m2 standard", () => {
-  const raw: ConnectorProps = { name: "conn", standard: "m2" }
-  const parsed = connectorProps.parse(raw)
-  expect(parsed.standard).toBe("m2")
-})
+for (const standard of connectorStandard.options) {
+  test(`should parse connector with ${standard} standard`, () => {
+    const raw: ConnectorProps = { name: "conn", standard }
+    const parsed = connectorProps.parse(raw)
+    expect(parsed.standard).toBe(standard)
+  })
+}
 
 test("should parse connector without standard", () => {
   const raw: ConnectorProps = { name: "conn" }
@@ -22,5 +22,11 @@ test("should parse connector without standard", () => {
 test("should fail for invalid connector standard", () => {
   expect(() =>
     connectorProps.parse({ name: "conn", standard: "invalid" } as any),
+  ).toThrow()
+})
+
+test("should reject a contradictory JST family and pitch", () => {
+  expect(() =>
+    connectorProps.parse({ name: "conn", standard: "jst_sh_2mm" } as any),
   ).toThrow()
 })

--- a/tests/connector.test.ts
+++ b/tests/connector.test.ts
@@ -30,3 +30,19 @@ test("should reject a contradictory JST family and pitch", () => {
     connectorProps.parse({ name: "conn", standard: "jst_sh_2mm" } as any),
   ).toThrow()
 })
+
+test("should parse an optional connector pin count", () => {
+  const raw: ConnectorProps = {
+    name: "conn",
+    standard: "jst_ph",
+    pinCount: 2,
+  }
+  const parsed = connectorProps.parse(raw)
+  expect(parsed.pinCount).toBe(2)
+})
+
+for (const pinCount of [0, -1, 2.5, Number.POSITIVE_INFINITY]) {
+  test(`should reject invalid connector pin count ${pinCount}`, () => {
+    expect(() => connectorProps.parse({ name: "conn", pinCount })).toThrow()
+  })
+}


### PR DESCRIPTION
## Summary

- add common JST wire-to-board families to `ConnectorProps.standard`
- add optional positive-integer `ConnectorProps.pinCount` for selecting a concrete circuit count
- export a reusable `connectorStandard` schema and `ConnectorStandard` type
- cover every accepted standard and validate connector pin counts
- regenerate the props documentation

JST family names are canonical without a pitch suffix. For example, SH is 1.0 mm and PH is 2.0 mm, so `jst_sh_2mm` remains invalid.

## User impact

TSX authors can describe both the JST family and circuit count:

```tsx
<connector name="J1" standard="jst_ph" pinCount={2} />
```

Supported families:

- `jst_sh`
- `jst_gh`
- `jst_zh`
- `jst_ph`
- `jst_xh`
- `jst_vh`

`pinCount` is optional for backward compatibility and is validated as a positive finite integer. End-to-end serialization and automatic part selection still require core/circuit-json/parts-engine to preserve and use these props.

## Validation

- `bun test` — 429 passed
- `bunx tsc --noEmit`
- `bun run build`
- `bun run format:check`
- all four generators required by `AGENTS.md`

Closes #792